### PR TITLE
Almost all example outputs were changed to literal versions

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -410,7 +410,7 @@ not a Hash:
 
     my @names = map {
         my $query = { name => "$_<firstName> $_<lastName>" };
-        say $query.WHAT;       # Block
+        say $query.WHAT;       # (Block)
         say $query<name>;      # ERROR: Type Block does not support associative indexing
 
         lookup-user($query);   # Type check failed in binding $h; expected Hash but got Block

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -779,8 +779,8 @@ as the target type. So you can define coercions for your own types like so:
     }
 
     sub print-bar(MyModule::Bar() $bar) {
-       say $bar.WHAT; #MyModule::Bar
-       say $bar.msg;  #I'm a foo! But I am now Bar.
+       say $bar.WHAT; # (Bar)
+       say $bar.msg;  # I'm a foo! But I am now Bar.
     }
 
     print-bar MyModule::Foo.new;

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -95,8 +95,8 @@ To test for elements convert the C<List> or C<Array> to a L<C<Set>|/type/Set>
 or use a Set L<operator|/language/setbagmix>.
 
     my @a = <foo bar buzz>;
-    say @a.Set<bar buzz>; # OUTPUT«(True True)␤»
-    say so 'bar' ∈ @a;    # OUTPUT«True␤»
+    say @a.Set<bar buzz>; # (True True)
+    say so 'bar' ∈ @a;    # True
 
 =head2 Sequences
 
@@ -307,11 +307,11 @@ including the bounds. For infinite upper boundaries we agree with
 mathematicians that C<Inf> equals C<Inf-1>.
 
     my @a = 1..5;
-    say @a[0..2]; # OUTPUT«(1 2 3)␤»
-    say @a[0..^2]; # OUTPUT«(1 2)␤»
-    say @a[0..*];  # OUTPUT«(1 2 3 4 5)␤␤»
-    say @a[0..^*]; # OUTPUT«(1 2 3 4 5)␤»
-    say @a[0..Inf-1]; # OUTPUT«(1 2 3 4 5)␤»
+    say @a[0..2];     # (1 2 3)
+    say @a[0..^2];    # (1 2)
+    say @a[0..*];     # (1 2 3 4 5)
+    say @a[0..^*];    # (1 2 3 4 5)
+    say @a[0..Inf-1]; # (1 2 3 4 5)
 
 =head2 Array Constructor Context
 
@@ -479,7 +479,7 @@ This can irk users of data you provide if you have deeply nested Arrays
 where they want flat data.  Currently they have to deeply map the structure
 by hand to undo the nesting:
 
-    say gather [0, [(1, 2), [3, 4]], $(5, 6)].deepmap: *.take; # 1 2 3 4 5 6
+    say gather [0, [(1, 2), [3, 4]], $(5, 6)].deepmap: *.take; # (1 2 3 4 5 6)
 
 ...future versions of Perl 6 might find a way to make this easier.  However,
 not returning Arrays or itemized lists from functions, when non-itemized lists

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -133,10 +133,10 @@ values are as follows:
 Thus constructs such as these are now possible:
 
     C« fixed-width POD text »
-    say (1, 2) »+« (3, 4);     # 4 6 ; element-wise add
+    say (1, 2) »+« (3, 4);     # (4 6) - element-wise add
     @array »+=» 42;            # add 42 to each element of @array
     say «moo»;                 # moo
-    my $baa = 123; say «$baa»; # 123
+    my $baa = 123; say «$baa»; # (123)
 
 =head2 Set/bag operators
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -78,8 +78,8 @@ seen in the current expression or declarator:
     say $foo.perl;          # 5
 
     my @bar = 7, 9;         # list assignment
-    say @bar.WHAT;          # Array
-    say @bar.perl;          # [7, 9]<>
+    say @bar.WHAT;          # (Array)
+    say @bar.perl;          # [7, 9]
 
     (my $baz) = 11, 13;     # list assignment
     say $baz.WHAT;          # (List)
@@ -94,7 +94,7 @@ assignment:
 
     my @array;
     @array = my $num = 42, "str";   # item assignment: uses declarator
-    say @array.perl;                # [42, "str"]<> (an Array)
+    say @array.perl;                # [42, "str"] (an Array)
     say $num.perl;                  # 42 (a Num)
 
 Similarly, if the internal assignment is an expression that is being
