### PR TITLE
add links to design docs

### DIFF
--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -504,7 +504,8 @@ See L<S32/Containers|https://design.perl6.org/S32/Containers.html>
 
 =head1 Operators
 
-See S03-operators for full details on all operators.
+See L<S03/Operators|https://design.perl6.org/S03.html#Overview>
+for full details on all operators.
 
 Unchanged:
 

--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -977,8 +977,8 @@ Strict mode is now on by default.
 
 Warnings are now on by default.
 
-C<no warnings> is currently NYI, but putting things in a quietly {} block
-will silence.
+C<no warnings> is currently L<NYI|http://design.perl6.org/S99.html#NYI>,
+but putting things in a quietly {} block will silence.
 
 =head3 C<autodie>
 

--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -500,7 +500,7 @@ The "Zen" slice does the same thing:
         my @a = $arrayref[];
         my %h = $hashref{};
 
-See S32/Containers
+See L<S32/Containers|https://design.perl6.org/S32/Containers.html>
 
 =head1 Operators
 

--- a/doc/Language/5to6-nutshell.pod
+++ b/doc/Language/5to6-nutshell.pod
@@ -1126,7 +1126,8 @@ Taint warnings are not yet specified.
 
 =item C<-P> C<-u> C<-U> C<-W> C<-X>
 
-Removed. See S19.
+Removed. See L<S19#Removed Syntactic
+Features|https://design.perl6.org/S19.html#Removed_Syntactic_Features>.
 
 =item C<-w>
 


### PR DESCRIPTION
I don't have perl6 handy, so I have no idea if this builds.
I also am not remotely confident that the links are correct.

I do know that as a reader, I expected links for these items.