### PR TITLE
Fix for issue https://github.com/perl6/doc/issues/545

### DIFF
--- a/htmlify.p6
+++ b/htmlify.p6
@@ -186,7 +186,7 @@ sub extract-pod(IO() $file) {
 
     if not $handle {
         # precompile it
-        $precomp.precompile($file, $id);
+        $precomp.precompile($file, $id, force => True);
         $handle = $precomp.load($id)[0];
     }
 

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -186,7 +186,7 @@ sub extract-pod(IO() $file) {
 
     if not $handle {
         # precompile it
-        $precomp.precompile($file, $id, force => True);
+        $precomp.precompile($file, $id, :force);
         $handle = $precomp.load($id)[0];
     }
 


### PR DESCRIPTION
In order to speed up the doc generation the program precompiles pod files
into the directory precompiled. The code in the sub extract-pod loads the
precompiled files but if it detects that a pod file has been changed it
calls the method precompile in CompUnit::PrecompilationRepository. The
problem is that the precompile method checks if the file, that it is being
asked to recompile, exists in the repo, and if it does it won't recompile
it unless the named parameter :force is set to True. My suggested
change is that we set :force => True when calling the precompile method.