### PR TITLE
Correct day-of-week return value documentation.

### DIFF
--- a/lib/Date.pod
+++ b/lib/Date.pod
@@ -69,7 +69,7 @@ Returns the day of the month of the date (1..31)
 
     method day-of-week(Date:D:) returns Int:D
 
-Returns the day of the week, where 0 is Sunday, 1 is Monday etc.
+Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
 =head2 day-of-year
 


### PR DESCRIPTION
At least with the latest Rakudo day-of-week returns 7 for Sunday, not 0.
