### PR TITLE
use nested [()] instead of (()) in sentence; specify that first list …

### DIFF
--- a/doc/Language/unicode_texas.pod
+++ b/doc/Language/unicode_texas.pod
@@ -31,9 +31,9 @@ that has the C<Zs>, C<Zl> or C<Zp> property.
 Any codepoint that has the C<No> property can be used standalone as a numeric value,
 such as ½ and ⅓.  (These aren't decimal digit characters, so can't be combined.)
 
-=head1 Other acceptable codepoints
+=head1 Other acceptable single codepoints
 
-This list contains the codepoints (and their Texas (ASCII) equivalents) that
+This list contains the single codepoints [and their Texas (ASCII) equivalents] that
 have a special meaning in Perl 6.
 
 =table
@@ -93,5 +93,18 @@ have a special meaning in Perl 6.
   ⊖     |  U+2296   | (^) |        |
   ⊍     |  U+228D   | (.) |         |
   ⊎     |  U+228E   |     (+) |       |
+
+=head1 Multiple codepoints
+
+This list contains multiple-codepoint operators that require special
+composition for their Texas (ASCII) equivalents.  Note the codepoints
+are shown space-separated but should be entered as adjacent codepoints
+when used.
+
+
+=table
+  Symbol        | Codepoints | Texas   | Since | Remarks
+  ==============|===========|=========|=======|=========================
+  »=»             |  U+00BB = U+00BB   | >>[=]>>    |       | uses ASCII '='
 
 =end pod


### PR DESCRIPTION
…consists of single codepoints; add another table to document weird compositions such as the one explained by Larry Wall in a recent comment on bug #127965