### PR TITLE
add example of a user-entered tolerance; emphasize Test is a core module

### DIFF
--- a/doc/Language/testing.pod
+++ b/doc/Language/testing.pod
@@ -26,7 +26,7 @@ project's base directory.
 A typical test file looks something like this:
 
     use v6;
-    use Test; # a core module
+    use Test;      # a Standard module included with Rakudo
     use lib 'lib';
 
     plan $num-tests;
@@ -145,7 +145,7 @@ The use can also input a desired tolerance, e.g., testing $some-number:
 
     my $spec-num = 1.2345;
     my $spec-tol = 0.1;
-    is-approx $some-number, $spec-num, $tol, "special tolerance check";
+    is-approx $some-number, $spec-num, $spec-tol, "special tolerance check";
  
 =head2 By structural comparison
 

--- a/doc/Language/testing.pod
+++ b/doc/Language/testing.pod
@@ -141,11 +141,15 @@ C<$description> of the test.
     my $eulers-constant-approx = 2.71828;
     is-approx $eulers-constant-approx, e, "approximate Euler's constant";
 
-The use can also input a desired tolerance, e.g., testing $some-number:
+=item X<is-approx($value, $expected, $tol, $description?)|is-approx>
 
-    my $spec-num = 1.2345;
-    my $spec-tol = 0.1;
-    is-approx $some-number, $spec-num, $spec-tol, "special tolerance check";
+Marks a test as passed if the C<$value> and C<$expected> numerical values
+are within C<$tol> of each other.  The function accepts an optional
+C<$description> of the test.  For example, test for an approximation of pi:
+
+    my $pi-approx = 3.1416;
+    my $pi-tol = 0.0001;
+    is-approx $pi-approx, pi, $pi-tol, "approximate ";
  
 =head2 By structural comparison
 

--- a/doc/Language/testing.pod
+++ b/doc/Language/testing.pod
@@ -26,7 +26,7 @@ project's base directory.
 A typical test file looks something like this:
 
     use v6;
-    use Test;
+    use Test; # a core module
     use lib 'lib';
 
     plan $num-tests;
@@ -141,6 +141,12 @@ C<$description> of the test.
     my $eulers-constant-approx = 2.71828;
     is-approx $eulers-constant-approx, e, "approximate Euler's constant";
 
+The use can also input a desired tolerance, e.g., testing $some-number:
+
+    my $spec-num = 1.2345;
+    my $spec-tol = 0.1;
+    is-approx $some-number, $spec-num, $tol, "special tolerance check";
+ 
 =head2 By structural comparison
 
 =item X<is-deeply($value, $expected, $description?)|is-deeply>

--- a/doc/Language/testing.pod
+++ b/doc/Language/testing.pod
@@ -149,7 +149,7 @@ C<$description> of the test.  For example, test for an approximation of pi:
 
     my $pi-approx = 3.1416;
     my $pi-tol = 0.0001;
-    is-approx $pi-approx, pi, $pi-tol, "approximate ";
+    is-approx $pi-approx, pi, $pi-tol, "approximate Pi";
  
 =head2 By structural comparison
 

--- a/doc/Language/traps.pod
+++ b/doc/Language/traps.pod
@@ -222,7 +222,7 @@ Here, C<tc> means "title case".
 
 =head2 Strings are not iterable
 
-There are methods that Str inherits from Any that work on iterables like lists. Interators on Strings contain one element that is the whole string. To use C<sort>, C<reverse> and friends, you need to split the string into a list first.
+There are methods that Str inherits from Any that work on iterables like lists. Iterators on Strings contain one element that is the whole string. To use C<sort>, C<reverse> and friends, you need to split the string into a list first.
 
     say "abc".reverse;              #   abc (what is wrong)
     say "abc".comb.reverse.join;    #   cba


### PR DESCRIPTION
Add a note about Test being a core module.  Also add an example of a user-supplied tolerance for numerical testing.

I find these additions helpful. It isn't clear in current docs that Test is a core module, and thus a casual user has to search a while for its source.  A section on core modules would be helpful, perhaps referenced on the page where the external modules are listed: <https://modules.perl6.org/>.

Another place to reference them would be to add another category, "Core Modules," on this page: <https://doc.perl6.org/>