@@ -103,12 +103,12 @@ expression determines the type of assignment:
 
     my $num;
     my @array = $num = 42, "str";    # item assignment: uses expression
-    say @array.perl;                 # [42, "str"]<> (an Array)
+    say @array.perl;                 # [42, "str"] (an Array)
     say $num.perl;                   # 42 (a Num)
 
     my ( @foo, $bar );
     @foo = ($bar) = 42, "str";       # list assignment: uses parens
-    say @foo.perl;                   # [42, "str"]<> (an Array)
+    say @foo.perl;                   # [42, "str"] (an Array)
     say $bar.perl;                   # $(42, "str")  (a List)
 
 However, if the internal assignment is neither a declarator nor an
@@ -117,8 +117,8 @@ larger expression determines the type of assignment:
 
     my ( @array, $num );
     @array = $num = 42, "str";    # list assignment
-    say @array.perl;              # [42, "str"]<> (an Array)
-    say $num.perl;                # [42, "str"]<> (an Array)
+    say @array.perl;              # [42, "str"] (an Array)
+    say $num.perl;                # [42, "str"] (an Array)
 
 This is because the whole expression is C<@array = $num = 42, "str">, while
 C<$num = 42> is not is own separate expression.

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -132,8 +132,8 @@ to reverse the characters in a string, use L<flip>.
 
 Examples:
 
-    say <hello world!>.reverse      #  world! hello
-    say reverse ^10                 # 9 8 7 6 5 4 3 2 1 0
+    say <hello world!>.reverse      # (world! hello)
+    say reverse ^10                 # (9 8 7 6 5 4 3 2 1 0)
 
 =head2 method sort
 
@@ -141,7 +141,7 @@ Sorts iterables with C<infix:<cmp>> or given code object and returns a new C<Lis
 
 Examples:
 
-    say <b c a>.sort;                           # a b c
+    say <b c a>.sort;                           # (a b c)
     say 'bca'.comb.sort.join;                   # abc
     say 'bca'.comb.sort({$^b cmp $^a}).join;    # cba
     say '231'.comb.sort(&infix:«<=>»).join;     # 123
@@ -215,7 +215,7 @@ take> to create a lazy list.
 Interprets the invocant as a list, evaluates it eagerly, and returns that
 list.
 
-    say (1..10).eager;              # 1 2 3 4 5 6 7 8 9 10
+    say (1..10).eager;              # (1 2 3 4 5 6 7 8 9 10)
 
 =head2 method elems
 
@@ -243,7 +243,7 @@ constructs a pair from them, unless the item in the key position already is a
 pair (in which case the pair is passed is passed through, and the next
 list item, if any, is considered to be a key again).
 
-    say (a => 1, 'b', 'c').pairup.perl;     # ("a" => 1, "b" => "c").list
+    say (a => 1, 'b', 'c').pairup.perl;     # (:a(1), :b("c")).Seq
 
 =head2 sub exit
 

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -56,7 +56,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.push: 'd';
-    say @foo;                   # a b c d
+    say @foo;                   # [a b c d]
 
 Note that C<push> does not attempt to flatten its argument list.  If you pass
 an array or list as the thing to push, it becomes one additional element:
@@ -105,7 +105,7 @@ Example:
     my @b = <d e f>;
     @a.append: @b;
     say @a.elems;               # 6
-    say @a;                     # a b c d e f
+    say @a;                     # [a b c d e f]
 
 =head2 routine shift
 
@@ -148,7 +148,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.unshift: 1, 3 ... 11;
-    say @foo;                   # (1 3 5 7 9 11) a b c
+    say @foo;                   # [(1 3 5 7 9 11) a b c]
 
 The notes in L<the documentation for method push|#method push> apply,
 regarding how many elements are added to the array.
@@ -176,7 +176,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.prepend: 1, 3 ... 11;
-    say @foo;                   # 1 3 5 7 9 11 a b c
+    say @foo;                   # [1 3 5 7 9 11 a b c]
 
 =head2 routine splice
 
@@ -197,8 +197,8 @@ all the elements starting from index C<$start> are deleted.
 Example:
 
     my @foo = <a b c d e f g>;
