### PR TITLE
Clarify description of lsb, msb

### DIFF
--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -155,8 +155,8 @@ Usage:
     INTEGER.lsb
 
 Returns L<Nil|/type/Nil> if the number is 0. Otherwise returns the zero-based
-index from the right of the first 1 in the binary representation of the
-number.
+index from the right of the least significant (rightmost) 1 in the binary
+representation of the number.
 
     say 0b01011.lsb;        # 0
     say 0b01010.lsb;        # 1
@@ -177,8 +177,8 @@ Usage:
     INTEGER.msb
 
 Returns L<Nil|/type/Nil> if the number is 0. Otherwise returns the zero-based
-index from the left of the first 1 in the binary representation of the
-number.
+index from the right of the most significant (leftmost) 1 in the binary
+representation of the number.
 
     say 0b00001.msb;        # 0
     say 0b00011.msb;        # 1


### PR DESCRIPTION
Description of msb was slightly misleading, as the indexing referred to is always from the right.
Clarified both lsb and msb.