### PR TITLE
remove 'autofocus' from search input field

### DIFF
--- a/template/header.html
+++ b/template/header.html
@@ -4,7 +4,7 @@
         >&nbsp;Perl 6 Documentation</a
     >
     <div id="search" class="ui-widget">
-        <div class="green"><input placeholder="Loading..." autofocus id="query" title="Enter Perl 6 document to search for"></div>
+        <div class="green"><input placeholder="Loading..." id="query" title="Enter Perl 6 document to search for"></div>
     </div>
     <div class="menu">
       MENU


### PR DESCRIPTION
The search field autofocus provides a very bad UX on mobile (I tested android/firefox) - causing the virtual keyboard to open on every new page load.

It also breaks the desktop/firefox feature "Search for text when I start typing", whereby typing no longer searches within the page by default.