### PR TITLE
Glossary cleanup

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1283,6 +1283,7 @@ compiled bytecode.
 Rakudo supports this only for modules so far.
 
 =head2 Importing specific functions from a module
+X<|import>
 
 In Perl 5 it is possible to selectively import functions from a given module
 like so:

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -114,6 +114,7 @@ generated. Both automatic variables can be used that the same time.
 =comment capture, destructuring,
 
 =head2 Arguments
+X<|Argument>
 
 Arguments are supplied as a comma separated list. To disambiguate nested calls
 parentheses or adverbial form can be used.

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -878,3 +878,5 @@ X<|whitespace>
 
 =head1 6model
 X<|6model>
+
+=end pod

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -19,16 +19,6 @@ implemented using L<roles|#Role> with L<stubbed|#Stub> methods.
         method bark { say "woof" }   # *MUST* be implemented by class
     }
 
-=head1 Actions
-X<|Actions>
-
-Action methods are typically used to perform transformations and
-other actions while parsing a source code program.  Parse grammars
-typically use the special token C< {*} > to indicate the point
-at which an action method is to be invoked.  In addition, a line
-containing C< {*} > may also use C< #= > to specify a "key" that
-is to be passed to the action method.
-
 =head1 Advent Calendar
 X<|Advent Calendar>
 
@@ -129,16 +119,6 @@ initial barrage of RFC's that came out of the Perl community.  Now only kept
 as an historical document for reference.  See also L<#Exegesis> and
 L<#Synopsis>.
 
-=head1 Argument
-X<|Argument>
-
-A value that you pass on to a L<subroutine|#Subroutine>, L<method|#Method>
-or a L<callable block|#Callable>.  As opposed to the L<#Parameter> that is
-specified in the definition of a subroutine/method/callable block.
-
-    sub foo($bar) { say $bar }     # $bar is a parameter
-    foo(42);                       # 42 is an argument
-
 =head1 Arity
 X<|Arity>
 
@@ -153,19 +133,6 @@ L<callable block|#Callable>.
 
 The arity of a C<Callable> is one of the main selectors in
 L<multi-dispatch|#Multi-Dispatch>.
-
-=head1 Attribute
-X<|Attribute> X<|Property> X<|Member> X<|Slot>
-
-A per-object storage slot. Other programming languages refer to this as
-C<Field>, C<Member>, C<Slot> or C<Property>.
-
-In Perl 6, attributes are defined with the L<#has> keyword inside a
-L<class|#Class>:
-
-    class Dog {
-        has $.name;    # public attribute "name"
-    }
 
 =head1 AST
 X<|AST>
@@ -259,41 +226,10 @@ with the appropriate sigil:
 
 See also L<#Adverb>.
 
-=head1 Constraint
-X<|Constraint>
-
-Constraints are a restriction placed on acceptable types for a parameter
-or subset type.  They are introduced with the word C<where>.  In the
-following example, a constraint is used to make sure an error occurs if
-anyone ever calls a subroutine named C<abbreviate> with a string which is
-shorter than 10 characters:
-
-    sub abbreviate(Str $thing where { .chars >= 10 }) { ... }
-
-The C<Str> in the above example is also a constraint, but is usually
-referred to as a "type constraint."
-
-Note that you can also differentiate candidates in a
-L<multi-dispatch|#Multi-Dispatch> by using a different constraint:
-
-    multi sub abbreviate(Str $thing where { .chars > 10 }) {
-        "$thing.substr(0, 7)..."
-    }
-    multi sub abbreviate(Str $thing) { $thing }  # no constraint
-
-    say abbreviate("Worthington");   # Worthin...
-    say abbreviate("Mäsak");         # Mäsak
-
 =head1 Damian Conway
 
 Original author of the L<#Exegesis> (among many other things).
 See also L<https://en.wikipedia.org/wiki/Damian_Conway>.