-    say @foo.splice(2, 3, <M N O P>);        # c d e
-    say @foo;                                # a b M N O P f g
+    say @foo.splice(2, 3, <M N O P>);        # [c d e]
+    say @foo;                                # [a b M N O P f g]
 
 =head2 method shape
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -20,7 +20,7 @@ The usual way to obtain an object of type C<Attribute> is by introspection:
     }
     my $a = Useless.^attributes(:local)[0];
     say $a.name;            # @!things
-    say $a.package;         # Useless()
+    say $a.package;         # (Useless)
     say $a.has_accessor;    # False
 
     # modifying an attribute from the outside
@@ -28,7 +28,7 @@ The usual way to obtain an object of type C<Attribute> is by introspection:
     # is at the level of the meta class, all is fair game
     my $instance = Useless.new;
     $a.set_value($instance, [1, 2, 3]);
-    say $a.get_value($instance);        # 1 2 3
+    say $a.get_value($instance);        # [1 2 3]
 
 =head1 Methods
 

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -45,9 +45,9 @@ which it is a shorthand).  Any positional parameters, regardless of their type,
 become elements of the bag:
 
     my $n = bag "a" => 0, "b" => 1, "c" => 2, "c" => 2;
-    say $n.keys.perl;        # ("a" => 0, "b" => 1, "c" => 2, "c" => 2).list
-    say $n.keys.map(&WHAT);  # (Pair) (Pair) (Pair) (Pair)
-    say $n.values.perl;      # (1, 1, 1, 1).list
+    say $n.keys.perl;        # (:c(2), :b(1), :a(0)).Seq
+    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
+    say $n.values.perl;      # (2, 1, 1).Seq
 
 Alternatively, the C<.Bag> coercer (or its functional form, C<Bag()>) can be
 called on an existing object to coerce it to a C<Bag>.  Its semantics depend on
@@ -57,9 +57,9 @@ Hash-like objects or Pair items, only the keys become elements of the bag, and
 the (cumulative) values become the associated integer weights:
 
     my $n = ("a" => 0, "b" => 1, "c" => 2, "c" => 2).Bag;
-    say $n.keys.perl;        # ("b", "c").list
-    say $n.keys.map(&WHAT);  # (Str) (Str)
-    say $n.values.perl;      # (1, 4).list
+    say $n.keys.perl;        # ("b", "c").Seq
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.values.perl;      # (1, 4).Seq
 
 Furthermore, you can get a C<Bag> by using bag operators (see next section) on
 objects of other types such as L<List>, which will internally call C<.Bag>

--- a/doc/Type/BagHash.pod6
+++ b/doc/Type/BagHash.pod6
@@ -50,9 +50,9 @@ C<BagHash>es can be composed using C<BagHash.new>.  Any positional parameters,
 regardless of their type, become elements of the bag:
 
     my $n = BagHash.new: "a" => 0, "b" => 1, "c" => 2, "c" => 2;
-    say $n.keys.perl;        # ("a" => 0, "b" => 1, "c" => 2, "c" => 2).list
-    say $n.keys.map(&WHAT);  # (Pair) (Pair) (Pair) (Pair)
-    say $n.values.perl;      # (1, 1, 1, 1).list
+    say $n.keys.perl;        # (:c(2), :b(1), :a(0)).Seq
+    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
+    say $n.values.perl;      # (2, 1, 1).Seq
 
 Alternatively, the C<.BagHash> coercer (or its functional form, C<BagHash()>)
 can be called on an existing object to coerce it to a C<BagHash>.  Its semantics
@@ -62,9 +62,9 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the bag, and the (cumulative) values become the associated integer weights:
 
     my $n = ("a" => 0, "b" => 1, "c" => 2, "c" => 2).BagHash;
-    say $n.keys.perl;        # ("b", "c").list
-    say $n.keys.map(&WHAT);  # (Str) (Str)
-    say $n.values.perl;      # (1, 4).list
+    say $n.keys.perl;        # ("b", "c").Seq
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.values.perl;      # (1, 4).Seq
 
 =head1 Operators
 

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -58,7 +58,7 @@ What makes C<grabpairs> different from L<pickpairs|#method pickpairs> is that th
     my $breakfast = (eggs => 2, bacon => 3).BagHash;
     say $breakfast.grabpairs;                         # bacon => 3
     say $breakfast;                                   # BagHash.new(eggs(2))
