### PR TITLE
add operator classifications to the Index

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -77,6 +77,11 @@ In the operator descriptions below, a default associativity of I<left>
 is assumed.
 
 =head1 Operator classification
+X<|prefix operator>
+X<|infix operator>
+X<|postfix operator>
+X<|circumfix operator>
+X<|postcircumfix operator>
 
 Operators can occur in several positions relative to a term:
 


### PR DESCRIPTION
In the spirit of https://github.com/perl6/doc/issues/728, adding operator classifications to the index.