### PR TITLE
@opts compilation error fix

### DIFF
--- a/bin/p6doc
+++ b/bin/p6doc
@@ -163,12 +163,12 @@ sub disambiguate-f-search($docee, %data) {
         for %found.keys -> $key {
             %options{$key}.push: %found{$key};
         }
+        my @opts = %options.values.map({ @($^a) });
 
         # 's' => Type::Supply.grep, ... | and we specifically want the %found values,
         #                               | not the presentation-versions in %options
         if INTERACT {
             my $total-elems = %found.values.map( +* ).sum;
-            my @opts = %options.values.map({ @($^a) });
             if +%found.keys < $total-elems {
                 my @prefixes = (1..$total-elems) X~ ") ";
                 say "\t" ~ ( @prefixes Z~ @opts ).join("\n\t") ~ "\n";


### PR DESCRIPTION
Lifted @opts to an outer scope so it could be seen in another spot it was used.