-    say $breakfast.grabpairs(1);                      # (eggs => 2)
+    say $breakfast.grabpairs(1);                      # [eggs => 2]
     say $breakfast.grabpairs(*);                      # []
 
     my $diet = ('eggs' => 2, 'bacon' => 3).Bag;

--- a/doc/Type/Block.pod6
+++ b/doc/Type/Block.pod6
@@ -13,7 +13,7 @@ Without an explicit signature or placeholder arguments, a block has C<$_>
 as a positional argument
 
     my $block = { uc $_; };
-    say $block.WHAT;            # Block
+    say $block.WHAT;            # (Block)
     say $block('hello');        # HELLO
 
 A block can have a signature between C<< -> >> or C<< <-> >> and the block:
@@ -40,7 +40,7 @@ transparent to L<return|/syntax/return>.
 
 The last statement is the implicit return value of the block.
 
-    say {1}.(); # OUTPUT«1␤»
+    say {1}.(); # 1
 
 Bare blocks in sink context are automatically executed:
 

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -19,11 +19,11 @@ named argument: 1) use an unquoted key naming a parameter, followed by
 C«=>», followed by the argument and 2) use a colon-pair literal named
 after the parameter:
 
-    say unique 1, -2, 2, 3, as => { abs $_ }; # 1, -2, 3
+    say unique 1, -2, 2, 3, as => { abs $_ }; # (1 -2 3)
     # ... is the same thing as:
-    say unique 1, -2, 2, 3, :as({ abs $_ });  # 1, -2, 3
+    say unique 1, -2, 2, 3, :as({ abs $_ });  # (1 -2 3)
     # Be careful not to quote the name of a named parameter:
-    say unique 1, -2, 2, 3, 'as' => { abs $_ }; # 1, -2, 2, 3, "as" => { ... }
+    say unique 1, -2, 2, 3, 'as' => { abs $_ }; # (1 -2 2 3 as => -> ;; $_? is raw { #`(Block|78857320) ... })
 
 A stand-alone Capture can also be made, stored, and used later.  A literal
 Capture can be created by prefixing a term with a backslash C<\>.

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1215,12 +1215,12 @@ string.
 If C<$delimiter> is a string, it is searched for literally and not treated
 as a regex.
 
-    say split(';', "a;b;c").perl;          # ("a", "b", "c").list
-    say split(';', "a;b;c", 2).perl;       # ("a", "b;c").list
+    say split(';', "a;b;c").perl;          # ("a", "b", "c")
+    say split(';', "a;b;c", 2).perl;       # ("a", "b;c").Seq
 
-    say split(';', "a;b;c,d").perl;        # ("a", "b", "c,d").list
-    say split(/\;/, "a;b;c,d").perl;       # ("a", "b", "c,d").list
-    say split(/<[;,]>/, "a;b;c,d").perl;   # ("a", "b", "c", "d").list
+    say split(';', "a;b;c,d").perl;        # ("a", "b", "c,d")
+    say split(/\;/, "a;b;c,d").perl;       # ("a", "b", "c,d")
+    say split(/<[;,]>/, "a;b;c,d").perl;   # ("a", "b", "c", "d")
 
 By default, split omits the matches, and returns a list of only those parts of
 the string that did not match. Specifying one of the C<:k, :v, :kv, :p> adverbs

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -51,7 +51,7 @@ If a L<Pair> is encountered where a value is expected, it is used as a
 hash value:
 
     my %h = 'a', 'b' => 'c';
-    say %h<a>.WHAT;             # Pair();
+    say %h<a>.WHAT;             # (Pair)
     say %h<a>.key;              # b
 
 If the same key appears more than once, the value associated with its last
@@ -320,7 +320,7 @@ index:
 
     my %wc = 'hash' => 323, 'pair' => 322, 'pipe' => 323;
     (my %inv).push: %wc.invert.unique;
-    say %inv;                           # 322 => 'pair', 323 => ['hash','pipe']
+    say %inv;                           # {322 => pair, 323 => [pipe hash]}
 
 Note that such a initialization could also be written as
 

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -65,12 +65,12 @@ printing.  Hence the following C<say> statements for the respective
 containers are equivalent:
 
     my @array = qw{1 2 3 4};
