### PR TITLE
Cross meta operator

### DIFF
--- a/doc/Language/operators.pod
+++ b/doc/Language/operators.pod
@@ -283,7 +283,13 @@ quote it with C<[]> (e.g. C<[\[\x]]>).
     say $lazy[^10]; # (1 3 6 10 15 21 28 36 45 55)
 
 =head2 Cross Operators
-TODO
+
+The cross metaoperator, C<X>, will apply a given infix operator in order of
+cross product to all lists, such that the rightmost operator varies most
+quickly.
+
+    1..3 X~ <a b>
+    # produces <1a, 1b, 2a, 2b, 3a, 3b>
 
 =head2 Zip Operators
 


### PR DESCRIPTION
Some of the meta operator documentation is repeated in the infix operator sections. This makes the cross section match the other meta operators, though.