### PR TITLE
Prettier usage output for p6doc and p6doc-index.

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -65,9 +65,11 @@ sub show-docs(Str $path, :$section) {
 }
 
 multi sub MAIN() {
+    my $me = $*PROGRAM_NAME.IO.basename;
+
     say 'What documentation do you want to read?';
-    say "Examples: $*PROGRAM_NAME Type::Str";
-    say "          $*PROGRAM_NAME Type::Str.split";
+    say "Examples: $me Type::Str";
+    say "          $me Type::Str.split";
 }
 
 multi sub MAIN($docee) {

--- a/bin/p6doc-index
+++ b/bin/p6doc-index
@@ -11,10 +11,12 @@ sub findbin() returns Str {
 constant INDEX = findbin() ~ 'index.data';
 
 multi sub MAIN() {
-    say "Usage: $*PROGRAM_NAME build        to build an index for 'p6doc -f'";
-    say "Usage: $*PROGRAM_NAME list         to list the names";
-    say "Usage: $*PROGRAM_NAME lookup <key> to display module name containing key";
-    say "Usage: $*PROGRAM_NAME path-to-index to show where the index file lives";
+    my $me = $*PROGRAM_NAME.IO.basename;
+
+    say "Usage: $me build        to build an index for 'p6doc -f'";
+    say "Usage: $me list         to list the names";
+    say "Usage: $me lookup <key> to display module name containing key";
+    say "Usage: $me path-to-index to show where the index file lives";
 }
 
 multi sub MAIN('path-to-index') {


### PR DESCRIPTION
Before:

~~~
$ p6doc 
What documentation do you want to read?
Examples: /Users/iv/src/rakudo-star-2015.02/install/bin/p6doc Type::Str
          /Users/iv/src/rakudo-star-2015.02/install/bin/p6doc Type::Str.split
~~~

After:

~~~
$ ~/src/doc/bin/p6doc
What documentation do you want to read?
Examples: p6doc Type::Str
          p6doc Type::Str.split
~~~

I only tested this on OS X.

I'm not sure we actually want this change, but I opened the PR for discussion.