### PR TITLE
Bool() doesn't return a Match object.

### DIFF
--- a/doc/Type/Regex.pod
+++ b/doc/Type/Regex.pod
@@ -58,6 +58,7 @@ failure.
 
     multi method Bool(Regex:D:) returns Bool:D
 
-Matches against the caller's L<$_> variable, and returns the L<Match> object
+Matches against the caller's L<$_> variable, and returns True for a match or
+False for no match. 
 
 =end pod


### PR DESCRIPTION
Bool() returns a Bool.