-    say @array;       # 1 2 3 4␤
-    say @array.gist;  # 1 2 3 4␤
+    say @array;       # [1 2 3 4]
+    say @array.gist;  # [1 2 3 4]
 
     my %hash = "a" => 1, "b" => 2, "c" => 3;
-    say %hash;        # a => 1, b => 2, c => 3␤
-    say %hash.gist;   # a => 1, b => 2, c => 3␤
+    say %hash;        # {a => 1, b => 2, c => 3}
+    say %hash.gist;   # {a => 1, b => 2, c => 3}
 
 =head2 sub note
 

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -59,7 +59,7 @@ C<< (<a b>, 'c').flat >> returns C<('a', 'b', 'c')>, which has three elems.
 Note that the flattening is recursive, so C<((("a", "b"), "c"), "d").flat>
 returns C<("a", "b", "c", "d")>, but it does not flatten itemized sublists:
 
-    say ($('a', 'b'), 'c').perl;    # ($("a", "b"), "c").Seq
+    say ($('a', 'b'), 'c').perl;    # ($("a", "b"), "c")
 
 =head2 method lazy
 

--- a/doc/Type/Junction.pod6
+++ b/doc/Type/Junction.pod6
@@ -59,7 +59,7 @@ Usage examples:
         so $x %% none(2..$x.sqrt);
     }
     my @primes_ending_in_1 = grep &is_prime & / 1$ /, 2..100;
-    say @primes_ending_in_1;        # 11 31 41 61 71
+    say @primes_ending_in_1;        # [11 31 41 61 71]
 
     my @exclude = <~ .git>;
     for dir(".") { say .Str if .Str.ends-with(none @exclude) }

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -245,7 +245,7 @@ these invocations in a result list.
 
 Unlike C<map> it flattens non-itemized lists and arrays, so
 
-    say ((1, 2), <a b>).flatmap(&uc).join('|');     # 1|2|A|B
+    say ((1, 2), <a b>).flatmap(&uc).join('|');     # 1 2|A B
 
 invokes L<uc|/type/Str#routine_uc> four times.
 
@@ -347,7 +347,7 @@ Examples:
 
     say (1, 22/7, 42, 300).first: * > 5, :k;        # 2
     say (1, 22/7, 42, 300).first: * > 5, :p;        # 2 => 42
-    say (1, 22/7, 42, 300).first: * > 5, :kv, :end; # 3 300
+    say (1, 22/7, 42, 300).first: * > 5, :kv, :end; # (3 300)
 
 =head2 method head
 
@@ -365,10 +365,10 @@ NUMBER <= 0.  Defaults to the first element seen if no NUMBER specified.
 
 Examples:
 
-    say ^10 .head(5)       # 0 1 2 3 4
-    say ^Inf .head(5)      # 0 1 2 3 4
-    say ^10 .head          # 0
-    say ^Inf .head         # 0
+    say ^10 .head(5)       # (0 1 2 3 4)
+    say ^Inf .head(5)      # (0 1 2 3 4)
+    say ^10 .head          # (0)
+    say ^Inf .head         # (0)
 
 =head2 method tail
 
@@ -387,9 +387,9 @@ Throws an exception if the list is lazy.
 
 Examples:
 
-    say ^10 .tail(5)      # 5 6 7 8 9
+    say ^10 .tail(5)      # (5 6 7 8 9)
     say ^Inf .tail(5)     # Cannot tail a lazy list
-    say ^10 .tail         # 9
+    say ^10 .tail         # (9)
     say ^Inf .tail        # Cannot tail a lazy list
 
 =head2 routine categorize
@@ -446,9 +446,9 @@ of the associated key.
 Example:
 
     say classify { $_ %% 2 ?? 'even' !! 'odd' }, (1, 7, 6, 3, 2);
-        #-> even => 6 2, odd => 1 7 3
+        # {even => [6 2], odd => [1 7 3]}
     say ('hello', 1, 22/7, 42, 'world').classify: { .Str.chars };
-        #-> 1 => 1, 2 => 42, 5 => hello world, 8 => 3.142857
+        # {1 => [1], 2 => [42], 5 => [hello world], 8 => [3.142857]}
 
 =head2 method Bool
 
