### PR TITLE
Add info exclusion new line reparator by .lines + fix typo in example

### DIFF
--- a/doc/Language/io.pod
+++ b/doc/Language/io.pod
@@ -34,7 +34,8 @@ the file for you.
 
 =head2 Line by line
 
-Of course, we also have the option to read a file line-by-line.
+Of course, we also have the option to read a file line-by-line. The new line
+separator (e.g. $*IN.nl) will be excluded.
 
     for 'huge-csv'.IO.lines -> $line {
         # Do something with $line

--- a/doc/Type/IO/Handle.pod
+++ b/doc/Type/IO/Handle.pod
@@ -35,10 +35,11 @@ Returns L<Bool::True> if the read operations have exhausted the content of the f
     method lines($limit = Inf)
 
 Return a lazy list of the file's lines read via L<get>, limited to C<$limit> lines.
+The new line separator (e.g. $*IN.nl) will be excluded.
 
     =for code :allow<B>
     my @data;
-    my $data-file = open 'readings.csv'
+    my $data-file = open 'readings.csv';
     for B<$data-file.lines> -> $line {
         @data.push($line.split(','))
     }


### PR DESCRIPTION
Most people will get to know .lines from the Input/Output chapter in the Language section of the documentation. It should be stated there that this method will exclude the new line separator.