### PR TITLE
Fix printf arguments

### DIFF
--- a/doc/Type/Str.pod
+++ b/doc/Type/Str.pod
@@ -425,11 +425,11 @@ no-ops (the semantics are still being determined).
 
 Examples:
 
- printf('%c', [97]);                  # a
- printf("%.2f", [1.969]);             # 1.97
- printf("%+.3f", [3.141592]);         # +3.142
- printf('%2$d %1$d', [12, 34]);       # 34 12
- printf("%x", [255]);                 # ff
+ printf('%c', 97);                  # a
+ printf("%.2f", 1.969);             # 1.97
+ printf("%+.3f", 3.141592);         # +3.142
+ printf('%2$d %1$d', 12, 34);       # 34 12
+ printf("%x", 255);                 # ff
 
 Special case:  printf("<b>%s</b>\n", "Perl 6")  will not work use either of the following:
 


### PR DESCRIPTION
I think that there is no reason to use the list for the arguments of the printf subroutine.
It will confuse those who read the following section.
https://doc.perl6.org/type/Signature#Slurpy_%28A.K.A._Variadic%29_Parameters
And they will think that "The printf subroutine in Perl 6 is different from C-style printf".