@@ -619,8 +619,8 @@ to reverse the characters in a string, use L<flip>.
 
 Examples:
 
-    say <hello world!>.reverse      #  world! hello
-    say reverse ^10                 # 9 8 7 6 5 4 3 2 1 0
+    say <hello world!>.reverse      # (world! hello)
+    say reverse ^10                 # (9 8 7 6 5 4 3 2 1 0)
 
 =head2 routine rotate
 
@@ -670,9 +670,9 @@ cached, so that C<&by> is only called once per list element.
 
 Examples:
 
-    say (3, -4, 7, -1, 2, 0).sort;                  # -4 -1 0 2 3 7
-    say (3, -4, 7, -1, 2, 0).sort: *.abs;           # 0 -1 2 3 -4 7
-    say (3, -4, 7, -1, 2, 0).sort: { $^b leg $^a }; # 7 3 2 0 -4 -1
+    say (3, -4, 7, -1, 2, 0).sort;                  # (-4 -1 0 2 3 7)
+    say (3, -4, 7, -1, 2, 0).sort: *.abs;           # (0 -1 2 3 -4 7)
+    say (3, -4, 7, -1, 2, 0).sort: { $^b leg $^a }; # (7 3 2 0 -4 -1)
 
 =head2 routine unique
 
@@ -695,8 +695,8 @@ even as duplicates are removed.
 
 Examples:
 
-    say <a a b b b c c>.unique    # a b c
-    say <a b b c c b a>.unique    # a b c
+    say <a a b b b c c>.unique    # (a b c)
+    say <a b b c c b a>.unique    # (a b c)
 
 (Use L<C<squish>> instead if you know the input is sorted such that identical
 objects are adjacent.)
@@ -707,7 +707,7 @@ but it's still the original values that make it to the result list:
 
 Example:
 
-    say <a A B b c b C>.unique(:as(&lc))          # a B c
+    say <a A B b c b C>.unique(:as(&lc))          # (a B c)
 
 One can also specify the comparator with the optional C<:with> parameter.  For
 instance if one wants a list of unique hashes, one could use the C<eqv>
@@ -716,7 +716,7 @@ comparator.
 Example:
 
     my @list = {a => 42}, {b => 13}, {a => 42};
-    say @list.unique(:with(&[eqv]))               # {a=>42} {b=>13}
+    say @list.unique(:with(&[eqv]))               # ({a => 42} {b => 13})
 
 =head2 routine repeated
 
@@ -737,12 +737,12 @@ as they're seen for the second time (or more).
 
 Examples:
 
-    say <a a b b b c c>.repeated                    # a b b c
-    say <a b b c c b a>.repeated                    # b c b a
-    say <a A B b c b C>.repeated(:as(&lc))          # A b b C
+    say <a a b b b c c>.repeated                    # (a b b c)
+    say <a b b c c b a>.repeated                    # (b c b a)
+    say <a A B b c b C>.repeated(:as(&lc))          # (A b b C)
 
     my @list = {a => 42}, {b => 13}, {a => 42};
-    say @list.repeated(:with(&[eqv]))               # {a=>42}
+    say @list.repeated(:with(&[eqv]))               # ({a => 42})
 
 =head2 routine squish
 
@@ -766,8 +766,8 @@ are removed.
 
 Examples:
 
-    say <a a b b b c c>.squish  # a b c
-    say <a b b c c b a>.squish  # a b c b a
+    say <a a b b b c c>.squish  # (a b c)
+    say <a b b c c b a>.squish  # (a b c b a)
 
 The optional C<:as> parameter, just like with L<C<unique>>, allows values to be
 temporarily transformed before comparison.

--- a/doc/Type/Metamodel/C3MRO.pod6
+++ b/doc/Type/Metamodel/C3MRO.pod6
@@ -48,7 +48,7 @@ Computes the method resolution order.
 
 Returns a list of types in the method resolution order.
 
-    say Int.^mro    # (Int) (Cool) (Any) (Mu)
+    say Int.^mro    # ((Int) (Cool) (Any) (Mu))
 
 Returns a list of types in the method resolution order, even those that are
 marked C<is hidden>.