-
-=head1 Enum
-X<|Enum>
-
-Enumerations provide constant key-value-pairs with an associated type.
-See L<Enum|/language/typesystem#enum>.
 
 =head1 Exegesis
 X<|Exegesis>
@@ -310,23 +246,11 @@ The value representing logical C<False> of the L<#Bool> L<enum|#Enum>.
 =head1 fiddly
 X<|fiddly>
 
-=head1 Field
-
-See L<#Attribute>.
-
 =head1 handles
 X<|handles>
 
-=head1 has
-X<|has>
-
-A keyword used to define L<attributes|#Attributes>.
-
 =head1 iffy
 X<|iffy>
-
-=head1 import
-X<|import>
 
 =head1 Instance
 X<|instance>
@@ -585,27 +509,6 @@ X<|WW>
 Short for C<wrong window>.  When on L<#IRC>, someone types something in a
 channel that was intended for another channel, or for a private message.
 
-=head1 Invocant
-X<|Invocant>
-
-The object upon which a method is called, is referred to as the I<invocant>
-in Perl 6.  It is what C<self> refers to in a method.
-
-    say 'str'.uc;   # 'str' is the invocant of method uc
-
-    class A { method show { self } }
-    say A.new.show;       # A.new
-
-=head1 JIT
-X<|JIT>
-
-L<Just-in-time compilation|https://en.wikipedia.org/wiki/Just-in-time_compilation>, a technique for improving the performance of virtual machines.
-
-=head1 JVM
-X<|JVM>
-
-Java Virtual Machine
-
 =head1 Larry Wall
 
 L<Perl's|#Perl> benevolent dictator for life, among many other things.  See
@@ -674,15 +577,6 @@ You can also have the mainline of any package-like declarator, such as
 L<class|#Class>, L<module|#Module>, L<grammar|#Grammar>, etc.  These are
 typically run just after the class/module/grammar have been compiled (or
 when loaded from a pre-compiled file).
-
-=head1 Member
-
-See L<#Attribute>.
-
-=head1 Method
-X<|Method>
-
-Methods are L<subroutine|#Subroutine>s that are called with an L<invocant|#Invocant>.
 
 =head1 MoarVM
 X<|MoarVM>
@@ -862,16 +756,6 @@ L<https://github.com/perl6/roast/>.  Originally developed for L<#pugs>, it
 now serves all Perl 6 implementations.  Why roast? It's the B<r>epository
 B<o>f B<a>ll B<s>pec B<t>ests.
 
-=head1 Role
-X<|Role>
-
-A role can be composed with zero or more other roles, then instantiated into
-a L<class|#Class>. The L<sigil|#Sigil> of a variable name indicates that the defined
-value in the container denoted by the variable belongs to a class composed
-from the associated role.  For example, the sigil C<@> denotes the
-C<Positional> role. So a variable C<@a> may contain a value of type C<List>
-because C<List.does(Positional)>.
-
 =head1 rule
 X<|rule>
 
@@ -897,26 +781,6 @@ starting with such a variable.
 =head1 Sigilless Variable
 X<|Sigilless Variable>
 
-=head1 Slot
-
-See L<#Attribute>.
-
-=head1 Slurpy
-X<|Slurpy>
-
-A parameter of a sub or method is said to be I<slurpy> if it can consume an
-arbitrary number of arguments. It is indicated by an asterisk C<*> in front
-of the parameter name.
-
-    sub sum(*@numbers) {
-        return [+] @numbers;
-    }
-
-This can also be used to collect all possible named parameters in a call:
-
-    sub allnameds(*%named) { .say for %named.sort }
-    allnameds a => 42, :666b, :c<foo>;  # a => 42, b => 666, c => foo
-
 =head1 Spesh
 X<|Spesh>
 
@@ -935,13 +799,6 @@ it's more of a guideline or model for Perl 6 implementations to follow.
 
 =head1 Stub
 X<|Stub>
