### PR TITLE
Clarify that CStructs are exchanged by reference

### DIFF
--- a/doc/Language/nativecall.pod
+++ b/doc/Language/nativecall.pod
@@ -219,7 +219,7 @@ a class; you could even have some of the attributes come from roles or have them
 inherited from another class. Of course, methods are completely fine too. Go wild!
 
 CStruct objects are passed to native functions by reference and native functions 
-must also by return CStruct objects by reference as well. The memory management 
+must also return CStruct objects by reference. The memory management 
 rules for these references are very much like the rules for arrays, though simpler 
 since a struct is never resized. When you create a struct, the memory is managed for 
 you and when the variable(s) pointing to the instance of a CStruct go away, the memory 

--- a/doc/Language/nativecall.pod
+++ b/doc/Language/nativecall.pod
@@ -218,11 +218,13 @@ CStruct reprs). Other than that, you can do the usual set of things you would wi
 a class; you could even have some of the attributes come from roles or have them
 inherited from another class. Of course, methods are completely fine too. Go wild!
 
-The memory management rules are very much like for arrays, though simpler since a
-struct is never resized. When you create a struct, the memory is managed for you and
-when the variable(s) pointing to the instance of a CStruct go away, the memory will
-be freed when GC gets to it. When a CStruct-based type is used for the return type,
-the memory is not managed for you.
+CStruct objects are passed to native functions by reference and native functions 
+must also by return CStruct objects by reference as well. The memory management 
+rules for these references are very much like the rules for arrays, though simpler 
+since a struct is never resized. When you create a struct, the memory is managed for 
+you and when the variable(s) pointing to the instance of a CStruct go away, the memory 
+will be freed when the GC gets to it. When a CStruct-based type is used as the return 
+type of a native function, the memory is not managed for you by the GC.
 
 NativeCall currently doesn't put object members in containers, so assigning new values
 to them (with =) doesn't work. Instead, you have to bind new values to the private


### PR DESCRIPTION
This commit clarifies that the CStructs of NativeCall are always pass by reference. 
This wasn't immediately clear to me when I worked on Compress::Brotli, leading to some odd behaviour.