### PR TITLE
Fix grammars.pod unescaped quote mark in string

### DIFF
--- a/lib/Language/grammars.pod
+++ b/lib/Language/grammars.pod
@@ -50,7 +50,7 @@ usually do what you want, but isn't appropriate for all cases:
     =begin code :allow<B>
     my regex works-but-slow { .+ q }
     my token fails-but-fast { .+ q }
-    my $s = 'Tokens won't backtrack, which makes them fail quicker!';
+    my $s = 'Tokens won\'t backtrack, which makes them fail quicker!';
     say so $s ~~ &works-but-slow; # True
     say so $s ~~ &fails-but-fast; # False, the entire string get taken by the .+
     =end code


### PR DESCRIPTION
Escape single-quote in string in sample code