### PR TITLE
Use $*TMPDIR to create temporary files

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -18,7 +18,7 @@ sub findbin() returns Str {
 constant INDEX = findbin() ~ 'index.data';
 
 sub tempfile() {
-    my $tempfile = %*ENV<TEMP> // %*ENV<TMP> // '/tmp';
+    my $tempfile = $*TMPDIR.Str;
     $tempfile ~= '/';
     $tempfile ~= join '', ('a'..'z', 0..9).roll(5);
     $tempfile ~= '.tmp';


### PR DESCRIPTION
`$*TMPDIR` will follow the operating system's best practices for
temporary file management