### PR TITLE
Typo fix

### DIFF
--- a/doc/Language/regexes.pod
+++ b/doc/Language/regexes.pod
@@ -772,7 +772,7 @@ way you can separate out the C<YYYY>, C<MM> and C<DD> parts of a date and
 reformat them into C<MM-DD-YYYY> order:
 
     $_ = '2016-01-23 18:09:00';
-    s/ (\d+)\-(\d+)\-(\d+) /$0-$1-$2/; # Transform YYYY-MM-DD to MM-DD-YYYY
+    s/ (\d+)\-(\d+)\-(\d+) /$1-$2-$0/; # Transform YYYY-MM-DD to MM-DD-YYYY
     .say;                              # 01-23-2016 18:09:00
 
 Since the right-hand side is effectively a regular Perl 6 interpolated string,


### PR DESCRIPTION
```perl6
$_ = '2016-01-23 18:09:00';
s/ (\d+)\-(\d+)\-(\d+) /$0-$1-$2/; # Transform YYYY-MM-DD to MM-DD-YYYY
.say;                              # 01-23-2016 18:09:00
```

With an order like "0-1-2" substitution makes no sense, since it doesn't change the variable. According to the comment line, the right order should probably be "1-2-0".