### PR TITLE
Clarified item on numeric computation.

### DIFF
--- a/doc/Language/faq.pod
+++ b/doc/Language/faq.pod
@@ -559,7 +559,7 @@ them offer all.
 
 =item System administration simplified due to simpler update/upgrade policies.
 
-=item Floating point math without precision loss because of Rats (rational numbers).
+=item Simple numeric computation without precision loss because of Rats (rational numbers).
 
 =item Extensible grammars for parsing data or code (which Perl 6 uses to parse itself).
 


### PR DESCRIPTION
Reason: rational numbers are not floating point and most math functions yield a Num.