-
-=head1 Subroutine
-X<|Subroutine>
-
-A subroutine is like a L<#block>, but its L<#runtime> context is stacked.
-When a subroutine is called, its context is pushed in the context stack
-is popped and the return argument becomes the value of the calling expression.
 
 =head1 Symbol
 X<|Symbol>
@@ -991,48 +848,10 @@ L<Exegeses|#Exegesis>.
 L<#IRC> screen name for L<#Larry Wall>, creator of Perl. The name comes from
 the pronunciation of L<#TIMTOWTDI> as a word.
 
-=head1 token
-X<|token>
-
 =head1 True
 X<|True>
 
 The value representing logical C<True> of the L<#Bool> L<enum|#Enum>.
-
-=head1 Twigil
-X<|Twigil>
-
-A secondary L<sigil|#Sigil>. For example, %*ENV has a sigil of % and a
-twigil of *.
-See L<Twigils|/language/variables#Twigils>.
-
-=head1 Type Object
-X<|Type Object>
-
-A I<type object> is an object representing a L<class|#Class>, L<role|#Role>,
-L<package|#Package>, L<grammar|#Grammar> or L<enum|#Enum>. It is generally
-accessible with the same name as the type.
-
-    class A { };
-    say A;              # A is the type object
-    my $x = A.new();    # same here
-
-    my $x = class {
-        method greet() {
-            say "hi";
-        }
-    }
-
-    # $x now holds a type object returned from the
-    # anonymous class definition
-
-If a variable is declared to be of a certain type, but never defined, then
-it will evaluate to the type object of that type.  As such, type objects can
-often turn up in places where "undefined" or "null" would in other
-languages:
-
-    # perl6 -e 'my Int $a; sub f(Int $x) { $x + 1 }; f($a);'
-    Invocant requires an instance, but a type object was passed
 
 =head1 value
 X<|value>
@@ -1059,21 +878,3 @@ X<|whitespace>
 
 =head1 6model
 X<|6model>
-
-=head1 $
-
-L<#Sigil> for L<scalar|#Scalar> L<variables|#Variable>.
-
-=head1 @
-
-L<#Sigil> for L<array|#Array> L<variables|#Variable>.
-
-=head1 %
-
-L<#Sigil> for L<hash|#Hash> L<variables|#Variable>.
-
-=head1 &
-
-L<#Sigil> for L<code|#Code> L<variables|#Variable>.
-
-=end pod

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -264,6 +264,7 @@ provided by parse methods:
     # 12
 
 =head1 Action Objects
+X<|Actions>
 
 A successful grammar match gives you a parse tree of L<Match|/type/Match>
 objects, and the deeper that match tree gets, and the more branches in the

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -136,6 +136,7 @@ useful if the class is an implementation detail nested inside a module or
 another class.
 
 =head2 Attributes
+X<|Attribute> X<|Property> X<|Member> X<|Slot>
 
 Attributes are variables that exist per instance of a class. They are where
 the state of an object is stored. In Perl 6, all attributes are private.

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -9,6 +9,7 @@ optionally by a second special character named I<twigil> and then an
 I<identifier>.
 
 =head1 Sigils
+<X|$ (sigil),@ (sigil),% (sigil),& (sigil)>
 
 The sigil serves as a variable indicator and type constraint.
 
@@ -149,6 +150,7 @@ something on as-is:
     }
 
 =head1 Twigils
+X<|Twigil>
 
 Twigils influence the scoping of a variable. Please be aware that twigils
 have no influence over whether the primary sigil interpolates. That is, if

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -93,6 +93,7 @@ say Foo.whoami; # => Well I'm class Foo, of course!
 
 X<|type constraint (Signature)>
 =head2 Type Constraints
+X<|Constraint>
 
 Parameters can optionally have a type constraint (the default is L<C<Any>>).
 These can be used to restrict the allowed input to a function.


### PR DESCRIPTION
1.Entries that just point to wiki were removed(except MoarVM, since it's definitely Perl6-specific).
2.Entries which are already described were removed.

This is a part of https://github.com/perl6/doc/issues/728#issuecomment-234317210