### PR TITLE
Bool.succ, .pred methods explained (please review)

### DIFF
--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -19,6 +19,8 @@ Returns C<True>.
     say True.succ;                                    # True
     say False.succ;                                   # True
 
+succ is short for successor. In many languages, the succ function is used to return the "next" enum, also known as the successor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<True> is its successor. And since C<True> is the "highest" Bool enum, its own successor is also C<True>.
+
 =head2 routine pred
 
     method pred() returns Bool:D
@@ -27,6 +29,8 @@ Returns C<False>.
 
     say True.pred;                                    # False
     say False.pred;                                   # False
+
+pred is short for predecessor. In many languages, the pred function is used to return the "previous" enum, also known as the predecessor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<False> is the predecessor to C<True>. And since C<False> is the "loweset" Bool enum, its own predecessor is also C<False>.
 
 =head2 routine enums
 

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -19,7 +19,7 @@ Returns C<True>.
     say True.succ;                                    # True
     say False.succ;                                   # True
 
-succ is short for successor. In many languages, the succ function is used to return the "next" enum, also known as the successor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<True> is its successor. And since C<True> is the "highest" Bool enum, its own successor is also C<True>.
+C<succ> is short for successor. In many languages, the C<succ> function is used to return the "next" enum, also known as the successor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<True> is its successor. And since C<True> is the "highest" Bool enum, its own successor is also C<True>.
 
 =head2 routine pred
 
@@ -30,7 +30,7 @@ Returns C<False>.
     say True.pred;                                    # False
     say False.pred;                                   # False
 
-pred is short for predecessor. In many languages, the pred function is used to return the "previous" enum, also known as the predecessor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<False> is the predecessor to C<True>. And since C<False> is the "loweset" Bool enum, its own predecessor is also C<False>.
+C<pred> is short for predecessor. In many languages, the C<pred> function is used to return the "previous" enum, also known as the predecessor. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<False> is the predecessor to C<True>. And since C<False> is the "loweset" Bool enum, its own predecessor is also C<False>.
 
 =head2 routine enums
 


### PR DESCRIPTION
I first encountered the method "succ" today, and it was a method on Bool. At first I misunderstood it to mean "success", and wondered what type of failure or disaster "pred" stood for. Then I discovered that "succ" means "successor" and "pred" means "predecessor" and that they seem to totally make sense if we think of Bool in terms of it consisting of two possible enums.  So, that's what I tried to explain, but I would really like someone that feels more comfortable with this topic to please review my proposed changes (and please improve them if needed), before merging this pull request. (I could have committed directly, but I wanted someone to review this first.)