### PR TITLE
Add documentation for pipeline operators

### DIFF
--- a/doc/Language/operators.pod
+++ b/doc/Language/operators.pod
@@ -1893,6 +1893,56 @@ Same as C<infix //>, except with looser precedence.
 Returns the first defined argument, or else the last argument.
 Short-circuits.
 
+=head1 Sequencer Precedence
+
+=head2 infix C«==>»
+
+This X<pipeline> operator takes the result from the left and passes it as the
+last parameter to the right. This allows for a more natural left-to-right data
+flow similar to method chaining, but can be used with functions that are not
+methods of the data in the pipeline.
+
+    # Traditional structure, read bottom-to-top
+    my @result =
+        sort               # (4) Sort, result is <Earth People>
+        grep { /<[PE]>/ }, # (3) Look for P or E
+        map { .tc },       # (2) Capitalize the words
+        <people of earth>; # (1) Start with the input
+
+    # Pipeline (left-to-right), read top-to-bottom
+    my @result =
+        <people of earth> # (1) Start with the input
+        ==> map { .tc }   # (2) Capitalize the words
+        ==> grep /<[PE]>/ # (3) Look for P or E
+        ==> sort;         # (4) Sort, result is <Earth People>
+
+    # For illustration, method chaning equivalent for Lists, read top-to-bottom
+    my @result =
+        <people of earth> # (1) Start with the input
+        .map({ .tc })     # (2) Capitalize the words
+        .grep(/<[PE]>/)   # (3) Look for P or E
+        .sort;            # (4) Sort, result is <Earth People>
+
+=head2 infix C«<==»
+
+This X<leftward pipeline> operator takes the result from the right and passes
+it as the last parameter to the left. This makes visible the right-to-left
+dataflow for a series of list manipulating functions.
+
+    # Traditional structure, read bottom-to-top
+    my @result =
+        sort               # (4) Sort, result is <Earth People>
+        grep { /<[PE]>/ }, # (3) Look for P or E
+        map { .tc },       # (2) Capitalize the words
+        <people of earth>; # (1) Start with the input
+
+    # Pipeline (right-to-left), read bottom-to-top
+    my @result =
+        sort                   # (4) Sort, result is <Earth People>
+        <== grep { /<[PE]>/ }, # (3) Look for P or E
+        <== map { .tc },       # (2) Capitalize the words
+        <== <people of earth>; # (1) Start with the input
+
 =end pod
 
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
I left out ==>> and <<== since they are not implemented in Rakudo.