### PR TITLE
Fixed definition for ~

### DIFF
--- a/doc/Language/operators.pod
+++ b/doc/Language/operators.pod
@@ -689,7 +689,7 @@ and then negates the result.
 
 =head2 prefix C«~»
 
-    multi sub prefix:<->(Any) returns Str:D
+    multi sub prefix:<~>(Any) returns Str:D
 
 X<String context operator>.
 


### PR DESCRIPTION
The sample definition for "~" was the same as that for "-"