### PR TITLE
How to increase the maximum threads in $*SCHEDULER

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1152,8 +1152,18 @@ X<|$*SPEC>X<|$*TMPDIR>X<|$*THREAD>X<|$*SCHEDULER>
     ------------------+--------------------------------------------
     $*THREAD          | A L<Thread> object representing the currently executing thread.
     ------------------+--------------------------------------------
-    $*SCHEDULER       | A L<ThreadPoolScheduler> object representing the current
-                      | default scheduler.
+    $*SCHEDULER       | A L<ThreadPoolScheduler> object representing the current default 
+                      | scheduler. 
+                      |
+                      | Note on usage: For the current Rakudo, by default this imposes a 
+                      | maximum of 16 threads on hyperoperators and methods such as
+                      | C<.hyper> and C<.race>. To change the maximum number of threads, either
+                      | set the environment variable RAKUDO_MAX_THREADS or create a scoped copy
+                      | with the default changed:
+                      | 
+                      | my $*SCHEDULER = ThreadPoolScheduler.new( max_threads => 64 );
+                      | 
+                      | This behavior is not tested in the spec tests and is subject to change.)
     ------------------+--------------------------------------------
 
 =end pod

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1156,14 +1156,14 @@ X<|$*SPEC>X<|$*TMPDIR>X<|$*THREAD>X<|$*SCHEDULER>
                       | scheduler. 
                       |
                       | Note on usage: For the current Rakudo, by default this imposes a 
-                      | maximum of 16 threads on hyperoperators and methods such as
-                      | C<.hyper> and C<.race>. To change the maximum number of threads, either
-                      | set the environment variable RAKUDO_MAX_THREADS or create a scoped copy
-                      | with the default changed:
+                      | maximum of 16 threads on the methods C<.hyper> and C<.race>. To change 
+                      | the maximum number of threads, either set the environment variable 
+                      | RAKUDO_MAX_THREADS before running perl6 or create a scoped copy
+                      | with the default changed before using C<.hyper> or C<.race>:
                       | 
                       | my $*SCHEDULER = ThreadPoolScheduler.new( max_threads => 64 );
                       | 
-                      | This behavior is not tested in the spec tests and is subject to change.)
+                      | This behavior is not tested in the spec tests and is subject to change.
     ------------------+--------------------------------------------
 
 =end pod

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1152,17 +1152,17 @@ X<|$*SPEC>X<|$*TMPDIR>X<|$*THREAD>X<|$*SCHEDULER>
     ------------------+--------------------------------------------
     $*THREAD          | A L<Thread> object representing the currently executing thread.
     ------------------+--------------------------------------------
-    $*SCHEDULER       | A L<ThreadPoolScheduler> object representing the current default 
-                      | scheduler. 
+    $*SCHEDULER       | A L<ThreadPoolScheduler> object representing the current default
+                      | scheduler.
                       |
-                      | Note on usage: For the current Rakudo, by default this imposes a 
-                      | maximum of 16 threads on the methods C<.hyper> and C<.race>. To change 
-                      | the maximum number of threads, either set the environment variable 
+                      | Note on usage: For the current Rakudo, by default this imposes a
+                      | maximum of 16 threads on the methods C<.hyper> and C<.race>. To change
+                      | the maximum number of threads, either set the environment variable
                       | RAKUDO_MAX_THREADS before running perl6 or create a scoped copy
                       | with the default changed before using C<.hyper> or C<.race>:
-                      | 
+                      |
                       | my $*SCHEDULER = ThreadPoolScheduler.new( max_threads => 64 );
-                      | 
+                      |
                       | This behavior is not tested in the spec tests and is subject to change.
     ------------------+--------------------------------------------
 


### PR DESCRIPTION
Explain the current default limit on hyperoperators and methods.