### PR TITLE
Simple cache support

### DIFF
--- a/META.info
+++ b/META.info
@@ -2,7 +2,7 @@
     "name"        : "p6doc",
     "version"     : "*",
     "description" : "Perl 6 documentation (tools and docs)",
-    "depends"     : [ "URI", "File::Temp", "JSON::Fast" ],
+    "depends"     : [ "URI", "File::Temp", "JSON::Fast", "Digest::MurmurHash3" ],
     "build-depends" : [ "File::Find" ],
     "provides"    : {
         "Perl6::Type"                   : "lib/Perl6/Type.pm",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: html html-nohighlight test help
 
 html:
-	perl6 htmlify.p6
+	perl6 htmlify.p6 --erase-cache
 
 html-nohighlight:
 	perl6 htmlify.p6 --no-highlight

--- a/htmlify.p6
+++ b/htmlify.p6
@@ -136,7 +136,9 @@ sub MAIN(
     Bool :$no-highlight = False,
     Bool :$no-inline-python = False,
     Int  :$parallel = 1,
+    Bool :$erase-cache = False,
 ) {
+    unlink $cache-filename if $erase-cache;
 
     # TODO: For the moment rakudo doc pod files were copied
     #       from its repo to subdir doc/Programs and modified to Perl 6 pod.


### PR DESCRIPTION
This is a quite simple implementation of generated page caching.

It can generate cache, update cache for new and changed pod6-files. With --sparse=5 time difference between cached and non-cached run on my machine is about 8x, without is about 9-10x.

It brings new dependency - Digest::MurmurHash3, it's the only one quite consistent hash function I found in the ecosystem. If anyone knows better(and more light-weight) tool - it will be appreciated. But since it's a C bindings, it's quite fast and simple.

I prefer explicit typing style, but if some things can be more clear or concise, I'd like to know about them(I'm not an idiomatic Perl 6 pro).

I suppose, for a documentation main server we shouldn't use cache(it can be disabled using command-line argument), but for local make it seems good enough.