### PR TITLE
syntax correction

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -367,7 +367,7 @@ This includes the numeric ranges starting from 0:
 or a Whatever operator for an infinite range with a non inclusive minimum:
 
 =begin code
-    say so 'aaaa' ~~ /a ~~ 1^..*/;    # True
+    say so 'aaaa' ~~ /a ** 1^..*/;    # True
 =end code
 
 =head2 X<Modified quantifier: %|regex,%;regex,%%>


### PR DESCRIPTION
Correction replaced second smartmatch with double asterisk. Now the statement is true as advertised.