### PR TITLE
fix tail docs

### DIFF
--- a/doc/Type/List.pod
+++ b/doc/Type/List.pod
@@ -369,8 +369,8 @@ Usage:
     LIST.tail
     LIST.tail(NUMBER)
 
-Returns the B<last> NUMBER items of the list.  Returns an empty list if
-NUMBER <= 0.  Defaults to the last element seen if no NUMBER specified.
+Returns a L<Seq> containing the B<last> NUMBER items of the list.  Returns an empty Seq if
+NUMBER <= 0.  Defaults to the last element if no NUMBER is specified.
 Throws an exception if the list is lazy.
 
 Examples:


### PR DESCRIPTION
clarify that tail always returns a Seq as its signature already correctly shows