### PR TITLE
Find all the references to curly braces and make them consistent

### DIFF
--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -359,7 +359,7 @@ I<Key/value-slicing>
     say join ',', %calories<pear plum>:kv;      # Perl 6 (prettier version)
 =end item
 
-Also note that the subscripting braces are now a normal postcircumfix
+Also note that the subscripting curly braces are now a normal postcircumfix
 operator rather than a special syntactic form, and thus L<checking for
 existence of keys|#exists> and L<removing keys|#delete> is done with
 adverbs.
@@ -411,7 +411,7 @@ In Perl 6, the curly braces are changed to parentheses.
         say keys %($hashref   );
         say      &($subref    );
 
-Note that in both Perl 5 and Perl 6, the surrounding braces or parens can
+Note that in both Perl 5 and Perl 6, the surrounding curly braces or parens can
 often be omitted, though the omission can reduce readability.
 
 In Perl 5, the arrow operator, C«->» , is used for single access to a

--- a/doc/Language/5to6-perlop.pod
+++ b/doc/Language/5to6-perlop.pod
@@ -240,12 +240,12 @@ L<http://doc.perl6.org/language/quoting>.
 There is a quoting operator that allows absolute literal strings: C<Q> or
 C<｢…｣>, although the latter might be difficult to find on your keyboard,
 depending on your keyboard... Backslash escapes do I<not> apply in C<Q> quoted
-strings. E. g. C<Q{This is still a closing brace → \}> renders "This is still a
-closing brace → \".
+strings. E. g. C<Q{This is still a closing curly brace → \}> renders "This is still a
+closing curly brace → \".
 
 C<q> does what you expect, allowing backslash escapes. E. g. C<q{This is
-not a closing brace → \}, but this is → }> returning "This is
-not a closing brace → }, but this is →". As in Perl 5, you can
+not a closing curly brace → \}, but this is → }> returning "This is
+not a closing curly brace → }, but this is →". As in Perl 5, you can
 get this behavior with single quotes.
 
 C<qq> allows interpolation of variables. However, by default, only

--- a/doc/Language/control.pod
+++ b/doc/Language/control.pod
@@ -74,7 +74,7 @@ In other words, it follows the same reification rules as everything else.
 
 Technically, C<do> is a loop which runs exactly one iteration.
 
-A C<do> may also be used on a bare statement (without brackets)
+A C<do> may also be used on a bare statement (without curly braces)
 but this is mainly just useful for avoiding the syntactical need to
 parenthesize a statement if it is the last thing in an expression:
 

--- a/doc/Language/objects.pod
+++ b/doc/Language/objects.pod
@@ -556,7 +556,7 @@ instances and roles are meant for managing behavior and code reuse.
     say $clone-of-p.x;      # 1
     =end code
 
-Roles are immutable as soon as the compiler parses the closing bracket of
+Roles are immutable as soon as the compiler parses the closing curly brace of
 the role declaration.
 
 =head2 Z<>Role Application

--- a/doc/Language/quoting.pod
+++ b/doc/Language/quoting.pod
@@ -25,7 +25,7 @@ possible.
 
 =for code :allow<B>
 Q<Make sure you B«<»matchB«>» opening and closing delimiters>
-Q{This is still a closing brace → B<\>}
+Q{This is still a closing curly brace → B<\>}
 
 These examples produce:
 
@@ -33,7 +33,7 @@ These examples produce:
     More plainly.
     Almost any non-word character can be a delimiter!
     Make sure you <match> opening and closing delimiters
-    This is still a closing brace → \
+    This is still a closing curly brace → \
 
 The other quote forms add to this basic functionality:
 
@@ -43,7 +43,7 @@ The other quote forms add to this basic functionality:
 B<'>Very plainB<'>
 B<q[>This backB<\s>lash staysB<]>
 B<q[>This backB<\\>slash staysB<]> # Identical output
-B<q{>This is not a closing brace → B<\}>, but this is → B<}>
+B<q{>This is not a closing culy brace → B<\}>, but this is → B<}>
 B<Q :q $>There are no backslashes here, only lots of B<\$>B<\$>B<\$>!B<$>
 B<'>(Just kidding. ThereB<\'>s no money in that string)B<'>
 B<'>No $interpolation {here}!B<'>
@@ -60,7 +60,7 @@ These examples produce:
     Very plain
     This back\slash stays
     This back\slash stays
-    This is not a closing brace → } but this is →
+    This is not a closing curly brace → } but this is →
     There are no backslashes here, only lots of $$$!
     (Just kidding. There's no money in that string)
     No $interpolation {here}!

--- a/doc/Language/subscripts.pod
+++ b/doc/Language/subscripts.pod
@@ -85,7 +85,7 @@ collection to be sure whether the keys are strings or objects:
     my %h; %h{pi}  = 1; say %h.perl; #-> { "3.14159265358979" => 1 }
 
 While the invisible quotes around single names is built into C<=>>,
-string conversion is not built into the braces: it is a behavior
+string conversion is not built into the curly braces: it is a behavior
 of the default C<Hash>.  Not all types of hashes or collections
 do so:
 

--- a/doc/Language/syntax.pod
+++ b/doc/Language/syntax.pod
@@ -62,7 +62,7 @@ A Perl 6 program is a list of statements, separated by semicolons C<;>.
 A semicolon after the final statement (or after the final statement inside a
 block) is optional, though it's good form to include it.
 
-A closing curling brace followed by a newline character implies a statement
+A closing curly brace followed by a newline character implies a statement
 separator, which is why you don't need to write a semicolon before the last
 line in the code
 

--- a/doc/Type/Block.pod
+++ b/doc/Type/Block.pod
@@ -7,7 +7,7 @@
     class Block is Code { }
 
 A C<Block> is a code object meant for small-scale code reuse. A block is
-created syntactically by a list of statements enclosed in curly brackets.
+created syntactically by a list of statements enclosed in curly braces.
 
 Without an explicit signature or placeholder arguments, a block has C<$_>
 as a positional argument


### PR DESCRIPTION
My brief research suggests that "braces" eq "curly braces" is American-English, so I figure we should disambiguate globally.