### PR TITLE
Travis runs make html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ perl6:
 install:
   - rakudobrew build-panda
   - panda installdeps .
+  - panda install Pod::To::HTML
+
+script: make test && make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+addons:
+  apt:
+    packages:
+      - graphviz
 branches:
   except:
     - gh-pages

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # p6doc -- an attempt to write something like 'perldoc' for Perl 6
 
+[![Build Status](https://travis-ci.org/perl6/doc.svg?branch=master)](https://travis-ci.org/perl6/doc) [![artistic](https://img.shields.io/badge/license-Artistic%202.0-blue.svg?style=flat)](https://opensource.org/licenses/Artistic-2.0)
+
 An HTML version of this documentation can be found at http://doc.perl6.org/.
 
 (If you are browsing this repository via github, it will not display most


### PR DESCRIPTION
This PR extends the travis configuration to also run make html.
I didn't commit this directly because it extends the travis build time from 11 min to **40 min**.

The Pro's are that issues such as  #227 and #240 and #241 will be immediately noticed when they arise.
The Con's are that this duplicates some info captured in the build logs http://doc.perl6.org/build-log/?C=M;O=D  and slows down the CI system substantially