### PR TITLE
add some examples; format some text for ease of maintenance

### DIFF
--- a/doc/Language/unicode_texas.pod
+++ b/doc/Language/unicode_texas.pod
@@ -4,24 +4,33 @@
 
 =SUBTITLE Unicode symbols and their Texas (ASCII) counterparts
 
-The following unicode symbols can be used in Perl 6 without needing to load
-any additional modules.  Please note that the Since column applies to the
-version of Perl the symbol was known to be available.  It is only mentioned
-if it is different from C<6.c>.
+The following unicode symbols can be used in Perl 6 without needing to
+load any additional modules.  Please note that the Since column
+applies to the version of Perl the symbol was known to be available.
+It is only mentioned if it is different from C<6.c>.
 
 =head1 Alphabetic Characters
 
 Any codepoint that has the C<Ll> (Letter, lowercase), C<Lu> (Letter,
-uppercase), C<Lt> (Letter, titlecase), or C<Lm> (Letter, modifier) property can be used just
-like any other alphabetic character from the ASCII range, like "A" or
-"a".  Any codepoint with the C<Lo> (Letter, other) property can be
-used as an alphabetic where case distinctions do not matter.
+uppercase), C<Lt> (Letter, titlecase), or C<Lm> (Letter, modifier)
+property can be used just like any other alphabetic character from the
+ASCII range, like "A" or "a".  Any codepoint with the C<Lo> (Letter,
+other) property can be used as an alphabetic character where case
+distinctions do not matter.
 
 =head1 Numeric characters
 
 Any codepoint that has the C<Nd> (Number, decimal digit) property, can
-be used as a digit in any number, unless special-cased in the list
-below.
+be used as a digit in any number.  For example:
+
+=begin code
+
+  my $var = 𝑒;
+  say $var; # 2.71828182845905
+
+=end code
+
+
 
 =head1 Whitespace characters
 
@@ -31,13 +40,22 @@ line), or C<Zp> (Separator, paragraph) property.
 
 =head1 Numeric values
 
-Any codepoint that has the C<No> (Number, other) property can be used standalone as a numeric value,
-such as ½ and ⅓.  (These aren't decimal digit characters, so can't be combined.)
+Any codepoint that has the C<No> (Number, other) property can be used
+standalone as a numeric value, such as ½ and ⅓.  (These aren't
+decimal digit characters, so can't be combined.)  For example:
+
+=begin code
+
+  my $var = ⅒ + 2;
+  say $var; # 2.1
+
+=end code
+
 
 =head1 Other acceptable single codepoints
 
-This list contains the single codepoints [and their Texas (ASCII) equivalents] that
-have a special meaning in Perl 6.
+This list contains the single codepoints [and their Texas (ASCII)
+equivalents] that have a special meaning in Perl 6.
 
 =table
   Symbol | Codepoint | Texas      | Since | Remarks

--- a/doc/Language/unicode_texas.pod
+++ b/doc/Language/unicode_texas.pod
@@ -9,17 +9,16 @@ load any additional modules.  Please note that the Since column
 applies to the version of Perl the symbol was known to be available.
 It is only mentioned if it is different from C<6.c>.
 
-Reference is made below to various properties of unicode codepoints.  The definitive list can be found here: L<http://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
-
+Reference is made below to various properties of unicode codepoints.
+The definitive list can be found here:
+L<http://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
 
 =head1 Alphabetic Characters
 
 Any codepoint that has the C<Ll> (Letter, lowercase), C<Lu> (Letter,
-uppercase), C<Lt> (Letter, titlecase), or C<Lm> (Letter, modifier)
-property can be used just like any other alphabetic character from the
-ASCII range, like "A" or "a".  Any codepoint with the C<Lo> (Letter,
-other) property can be used as an alphabetic character where case
-distinctions do not matter.
+uppercase), C<Lt> (Letter, titlecase), C<Lm> (Letter, modifier), or
+the C<Lo> (Letter, other) property can be used just like any other
+alphabetic character from the ASCII range.
 
 =head1 Numeric characters
 
@@ -32,14 +31,6 @@ be used as a digit in any number.  For example:
   say $var + 2;  # 21
 
 =end code
-
-
-
-=head1 Whitespace characters
-
-Besides spaces and tabs you can use any other unicode whitespace
-character that has the C<Zs> (Separator, space), C<Zl> (Separator,
-line), or C<Zp> (Separator, paragraph) property.
 
 =head1 Numeric values
 
@@ -54,6 +45,11 @@ decimal digit characters, so can't be combined.)  For example:
 
 =end code
 
+=head1 Whitespace characters
+
+Besides spaces and tabs you can use any other unicode whitespace
+character that has the C<Zs> (Separator, space), C<Zl> (Separator,
+line), or C<Zp> (Separator, paragraph) property.
 
 =head1 Other acceptable single codepoints
 

--- a/doc/Language/unicode_texas.pod
+++ b/doc/Language/unicode_texas.pod
@@ -9,6 +9,9 @@ load any additional modules.  Please note that the Since column
 applies to the version of Perl the symbol was known to be available.
 It is only mentioned if it is different from C<6.c>.
 
+Reference is made below to various properties of unicode codepoints.  The definitive list can be found here: L<http://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
+
+
 =head1 Alphabetic Characters
 
 Any codepoint that has the C<Ll> (Letter, lowercase), C<Lu> (Letter,

--- a/doc/Language/unicode_texas.pod
+++ b/doc/Language/unicode_texas.pod
@@ -25,8 +25,8 @@ be used as a digit in any number.  For example:
 
 =begin code
 
-  my $var = 𝑒;
-  say $var; # 2.71828182845905
+  my $var = １９; # U+FF11 U+FF19
+  say $var + 2;  # 21
 
 =end code
 


### PR DESCRIPTION
I think we should add a note about best practice:  for portable Perl 6 code, use of non-ASCII characters for operators and mathematical operations is not recommended.