### PR TITLE
Document recent changes to allow non-inclusive ranges as quantifiers

### DIFF
--- a/doc/Language/regexes.pod
+++ b/doc/Language/regexes.pod
@@ -351,7 +351,7 @@ is possible: C<a ** 5> matches C<a> exactly five times.
     say Bool('aaaaa' ~~ /a ** 5/);   #-> True
 =end code
 
-It is also posible to use non inclusive ranges using a carat:
+It is also posible to use non inclusive ranges using a caret:
 
 =begin code
     say Bool('a' ~~ /a ** 1^..^6); #-> False

--- a/doc/Language/regexes.pod
+++ b/doc/Language/regexes.pod
@@ -351,6 +351,25 @@ is possible: C<a ** 5> matches C<a> exactly five times.
     say Bool('aaaaa' ~~ /a ** 5/);   #-> True
 =end code
 
+It is also posible to use non inclusive ranges using a carat:
+
+=begin code
+    say Bool('a' ~~ /a ** 1^..^6); #-> False
+    say Bool('aaaa' ~~ /a ** 1^..^6); #-> True
+=end code
+
+This includes the numeric ranges staring from 0:
+
+=begin code
+    say Bool('aaa' ~~ /a ** ^6/); #->true
+=end code
+
+or a Whatever operator for an infinite range with a non inclusive minimum:
+
+=begin code
+    say Bool('aaaa' ~~ /a ~~ 1^..*/); #-> True
+=end code
+
 =head2 X<Modified quantifier: %|regex,%;regex,%%>
 
 To more easily match things like comma separated values, you can tack on a


### PR DESCRIPTION
Recent changes allowed 1^..^10 non inclusive range syntax as general quantifiers in regexes. These were documented.