### PR TITLE
Precompile .pod files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ html/language/
 html/syntax/
 html/images/type-graph*
 html/js/search.js
+precompiled

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -155,9 +155,22 @@ sub MAIN(
     }
 }
 
-sub extract-pod($file) {
-    use MONKEY-SEE-NO-EVAL;
-    my $pod  = EVAL(slurp($file.path) ~ "\n\$=pod")[0];
+my $precomp-store = CompUnit::PrecompilationStore::File.new(:prefix($?FILE.IO.parent.child("precompiled")));
+my $precomp = CompUnit::PrecompilationRepository::Default.new(store => $precomp-store);
+
+sub extract-pod(IO() $file) {
+    use nqp;
+    # The file name is enough for the id because POD files don't have depends
+    my $id = nqp::sha1(~$file);
+    my $handle = $precomp.load($id,:since($file.modified));
+
+    if not $handle {
+        # precomile it
+        $precomp.precompile($file, $id);
+        $handle = $precomp.load($id);
+    }
+
+    return nqp::atkey($handle.unit,'$=pod')[0];
 }
 
 sub process-pod-dir($dir, :&sorted-by = &[cmp], :$sparse) {


### PR DESCRIPTION
They get put in a directory named `precompiled`. They are only
re-precompiled if changes are made (like .precomp). This reduces memory
usage (works around RT #127020), and speeds it up on second run (despite
slowing it on the first).

run|time|peak mem
-----|-----|--------------
htmlify before |    594s | 1.1GB
after, first run |  634s | 770MB
after, second run | 584s | 730MB

Making a PR so at least one person agrees with me that this is a good idea.