### PR TITLE
Replacing hard tab with spaces in code example

### DIFF
--- a/lib/Type/IO/FileTestable.pod
+++ b/lib/Type/IO/FileTestable.pod
@@ -39,7 +39,7 @@ If you have a string - a path to something in the filesystem:
 
     if "path/to/file".IO ~~ :e {
         say 'file exists';
-	}
+    }
 
     my $file = "path/to/file";
     if $file.IO ~~ :e {


### PR DESCRIPTION
The hard tab had the effect of making the code example be split in the html;
the closing brace was in a separate "code" presentation block.  With this
change the entire code example is in the same presentation block in the
html.