### PR TITLE
Parallelize a bunch of htmlify.p6

### DIFF
--- a/htmlify.p6
+++ b/htmlify.p6
@@ -618,20 +618,19 @@ sub write-type-graph-images(:$force, :$parallel) {
         FIRST my @type-graph-images;
 
         my $viz = Perl6::TypeGraph::Viz.new-for-type($type);
-        try {
-            @type-graph-images.push: $viz.to-file("html/images/type-graph-{$type}.svg", format => 'svg');
-            @type-graph-images.push: $viz.to-file("html/images/type-graph-{$type}.png", format => 'png', size => '8,3');
-
-            CATCH {
-                die 'dot command failed! (did you install Graphviz?)';
-            }
-        }
-        print '.';
-
+        @type-graph-images.push: $viz.to-file("html/images/type-graph-{$type}.svg", format => 'svg');
         if @type-graph-images %% $parallel {
             await(@type-graph-images);
             @type-graph-images = ();
         }
+
+        @type-graph-images.push: $viz.to-file("html/images/type-graph-{$type}.png", format => 'png', size => '8,3');
+        if @type-graph-images %% $parallel {
+            await(@type-graph-images);
+            @type-graph-images = ();
+        }
+
+        print '.';
 
         LAST await(@type-graph-images);
     }
@@ -648,15 +647,13 @@ sub write-type-graph-images(:$force, :$parallel) {
         my $viz = Perl6::TypeGraph::Viz.new(:types(@types),
                                             :dot-hints(viz-hints($group)),
                                             :rank-dir('LR'));
-        try {
-            @specialized-visualizations.push: $viz.to-file("html/images/type-graph-{$group}.svg", format => 'svg');
-            @specialized-visualizations.push: $viz.to-file("html/images/type-graph-{$group}.png", format => 'png', size => '8,3');
-
-            CATCH {
-                die 'dot command failed! (did you install Graphviz?)';
-            }
+        @specialized-visualizations.push: $viz.to-file("html/images/type-graph-{$group}.svg", format => 'svg');
+        if @specialized-visualizations %% $parallel {
+            await(@specialized-visualizations);
+            @specialized-visualizations = ();
         }
 
+        @specialized-visualizations.push: $viz.to-file("html/images/type-graph-{$group}.png", format => 'png', size => '8,3');
         if @specialized-visualizations %% $parallel {
             await(@specialized-visualizations);
             @specialized-visualizations = ();

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -657,6 +657,11 @@ sub write-type-graph-images(:$force, :$parallel) {
             }
         }
 
+        if @specialized-visualizations %% $parallel {
+            await(@specialized-visualizations);
+            @specialized-visualizations = ();
+        }
+
         LAST await(@specialized-visualizations);
     }
 }

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -105,6 +105,10 @@ sub recursive-dir($dir) {
 
 # --sparse=5: only process 1/5th of the files
 # mostly useful for performance optimizations, profiling etc.
+#
+# --parallel=10: perform some parts in parallel (with width/degree of 10)
+# much faster, but with the current state of async/concurrency
+# in Rakudo you risk segfaults, weird errors, etc.
 sub MAIN(
     Bool :$typegraph = False,
     Int  :$sparse,
@@ -112,7 +116,7 @@ sub MAIN(
     Bool :$search-file = True,
     Bool :$no-highlight = False,
     Bool :$no-inline-python = False,
-    Int  :$parallel = 5,
+    Int  :$parallel = 1,
 ) {
 
     # TODO: For the moment rakudo doc pod files were copied

--- a/lib/Perl6/TypeGraph/Viz.pm
+++ b/lib/Perl6/TypeGraph/Viz.pm
@@ -91,11 +91,11 @@ class Perl6::TypeGraph::Viz {
         spurt $file, self.as-dot;
     }
 
-    method to-file ($file, :$format = 'svg', :$size) {
+    method to-file ($file, :$format = 'svg', :$size --> Promise:D) {
+        die "bad filename '$file'" unless $file;
         my ($filename, $filehandle) = tempfile(:tempdir($*TMPDIR), :prefix('p6-doc-graphviz-'));
         spurt $filename, self.as-dot(:$size);
-        die "bad filename '$file'" unless $file;
-        run 'dot', "-T$format", "-o$file", $filename or die 'dot command failed! (did you install Graphviz?)';
+        Proc::Async.new('dot', '-T', $format, '-o', $file, $filename).start;
     }
 }
 

--- a/lib/Perl6/TypeGraph/Viz.pm
+++ b/lib/Perl6/TypeGraph/Viz.pm
@@ -91,7 +91,11 @@ class Perl6::TypeGraph::Viz {
     }
 
     method to-file ($file, :$format = 'svg', :$size --> Promise:D) {
+        once {
+            run 'dot', '-V', :!err or die 'dot command failed! (did you install Graphviz?)';
+        }
         die "bad filename '$file'" unless $file;
+
         my $dot = Proc::Async.new(:w, 'dot', '-T', $format, '-o', $file);
         my $promise = $dot.start;
         await($dot.write(self.as-dot(:$size).encode));


### PR DESCRIPTION
Convert the "Processing $dir Pod files ..." section to a bunch of start()s and await()s. Convert the "Writing [type graph images, specialized visualizations] to html/image" section to a bunch of Proc::Async.new.start()s, and awaits(). 

For me, this brings "time perl6 htmlify.p6 --no-highlight" from 6 min to 1.5 min. However, in my experience, the async/concurrency parts of Rakudo are definitely kind of weird crash prone, and this change does produce the occasional segfault.