### PR TITLE
Second part of entries cleanup

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -7,7 +7,7 @@
 =head1 Abstract Class
 X<|Abstract Class>
 
-The generic Computer Science term "abstract L<class|#Class>" defines the
+The generic Computer Science term "abstract class" defines the
 L<interface|#Interface> or L<#API> of a class.  In Perl 6, this is
 implemented using roles with L<stubbed|#Stub> methods.
 
@@ -134,13 +134,6 @@ L<callable block|#Callable>.
 The arity of a C<Callable> is one of the main selectors in
 L<multi-dispatch|#Multi-Dispatch>.
 
-=head1 AST
-X<|AST>
-
-Acronym for
-L<B<A>bstract B<S>yntax B<T>ree|https://en.wikipedia.org/wiki/Abstract_syntax_tree>.
-Used in many places, including actions, L<#PAST>, and L<#QAST>.
-
 =head1 Autothreading
 X<|Autothreading>
 
@@ -185,12 +178,6 @@ X<|bytecode>
 X<|Camelia>
 
 A butterfly image intended primarily to represent Perl 6, The Language.
-
-=head1 Class
-X<|Class>
-
-A basic software structure in L<#OOP>.
-See the L<Wikipedia entry|https://en.wikipedia.org/wiki/Class_%28computer_programming%29>.
 
 =head1 Colon Pair and Colon List
 X<|Color Pair> X<|Colon List>
@@ -423,7 +410,7 @@ No Such Thing
 X<|Opt>
 
 Short for "optimization", usually in either the context of L<spesh|#Spesh> or
-L<#JIT>.
+JIT.
 
 =head2 PB
 X<|PB>
@@ -509,16 +496,6 @@ X<|WW>
 Short for C<wrong window>.  When on L<#IRC>, someone types something in a
 channel that was intended for another channel, or for a private message.
 
-=head1 JIT
-X<|JIT>
-
-L<Just-in-time compilation|https://en.wikipedia.org/wiki/Just-in-time_compilation>, a technique for improving the performance of virtual machines.
-
-=head1 JVM
-X<|JVM>
-
-Java Virtual Machine
-
 =head1 Larry Wall
 
 L<Perl's|#Perl> benevolent dictator for life, among many other things.  See
@@ -567,11 +544,6 @@ Examples of things that are not lvalues:
 
 These are typically called L<rvalues|#rvalue>.
 
-=head1 machine code
-X<|machine code>
-
-See L<Wikipedia entry|https://en.wikipedia.org/wiki/Machine_code>
-
 =head1 Mainline
 X<|Mainline>
 
@@ -584,7 +556,7 @@ The C<mainline> is the program text that is not part of any kind of block.
     f();        # in mainline again
 
 You can also have the mainline of any package-like declarator, such as
-L<class|#Class>, L<module|#Module>, L<grammar|#Grammar>, etc.  These are
+class, L<module|#Module>, L<grammar|#Grammar>, etc.  These are
 typically run just after the class/module/grammar have been compiled (or
 when loaded from a pre-compiled file).
 
