### PR TITLE
Remove typo

### DIFF
--- a/doc/Language/functions.pod
+++ b/doc/Language/functions.pod
@@ -597,7 +597,7 @@ Here C<a 1> calls the most specific C<Int> candidate first, and C<callwith>
 re-dispatches to the less specific C<Any> candidate.
 
 Very often, a re-dispatch passes the same argument along that the caller
-received, so there is a special routine for that: C<callsame>.G
+received, so there is a special routine for that: C<callsame>.
 
 =begin code
 multi a(Any $x) {


### PR DESCRIPTION
"Very often, a re-dispatch passes the same argument along that the caller received, so there is a special routine for that: callsame.G"
=> 
"Very often, a re-dispatch passes the same argument along that the caller received, so there is a special routine for that: callsame."