### PR TITLE
p6doc not ignore files that have only declarative comments

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -48,7 +48,7 @@ sub locate-module(Str $modulename) {
 
 sub show-docs(Str $path, :$section) {
    my $pager = %*ENV<PAGER> // ($*OS eq 'MSWin32' ?? 'more' !! 'less');
-   if not open($path).lines.grep( /^\=/ )  {
+   if not open($path).lines.grep( /^('=' | '#|' | '#=')/ )  {
       say "No Pod found in $path";
       return;
    }


### PR DESCRIPTION
From S26: _Every directive starts either with an equals sign (=) followed immediately by an identifier [1], or with a #= or #| followed immediately by whitespace or an opening bracket._
