### PR TITLE
fix anchor link

### DIFF
--- a/lib/Language/classtut.pod
+++ b/lib/Language/classtut.pod
@@ -312,7 +312,7 @@ Since C<BUILD> runs in the context of the newly created C<Task> object, it
 is allowed to manipulate those private attributes. The trick here is that
 the private attributes (C<&!callback> and C<&!dependencies>) are being used
 as the bind targets for C<BUILD>'s parameters. Zero-boilerplate
-initialization! See L<objects|/language/objects#Object Construction> for
+initialization! See L<objects|/language/objects#Object_Construction> for
 more information.
 
 The C<BUILD> method is responsible for initialilzing all attributes, it must


### PR DESCRIPTION
The old link was to `#Object Construction` but the live page has an underscore in place of space.