### PR TITLE
Added X.pod to Types for p6doc to more accurately reflect what the X

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -109,6 +109,7 @@ multi sub MAIN(Bool :$l!) {
     my @modules;
     for @paths -> $dir {
         for dir($dir).sort -> $file {
+            next if $file.d;
             @modules.push: $file.basename.Str.subst('.pod','');
         }
     }

--- a/doc/Type/X.pod
+++ b/doc/Type/X.pod
@@ -1,0 +1,8 @@
+=begin pod
+
+=TITLE package X
+
+The Package X provides no functionality itself; it is only the base package of
+all public exception classes.
+
+=end pod

--- a/doc/Type/X.pod
+++ b/doc/Type/X.pod
@@ -1,8 +1,0 @@
-=begin pod
-
-=TITLE package X
-
-The Package X provides no functionality itself; it is only the base package of
-all public exception classes.
-
-=end pod


### PR DESCRIPTION
package does (or, more to the point, doesn't do)

Further note: As X turns up in the list resulting from 'p6doc -l' it should probably reflect the fact that X isn't actually useful by itself, rather than just that it's a builtin type, as currently occurs.