### PR TITLE
README example needs PERL6LIB to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ files correctly, because this is Perl 6 Pod, and github assumes Perl 5 POD).
 
 With a Rakudo `perl6` executable in `PATH`, try
 
-    PERL6LIB=. ./bin/p6doc Type::Str
+    ./bin/p6doc Type::Str
 
 to see the documentation for class `Str`, or
 
-    PERL6LIB=. ./bin/p6doc Type::Str.split
+    ./bin/p6doc Type::Str.split
 
 to see the documentation for method `split` in class `Str`.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ files correctly, because this is Perl 6 Pod, and github assumes Perl 5 POD).
 
 With a Rakudo `perl6` executable in `PATH`, try
 
-    ./bin/p6doc Type::Str
+    PERL6LIB=. ./bin/p6doc Type::Str
 
 to see the documentation for class `Str`, or
 
-    ./bin/p6doc Type::Str.split
+    PERL6LIB=. ./bin/p6doc Type::Str.split
 
 to see the documentation for method `split` in class `Str`.
 

--- a/bin/p6doc
+++ b/bin/p6doc
@@ -22,7 +22,7 @@ sub findbin() returns Str {
 constant INDEX = findbin() ~ 'index.data';
 
 sub search-paths() returns Seq {
-    ($*REPO.repo-chain()>>.Str X~ </doc/>).grep: *.IO.d
+    (('.', $*REPO.repo-chain())>>.Str X~ </doc/>).grep: *.IO.d
 }
 
 sub module-names(Str $modulename) returns Seq {

--- a/bin/p6doc
+++ b/bin/p6doc
@@ -22,7 +22,7 @@ sub findbin() returns Str {
 constant INDEX = findbin() ~ 'index.data';
 
 sub search-paths() returns Seq {
-    (('.', $*REPO.repo-chain())>>.Str X~ </doc/>).grep: *.IO.d
+    (('.', |$*REPO.repo-chain())>>.Str X~ </doc/>).grep: *.IO.d
 }
 
 sub module-names(Str $modulename) returns Seq {


### PR DESCRIPTION
Hi,

The first example in the README wasn't working for me (rakudo 2016.06).  Setting PERL6LIB seems to fix it.

best
Brian
