### PR TITLE
Fix markup in nutshell headers

### DIFF
--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -983,9 +983,17 @@ So, change the C«=>» to C<=> , and add a sigil.
     use constant pi => 4 * atan2(1, 1); # Perl 5
     # pi, e, i are built-in constants in  Perl 6
 
-encoding - allows you to write your script in non-ascii or non-utf8
-integer - Perl pragma to use integer arithmetic instead of floating point
-lib - manipulate @INC at compile time
+=head3 C<encoding>
+
+TODO Allows you to write your script in non-ascii or non-utf8
+
+=head3 C<integer>
+
+Perl pragma to use integer arithmetic instead of floating point
+
+=head3 C<lib> 
+
+Manipulate @INC at compile time
 
 =head3 C<mro>
 


### PR DESCRIPTION
These headers had incorrect markup and were not displaying as such. Now they are fixed, but the is the content up to date, or should it be marked as TODO?