### PR TITLE
Add missing matching "/" at the end of regex

### DIFF
--- a/doc/Language/regexes.pod
+++ b/doc/Language/regexes.pod
@@ -280,7 +280,7 @@ write the backslashed forms for character classes between the C< [ ] >.
 
     / <[\d] - [13579]> /
     # not quite the same as
-    / <[02468]>
+    / <[02468]> /
     # because the first one also contains "weird" unicodey digits
 
 To negate a character class, put a C<-> after the opening angle:


### PR DESCRIPTION
Trivial change to avoid unterminated regex in an example.