@@ -624,17 +596,12 @@ subset of the Perl 6 syntax.  It's not intended to be a full-fledged
 programming language, nor does it provide a runtime environment beyond
 the basic VM primitives.  Compilers (such as L<#Rakudo> typically use
 NQP to compile action methods that convert a parse tree
-into its equivalent L<abstract syntax tree|#AST> representation.
+into its equivalent abstract syntax tree representation.
 
 =head1 NYI
 X<|NYI>
 
 Not Yet Implemented
-
-=head1 OOP
-X<|OOP>
-
-Object Oriented Programming, see L<https://en.wikipedia.org/wiki/Object-oriented_programming>
 
 =head1 opcode
 X<|opcode>
@@ -660,15 +627,10 @@ that completes the information provided by its category.  Below
 C<%conditional> is the category, C<< :reducecheck<ternary> >>, which
 specifies calling C<.ternary> to post-process the L<parse subtree|#Parse Tree>
 and C<< :pasttype<if> >> specifies the NQP L<#opcode> generated in the
-L<#AST> from the parse subtree.
+AST from the parse subtree.
 
         <O('%conditional, :reducecheck<ternary>, :pasttype<if>')>
 
-
-=head1 OS
-X<|OS>
-
-See L<Wikipedia article|https://en.wikipedia.org/wiki/Operating_system>
 
 =head1 Parse Tree
 X<|Parse Tree>
@@ -693,7 +655,7 @@ L<dynamic languages|#Dynamic Language>.  No longer actively maintained.
 =head1 PAST
 X<|PAST>
 
-L<#Parrot> L<#AST>.
+L<#Parrot> AST.
 
 =head1 perl
 X<|perl>
@@ -738,18 +700,9 @@ Successor to L<#QAST>.
 X<|Rakudo>
 
 Rakudo is the name of a Perl 6 implementation that runs on L<#MoarVM> and
-the L<#JVM>.  It is an abbreviation of "Rakuda-do," which, when translated
+the JVM.  It is an abbreviation of "Rakuda-do," which, when translated
 from Japanese, means "The Way of the Camel".  Also, in Japanese, "Rakudo"
 means "Paradise."
-
-=head1 Regular Expression
-
-See L<Regular Expression|https://en.wikipedia.org/wiki/Regular_expression>
-
-=head1 regex
-X<|Regular Expression,regex>
-
-L<#Regular Expression>.
 
 =head1 Repository
 X<|Repository>
@@ -791,8 +744,8 @@ X<|Sigilless Variable>
 X<|Spesh>
 
 A functionality of the L<#MoarVM> platform that uses run-time gathered data
-to improve commonly used pieces of L<#bytecode>. It is much like a L<#JIT>
-compiler, except that those usually output L<#machine code> rather than
+to improve commonly used pieces of L<#bytecode>. It is much like a JIT
+compiler, except that those usually output machine code rather than
 bytecode.
 
 =head1 STD
@@ -810,7 +763,7 @@ X<|Stub>
 X<|Symbol>
 
 Fancy alternative way to denote a name. Generally used in the context of
-L<module|#Module>s linking, be it in the L<#OS> level, or at the Perl 6 L<#VM> level
+L<module|#Module>s linking, be it in the OS level, or at the Perl 6 L<#VM> level
 for modules generated from languages targeting these VMs.  The set of
 imported or exported symbols is called the symbol table.
 
@@ -875,9 +828,9 @@ X<|Virtual Machine>
 
 A virtual machine is the Perl compiler entity that executes the
 L<bytecode|#Bytecode>.  It can optimize the bytecode or generate
-L<machine code|#Machine code> L<Just in Time|#JIT>.  Examples are
+machine code Just in Time.  Examples are
 L<#MoarVM>, L<#Parrot> (who are intended to run Perl 6) and more
-generic virtual machines such as L<#JVM> and L<#Javascript>.
+generic virtual machines such as JVM and L<#Javascript>.
 
 =head1 whitespace
 X<|whitespace>

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -556,7 +556,7 @@ The C<mainline> is the program text that is not part of any kind of block.
     f();        # in mainline again
 
 You can also have the mainline of any package-like declarator, such as
-class, L<module|#Module>, L<grammar|#Grammar>, etc.  These are
+L<class|#Class>, L<module|/language/modules>, L<grammar|/language/grammars>, etc.  These are
 typically run just after the class/module/grammar have been compiled (or
 when loaded from a pre-compiled file).
 
@@ -763,7 +763,7 @@ X<|Stub>
 X<|Symbol>
 
 Fancy alternative way to denote a name. Generally used in the context of
-L<module|#Module>s linking, be it in the OS level, or at the Perl 6 L<#VM> level
+L<module|/language/modules>s linking, be it in the L<#OS> level, or at the Perl 6 L<#Virtual Machine> level
 for modules generated from languages targeting these VMs.  The set of
 imported or exported symbols is called the symbol table.
 
@@ -830,7 +830,7 @@ A virtual machine is the Perl compiler entity that executes the
 L<bytecode|#Bytecode>.  It can optimize the bytecode or generate
 machine code Just in Time.  Examples are
 L<#MoarVM>, L<#Parrot> (who are intended to run Perl 6) and more
-generic virtual machines such as JVM and L<#Javascript>.
+generic virtual machines such as L<#JVM> and Javascript.
 
 =head1 whitespace
 X<|whitespace>


### PR DESCRIPTION
According to https://github.com/perl6/doc/issues/728 discussion, this is a patch that removes glossary items which just point to wikipedia pages.

**Should we remove them or not is still a debatable question, so don't merge this "Just because".**

Opinions are still needed.