### PR TITLE
As we have a plan, the deprecated "done;" can be removed.

### DIFF
--- a/t/pod-convenience.t
+++ b/t/pod-convenience.t
@@ -179,7 +179,6 @@ subtest {
         is($lowered-pod[0].level, 2, "heading head3 lowered to level 2");
         is($lowered-pod[2].level, 3, "heading head4 lowered to level 3");
     }
-    done;
 }, "pod-lower-headings";
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/typegraph.t
+++ b/t/typegraph.t
@@ -17,6 +17,4 @@ is $t.types<Match>.mro, 'Match Capture Cool Any Mu', 'Match mro';
 is $t.types<Exception>.super.any, 'Any', 'Any as default parent works';
 is $t.types<Any>.super, 'Mu', 'default-Any did not add a parent to Any';
 
-done;
-
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
This also fixes the below test failure:

    $ panda install p6doc
    ==> Fetching p6doc
    ==> Building p6doc
    ==> Testing p6doc
    t/pod-convenience.t .. 
    Failed 1/10 subtests 
    t/pod-htmlify.t ...... ok
    t/typegraph.t ........ ok

    Test Summary Report
    -------------------
    t/pod-convenience.t (Wstat: 0 Tests: 9 Failed: 0)
      Parse errors: Bad plan.  You planned 10 tests but ran 9.
    Files=3, Tests=21, 30 wallclock secs ( 0.20 usr  0.03 sys + 26.77 cusr  1.00 csys = 28.00 CPU)
    Result: FAIL
    test stage failed for p6doc: Tests failed
      in method throw at /home/cschwenz/.rakudobrew/moar-nom/install/share/perl6/runtime/CORE.setting.moarvm:1
      in method install at /home/cschwenz/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda.pm:142
      in method resolve at /home/cschwenz/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda.pm:219
      in sub MAIN at /home/cschwenz/.rakudobrew/bin/../moar-nom/install/share/perl6/site/bin/panda:18
      in block <unit> at /home/cschwenz/.rakudobrew/bin/../moar-nom/install/share/perl6/site/bin/panda:95


    Failure Summary
    ----------------
    p6doc(
      *test stage failed for p6doc: Tests failed)