### PR TITLE
Added alphabetic-after-hyphen-or-quote restriction to Identifier

### DIFF
--- a/doc/Language/syntax.pod
+++ b/doc/Language/syntax.pod
@@ -142,10 +142,11 @@ say 'code again';
 =head2 Identifiers
 
 Identifiers are a grammatical building block that occur in several places. An
-identifier is a primitive name, and must start with an alphabetic character (or
-an underscore), followed by zero or more word characters (alphabetic,
-underscore or number). You can also embed dashes C<-> or single quotes C<'> in
-the middle, but not two in a row.
+identifier is a primitive name, and must start with an alphabetic character
+(or an underscore), followed by zero or more word characters (alphabetic,
+underscore or number). You can also embed dashes C<-> or single quotes C<'>
+in the middle, but not two in a row, and only if followed immediately by an
+alphabetic character.
 
     # valid identifiers:
     x


### PR DESCRIPTION
Added language to the description of how identifiers are formed to indicate that an embedded quote or hyphen must be followed immediately by an alphabetic character.