--- a/doc/Type/Metamodel/ClassHOW.pod6
+++ b/doc/Type/Metamodel/ClassHOW.pod6
@@ -32,7 +32,7 @@
 C<Metamodel::ClassHOW> is the meta class behind the C<class> keyword.
 
     say so Int.HOW ~~ Metamodel::ClassHOW;      # True
-    say say Int.^methods(:all).pick.name;       # sin
+    say Int.^methods(:all).pick.name;       # random Int method name
 
 =head1 Methods
 

--- a/doc/Type/Metamodel/MultipleInheritance.pod6
+++ b/doc/Type/Metamodel/MultipleInheritance.pod6
@@ -50,7 +50,7 @@ a nested list is returned.
 
     say A.^parents(:all).perl;          # (B, C1, C2, D, Any, Mu)
     say A.^parents(:all, :tree).perl;
-        # ([B, [C1, [D, [Any, [Mu]]]], [C2, [D, [Any, [Mu]]]]],)
+        # [B, ([C1, [D, [Any, [Mu]]]], [C2, [D, [Any, [Mu]]]])]
 
 =head2 method hides
 

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -43,8 +43,8 @@ type, become elements of the mix - with a weight of C<1> for each time the
 parameter occurred:
 
     my $n = mix "a", "a", "b" => 0, "c" => 3.14;
-    say $n.keys.map(&WHAT);  # (Str) (Pair) (Pair)
-    say $n.pairs;            # "a" => 2 ("b" => 0) => 1 ("c" => 3.14) => 1
+    say $n.keys.map(&WHAT);  # ((Str) (Pair) (Pair))
+    say $n.pairs;            # (a => 2 (c => 3.14) => 1 (b => 0) => 1)
 
 Alternatively, the C<.Mix> coercer (or its functional form, C<Mix()>) can be
 called on an existing object to coerce it to a C<Mix>. Its semantics depend on
@@ -54,8 +54,8 @@ Hash-like objects or Pair items, only the keys become elements of the mix, and
 the (cumulative) values become the associated numeric weights:
 
     my $n = ("a", "a", "b" => 0, "c" => 3.14).Mix;
-    say $n.keys.map(&WHAT);  # (Str) (Str)
-    say $n.pairs;            # "a" => 2 "c" => 3.14
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.pairs;            # (a => 2 c => 3.14)
 
 =head1 Operators
 

--- a/doc/Type/MixHash.pod6
+++ b/doc/Type/MixHash.pod6
@@ -49,8 +49,8 @@ regardless of their type, become elements of the mix - with a weight of C<1> for
 each time the parameter occurred:
 
     my $n = MixHash.new: "a", "a", "b" => 0, "c" => 3.14;
-    say $n.keys.map(&WHAT);  # (Str) (Pair) (Pair)
-    say $n.pairs;            # "a" => 2 ("b" => 0) => 1 ("c" => 3.14) => 1
+    say $n.keys.map(&WHAT);  # ((Str) (Pair) (Pair))
+    say $n.pairs;            # (a => 2 (c => 3.14) => 1 (b => 0) => 1)
 
 Alternatively, the C<.MixHash> coercer (or its functional form, C<MixHash()>)
 can be called on an existing object to coerce it to a C<MixHash>. Its semantics
@@ -60,8 +60,8 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the mix, and the (cumulative) values become the associated numeric weights:
 
     my $n = ("a", "a", "b" => 0, "c" => 3.14).MixHash;
-    say $n.keys.map(&WHAT);  # (Str) (Str)
-    say $n.pairs;            # "a" => 2 "c" => 3.14
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.pairs;            # (a => 2 c => 3.14)
 
 =head1 Operators
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -138,7 +138,7 @@ L<excludes-max> are C<True> in which case a L<Failure|/type/Failure> is returned
     say $r3.is-int, ', ', $r4.is-int;                 # False, False
     say $r3.excludes-max, ', ', $r4.excludes-max;     # False, True
     say $r3.minmax;                                   # (1.1 5.2)
-    say $r4.minmax;                                   # Failure
+    say $r4.minmax;                                   # Cannot return minmax on Range with excluded ends
 
 =head2 method elems
 

--- a/doc/Type/Rat.pod6
+++ b/doc/Type/Rat.pod6
@@ -27,8 +27,8 @@ the denominator quickly:
         $x = ($x + $n / $x) / 2 for ^$iterations;
         return $x;
     }
