### PR TITLE
Made headings in control.pod searchable

### DIFF
--- a/doc/Language/control.pod
+++ b/doc/Language/control.pod
@@ -4,7 +4,7 @@
 
 =SUBTITLE Statements used to control the flow of execution
 
-=head2 blocks
+=head2 X<blocks|control flow>
 
 Like many languages, Perl6 uses C<blocks> delimited by C<{> and C<}>
 to compartmentalize code.  When a block stands alone as a statement,
@@ -48,7 +48,7 @@ You have to watch out for this in most languages anyway to prevent things
 from getting accidentally commented out.  Many of the examples below may
 have unnecessary semicolons for clarity.
 
-=head2 do
+=head2 X<do|control flow>
 
 The simplest way to run a block where it cannot be a stand-alone statement
 is by writing C<do> before it:
@@ -138,7 +138,7 @@ for it more strongly:
     $_ = 1; if 42 -> $a { $_.say;  $a.say } ; # says "1" then says "42"
     $_ = 1; if 42       { $_.say; $^a.say } ; # says "1" then says "42"
 
-=head3 else/elsif
+=head3 X<else/elsif|control flow,else elsif>
 
 A compound conditional may be produced by following an C<if> conditional
 with C<else> to provide an alternative block to run when the conditional
@@ -213,7 +213,7 @@ what the C<else> sees, since it was the last one tried:
 
     if False { } elsif 0 { } else -> $a { $a.say }  ; # says "0"
 
-=head3 unless
+=head3 X<unless|control flow>
 
 When you get sick of typing "if not (X)" you may use C<unless> to invert
 the sense of a conditional statement.  You cannot use C<else> or C<elsif>
@@ -238,7 +238,7 @@ two differences C<unless> works the same as L<if>:
 Implementation note: Currently, Rakudo will say "1 Nil 3 0" for the last
 example because it is not caught up to this part of the design yet.
 
-=head3 with, orwith, without
+=head3 X<with, orwith, without|control flow,with orwith without>
 
 The C<with> statement is like C<if> but tests for definedness rather than
 truth.  In addition, it topicalizes on the condition, much like C<given>:
@@ -264,7 +264,7 @@ There are also C<with> and C<without> statement modifiers:
     return 42 with $answer;
     .throw without $answer;
 
-=head2 for
+=head2 X<for|control flow>
 
 The C<for> loop iterates over a list.
 
@@ -310,7 +310,7 @@ for @cars <-> $_ {...}
 
 =end code
 
-=head2 gather/take
+=head2 X<gather/take|control flow,gather take>
 
 C<gather> is a statement or block prefix that returns a L<sequence|/type/Seq>
 of values. The values come from calls to C<take> in the dynamic scope of the C<gather> block.
@@ -360,7 +360,7 @@ from within C<gather>:
     say weird(<a b c>, :direction<backward> );          # (c b a)
 
 
-=head2 given
+=head2 X<given|control flow>
 
 The C<given> statement is Perl 6's topicalizing keyword in a similar way that
 C<switch> topicalizes in languages such as C.  In other words, C<given>
@@ -382,7 +382,7 @@ This is a lot more understandable than:
     { .say; .Numeric; }(EXPR)
 
 
-=head3 default and when
+=head3 X<default and when|control flow,default when>
 
 A block containing a C<default> statement will be left immediately
 when the sub-block after the C<default> statement is left.  It is
@@ -418,7 +418,7 @@ C<when> statements.  The following code says C<"Int"> not C<42>.
     }
     #-> Int
 
-=head3 proceed and succeed
+=head3 X<proceed and succeed|control flow,proceed succeed>
 
 Both C<proceed> and C<succeed> are meant to be used only from inside C<when>
 or C<default> blocks.
@@ -480,7 +480,7 @@ specify a final value for the block.
     }
     #-> Int
 
-=head2 loop
+=head2 X<loop|control flow>
 
 The C<loop> statement is the C-style C<for> loop in disguise:
 
@@ -498,7 +498,7 @@ is equivalent to the C-ish idiom:
 
     loop (;;) {...}
 
-=head2 while, until
+=head2 X<while, until|control flow,while until>
 
 The C<while> statement executes the block as long as its condition is
 true. So
@@ -556,7 +556,7 @@ $x++ while $x < 12
 
 Also see C<repeat/while> and C<repeat/until> below.
 
-=head2 repeat/while, repeat/until
+=head2 X<repeat/while, repeat/until|control flow,repeat>
 
 Perl 5 allows one to apply a statement modifier to a C<do> block such that
 C-like constructs such as
@@ -580,11 +580,7 @@ This can also be written quite naturally with C<until>:
         ...
     } until $x >= 10;
 
-=head2 while
-
-=comment TODO
-
-=head2 return
+=head2 X<return|control flow>
 
 =comment TODO
 
@@ -602,7 +598,7 @@ LINE: for $*IN.lines -> $line {
 
 =end code
 
-=head2 next
+=head2 X<next|control flow>
 
 The C<next> command starts the next iteration of the loop. So the code
 
@@ -618,7 +614,7 @@ my @x = 1, 2, 3, 4, 5;
 
 prints "1245".
 
-=head2 last
+=head2 X<last|control flow>
 
 The C<last> command immediately exits the loop in question.
 
@@ -634,7 +630,7 @@ for @x -> $x {
 
 prints "12".
 
-=head2 redo
+=head2 X<redo|control flow>
 
 The C<redo> command restarts the loop block without evaluating the
 conditional again.
@@ -645,7 +641,7 @@ conditional again.
 
 =end code
 
-=head2 goto
+=head2 X<goto|control flow>
 
 =comment TODO
 

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -378,6 +378,8 @@ sub find-definitions (:$pod, :$origin, :$min-level = -1, :$url) {
                 my $fc := .[1];
                 proceed unless $fc.type eq "X";
                 @definitions = $fc.meta[0].flat;
+                # set default name if none provide so X<if|control> gets name 'if'
+                @definitions[1] = $fc.contents[0] if @definitions == 1;
                 $unambiguous = True;
             }
             when :(Str $ where /^The \s \S+ \s \w+$/) {


### PR DESCRIPTION
```
1. Added X<> blocks around everything control.pod (separating via ' '
instead of '/'. '/' conflicts with url path atm)
2. Made X<if|control flow> work as shorthand for X<if|control flow,if> in htmlify.p6
3. Got rid of extra `while` heading, it was already documented in `while/until`
```

Making PR just incase 2. is not desirable. I X<>'d everything except for LABELs as "control flow".