### PR TITLE
Update classtut.pod

### DIFF
--- a/lib/Language/classtut.pod
+++ b/lib/Language/classtut.pod
@@ -448,7 +448,6 @@ significant improvement over Perl 5's approach to handling multiple inheritance.
     =begin code
     class GeekCook is Programmer is Cook {
         method new( *%params ) {
-            %params<cookbooks> //= [];  # remove once Rakudo fully supports autovivification
             push( %params<cookbooks>, "Cooking for Geeks" );
             return self.bless(|%params);
         }


### PR DESCRIPTION
Rakudo now appears to support at least enough autovivification to remove this line.

The program below does the right thing and the examples appear to work without the initialization.
perl6 -e 'my %h; push(%h<k>, "v"); %h.say'

That part of the code seems to date back to September 2012 or earlier.