-    say approx-sqrt(2, 5).WHAT;     # Rat()
-    say approx-sqrt(2, 10).WHAT;    # Num()
+    say approx-sqrt(2, 5).WHAT;     # (Rat)
+    say approx-sqrt(2, 10).WHAT;    # (Num)
 
 If you want arbitrary precision arithmetic with rational numbers, use the
 C<FatRat> type instead.

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -34,8 +34,8 @@ which it is a shorthand). Any positional parameters, regardless of their type,
 become elements of the set:
 
     my $n = set "zero" => 0, "one" => 1, "two" => 2;
-    say $n.keys.perl;        # ("zero" => 0, "one" => 1, "two" => 2).list
-    say $n.keys.map(&WHAT);  # (Pair) (Pair) (Pair)
+    say $n.keys.perl;        # (:two(2), :zero(0), :one(1)).Seq
+    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
 
 Alternatively, the C<.Set> coercer (or its functional form, C<Set()>) can be
 called on an existing object to coerce it to a C<Set>. Its semantics depend on
@@ -45,8 +45,8 @@ Hash-like objects or Pair items, only the keys become elements of the set - and
 keys mapped to values which boolify to C<False> are skipped:
 
     my $n = ("zero" => 0, "one" => 1, "two" => 2).Set;
-    say $n.keys.perl;        # ("one", "two").list
-    say $n.keys.map(&WHAT);  # (Str) (Str)
+    say $n.keys.perl;        # ("one", "two").Seq
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
 
 Furthermore, you can get a C<Set> by using set operators (see next section) on
 objects of other types such as L<List>, which will internally call C<.Set>

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -39,8 +39,8 @@ C<SetHash>es can be composed using C<SetHash.new>. Any positional parameters,
 regardless of their type, become elements of the set:
 
     my $n = SetHash.new: "zero" => 0, "one" => 1, "two" => 2;
-    say $n.keys.perl;        # ("zero" => 0, "one" => 1, "two" => 2).list
-    say $n.keys.map(&WHAT);  # (Pair) (Pair) (Pair)
+    say $n.keys.perl;        # (:two(2), :zero(0), :one(1)).Seq
+    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
 
 Alternatively, the C<.SetHash> coercer (or its functional form, C<SetHash()>)
 can be called on an existing object to coerce it to a C<SetHash>. Its semantics
@@ -50,8 +50,8 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the set - and keys mapped to values which boolify to C<False> are skipped:
 
     my $n = ("zero" => 0, "one" => 1, "two" => 2).SetHash;
-    say $n.keys.perl;        # ("one", "two").list
-    say $n.keys.map(&WHAT);  # (Str) (Str)
+    say $n.keys.perl;        # ("one", "two").Seq
+    say $n.keys.map(&WHAT);  # ((Str) (Str))
 
 =head1 Operators
 

--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -9,7 +9,7 @@
 A type for subroutines. Subs are created with the C<sub> keyword
 
     my $s = sub ($a, $b) { $a + $b };
-    say $s.WHAT;        # Sub()
+    say $s.WHAT;        # (Sub)
     say $s(2, 5);       # 7
 
 =end pod

--- a/doc/Type/Whatever.pod6
+++ b/doc/Type/Whatever.pod6
@@ -51,15 +51,15 @@ a C<Whatever> object.
 The range operators are handled specially. They do not curry with
 C<Whatever>-stars, but they do curry with C<WhateverCode>
 
-    say (1..*).WHAT;        # Range
-    say (1..*-1).WHAT;      # WhateverCode
+    say (1..*).WHAT;        # (Range)
+    say (1..*-1).WHAT;      # (WhateverCode)
 
 This allow all these constructs to work:
 
     .say for 1..*;          # infinite loop
     my @a = 1..4;
-    say @a[0..*];           # 1 2 3 4
-    say @a[0..*-2];         # 1 2 3
+    say @a[0..*];           # (1 2 3 4)
+    say @a[0..*-2];         # (1 2 3)
 
 Because I<Whatever-currying> is a purely syntactic compiler transform, you will get no
 runtime currying of stored C<Whatever>-stars into C<WhateverCode>s.


### PR DESCRIPTION
See https://github.com/perl6/doc/issues/761 for details.