### PR TITLE
Changed "item" to "scalar" in section on scalar sigils

### DIFF
--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -181,7 +181,7 @@ name.
 
 =head4 C<$> Scalar
 
-The C<$> sigil is now always used with "item" variables (e.g. C<$name>),
+The C<$> sigil is now always used with "scalar" variables (e.g. C<$name>),
 and no longer for L<array indexing|#[]_Array_indexing/slicing> and L<Hash
 indexing|#{}_Hash_indexing/slicing>.  That is, you will still use C<$x[1]>
 and C<$x{"foo"}>, but you use them on C<$x>, not C<@x> or C<%x>.


### PR DESCRIPTION
Not sure how "item" got in here, as it's not used anywhere else in this context. So, reverting to the more traditional "scalar".