### PR TITLE
clarifying push usage

### DIFF
--- a/doc/Type/Hash.pod
+++ b/doc/Type/Hash.pod
@@ -231,6 +231,13 @@ Example:
     %h.push: (a => 1);                  # a => [1,1]
     %h.push: (a => 1) xx 3 ;            # a => [1,1,1,1,1]
     %h.push: (b => 3);                  # a => [1,1,1,1,1], b => 3
+    %h.push('c' => 4);                  # a => [1,1,1,1,1], b => 3, c => 4
+    push %h, 'd' => 5;                  # a => [1,1,1,1,1], b => 3, c => 4, d => 5
+
+Be careful to quote the keys in the last two methods, as these have no effect:
+
+    %h.push(e => 6);
+    push %h, f => 7;
 
 Also note that push can be used as a replacement for assignment during hash
 initialization very useful ways. Take for instance the case of an inverted


### PR DESCRIPTION
added examples of the other two forms of calling, and documented some non-obvious behaviour of what perl5 programmers might expect from fat commas