### PR TITLE
Provide a simpler example for reversed operators

### DIFF
--- a/doc/Language/operators.pod
+++ b/doc/Language/operators.pod
@@ -163,6 +163,7 @@ There are shortcuts for C<!==> and C<!eq>, namely C<!=> and C<ne>.
 Any infix operator may be called with its two arguments reversed by prefixing
 with C<R>. Associativity of operands is reversed as well.
 
+    say 4 R/ 12; # 3
     say [R/] 2, 4, 16; # 2
 
 =head2 Hyper Operators


### PR DESCRIPTION
Reversed operators are taught before operator reduction, so give an example that does not depend on operator reduction