### PR TITLE
done() has become done-testing()

### DIFF
--- a/lib/Language/testing.pod
+++ b/lib/Language/testing.pod
@@ -66,11 +66,11 @@ the subtest.
 If a C<plan> is used, it is not necessary to denote the end of testing with
 C<done>.
 
-=item done
+=item done-testing
 
 Specify that testing has finished.  Use this function when you do not as yet
 have a C<plan> for the number of tests to run.  A C<plan> is thus not
-required when using C<done>.
+required when using C<done-testing>.
 
 =head1 Test functions
 


### PR DESCRIPTION
To signify the end of a test file without using a plan, we used to use `done()`. This has since become `done-testing()`.