### PR TITLE
repairing a typo

### DIFF
--- a/doc/Type/Tap.pod
+++ b/doc/Type/Tap.pod
@@ -57,7 +57,7 @@ Returns the supply to which the tap belongs.
 
 =head2 method close
 
-    method closing(Tap:D:)
+    method close(Tap:D:)
 
 Closes the tap.
 


### PR DESCRIPTION
at line 60 `method closing(Tap:D:)'  changed into 'method close(Tap:D:)'