### PR TITLE
Comment about new method to not confuse new users

### DIFF
--- a/doc/Language/classtut.pod
+++ b/doc/Language/classtut.pod
@@ -17,6 +17,8 @@ is interesting and, at times, useful.
         has Task @!dependencies;
         has Bool $.done;
 
+        # Normally don't need to written
+        # BUILD is equivalent of constructor in other languages
         method new(&callback, *@dependencies) {
             return self.bless(:&callback, :@dependencies);
         }


### PR DESCRIPTION
Due to first example contains custom `new` it may give impression that writing `new` is something that programmer want to do. Maybe it would be good to mark it as non standard behavior and say that probably want to write build method?

Or maybe better to close this pull request and rewrite this tutorial in way that will not contain neither BUILD nor new at start. Perl has many ways to initialize attributes without them and should be shown first

Example question http://www.nntp.perl.org/group/perl.perl6.users/2015/10/msg2309.html