### PR TITLE
Remove blob literal section.

### DIFF
--- a/doc/Language/syntax.pod
+++ b/doc/Language/syntax.pod
@@ -235,12 +235,6 @@ String literals are surrounded by quotes:
 
 See L<quoting|/language/quoting> for many more options.
 
-=head3 Blob literals
-
-Binary data of L<type Blob|/type/Blob> can be written as C<:base{data}>, so
-
-    :16<DEADBEEF>
-
 =head3 Number literals
 
 Number literals are generally specified in base ten, unless a prefix like

--- a/doc/Language/syntax.pod
+++ b/doc/Language/syntax.pod
@@ -330,8 +330,8 @@ Long forms with explicit values:
 
 =head3 Array literals
 
-A pair of square brackets can surround an expression to for an
-itmized L<Array|/type/Array> literal; typically there is a comma-delimited list
+A pair of square brackets can surround an expression to form an itemized
+L<Array|/type/Array> literal; typically there is a comma-delimited list
 inside:
 
     say ['a', 'b', 42].join(' ');   # a b 42


### PR DESCRIPTION
Blob literals are described in S02 but the section in syntax.pod uses
the wrong syntax and blob literals don't appear to be implemented in
Rakudo or tested for in Roast.  Avoid confusion, remove the section.