### PR TITLE
fixed typo surrouned -> surrounded

### DIFF
--- a/lib/Language/5to6.pod
+++ b/lib/Language/5to6.pod
@@ -798,7 +798,7 @@ C<P5> modifier.
 
 There are many cases of special matching syntax that Perl 5 regexes
 support. They won't all be listed here, but often instead of being
-surrounded by C<()>, the assertions will be surrouned by C«<>».
+surrounded by C<()>, the assertions will be surrounded by C«<>».
 
 For character classes, this means that:
 


### PR DESCRIPTION
fixed typo in section "Special matchers generally fall under the <> syntax": surrouned -> surrounded