### PR TITLE
Now all entries of `Perl 6|5` are written with non-breaking space

### DIFF
--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -1,6 +1,6 @@
 =begin Html
 <img style="float: right; margin: 0 0 1em 1em" src="/images/camelia.png" alt="" id="home_logo"/>
-Welcome to the official documentation of the <a href="https://perl6.org">Perl 6</a>
+Welcome to the official documentation of the <a href="https://perl6.org">Perl 6</a>
 programming language!
 Besides online browsing and searching, you can also
 Z<< <a>download</a> an offline HTML or PDF copy, and>>
@@ -14,7 +14,7 @@ by reporting mistakes or sending patches.
 <dt><a href="/language.html">Language Reference &amp; Tutorials</a></dt>
 <dd>
     A collection of documents describing, in detail, the various
-    conceptual parts of the language.Z<< If you're new to Perl 6,
+    conceptual parts of the language.Z<< If you're new to Perl 6,
     language>intro is a good place to start.>>
 </dd>
 
@@ -28,11 +28,11 @@ by reporting mistakes or sending patches.
     Index of built-in subroutines and methods.
 </dd>
 
-<dt><a href="/programs.html">Perl 6 Programs</a></dt>
+<dt><a href="/programs.html">Perl 6 Programs</a></dt>
 <dd>
     A collection of documents describing how to
-    run the Perl 6 executable program and other utilities,
-    how to debug Perl 6 programs, and how to hack on Perl 6
+    run the Perl 6 executable program and other utilities,
+    how to debug Perl 6 programs, and how to hack on Perl 6
     source code.
 </dd>
 
@@ -47,15 +47,15 @@ Z<<
 <hr/>
 
 
-<p>The Perl 6 homepage offers <a href="https://perl6.org/documentation/">a
-comprehensive list of Perl 6 documentation</a>, including tutorials, HowTos
+<p>The Perl 6 homepage offers <a href="https://perl6.org/documentation/">a
+comprehensive list of Perl 6 documentation</a>, including tutorials, HowTos
 and <a href="/language/faq">FAQs (Frequently Asked Questions)</a>.</p>
 
 <p>
-You may also be interested in the Perl 6 <a href="https://design.perl6.org">design documents</a>,
+You may also be interested in the Perl 6 <a href="https://design.perl6.org">design documents</a>,
 which are in some places more complete than this documentation, but targeted
 toward compiler writers rather than users of the language.
-Documentation for the different but related <a href="https://www.perl.org/">Perl 5</a> language
-can be found on the <a href="http://perldoc.perl.org/">Perl 5 documentation website</a>.
+Documentation for the different but related <a href="https://www.perl.org/">Perl 5</a> language
+can be found on the <a href="http://perldoc.perl.org/">Perl 5 documentation website</a>.
 </p>
 =end Html

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1523,9 +1523,9 @@ read and further processed into Perl 6 code by a MAD parser.
 Please consult #perl6 to find out the best release of Perl 5 to use for
 your MAD science experiments.
 
-=head2 Perl-ToPerl 6
+=head2 Perl-ToPerl6
 
-Jeff Goff's Perl::ToPerl 6 module for Perl 5 is designed around
+Jeff Goff's Perl::ToPerl6 module for Perl 5 is designed around
 Perl::Critic's framework. It aims to convert Perl5 to compilable (if not
 necessarily running) Perl 6 code with the bare minimum of changes. Code
 transformers are configurable and pluggable, so you can create and

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -2,28 +2,28 @@
 
 =TITLE 5to6-nutshell
 
-=SUBTITLE Perl 5 to Perl 6, in a nutshell: How do I do what I used to do?
+=SUBTITLE Perl 5 to Perl 6, in a nutshell: How do I do what I used to do?
 
 This page attempts to index the changes in syntax and semantics from
-Perl 5 to Perl 6. Whatever worked in Perl 5 and must be written differently
-in Perl 6, should be listed here (whereas many I<new> Perl 6 features and
+Perl 5 to Perl 6. Whatever worked in Perl 5 and must be written differently
+in Perl 6, should be listed here (whereas many I<new> Perl 6 features and
 idioms won't be).
 
 Hence this should not be mistaken for a beginner tutorial or a promotional
-overview of Perl 6; it is intended as a technical reference for Perl 6
-learners with a strong Perl 5 background and for anyone porting Perl 5 code
-to Perl 6 (though note that L<#Automated Translation> might be more
+overview of Perl 6; it is intended as a technical reference for Perl 6
+learners with a strong Perl 5 background and for anyone porting Perl 5 code
+to Perl 6 (though note that L<#Automated Translation> might be more
 convenient).
 
 A note on semantics; when we say "now" in this document, we mostly just
-mean "now that you are trying out Perl 6."  We don't mean to imply that
-Perl 5 is now suddenly obsolete.  Quite the contrary, most of us love
-Perl 5, and we expect Perl 5 to continue in use for a good many years.
+mean "now that you are trying out Perl 6."  We don't mean to imply that
+Perl 5 is now suddenly obsolete.  Quite the contrary, most of us love
+Perl 5, and we expect Perl 5 to continue in use for a good many years.
 Indeed, one of our more important goals has been to make interaction between
-Perl 5 and Perl 6 run smoothly.  However, we do also like the design
-decisions in Perl 6, which are certainly newer and arguably better
-integrated than many of the historical design decisions in Perl 5.
-So many of us do hope that over the next decade or two, Perl 6 will
+Perl 5 and Perl 6 run smoothly.  However, we do also like the design
+decisions in Perl 6, which are certainly newer and arguably better
+integrated than many of the historical design decisions in Perl 5.
+So many of us do hope that over the next decade or two, Perl 6 will
 become the more dominant language.  If you want to take "now" in that
 future sense, that's okay too.  But we're not at all interested in the
 either/or thinking that leads to fights.
@@ -33,20 +33,20 @@ either/or thinking that leads to fights.
 
 See L<https://modules.perl6.org/> .
 
-If the module that you were using has not been converted to Perl 6, and no
-alternative is listed in this document, then its use under Perl 6 may not
+If the module that you were using has not been converted to Perl 6, and no
+alternative is listed in this document, then its use under Perl 6 may not
 have been addressed yet.
 
-There are multiple projects aiming to make it possible to C<use> Perl 5
-modules directly from Perl 6 code:
+There are multiple projects aiming to make it possible to C<use> Perl 5
+modules directly from Perl 6 code:
 
 =defn  L<v5|https://github.com/rakudo-p5/v5/>
-A slang that lets Rakudo itself parse blocks of Perl 5 code, and compile
-them to the same bytecode that it compiles Perl 6 code to.
+A slang that lets Rakudo itself parse blocks of Perl 5 code, and compile
+them to the same bytecode that it compiles Perl 6 code to.
 
 =defn  L<Inline::Perl5|https://github.com/niner/Inline-Perl5/>
-Uses an embedded instance of the C<perl> interpreter to run Perl 5 code
-called from your Perl 6 script.
+Uses an embedded instance of the C<perl> interpreter to run Perl 5 code
+called from your Perl 6 script.
 
 Of these, Inline::Perl5 is currently the furthest along and the most
 promising.
@@ -58,11 +58,11 @@ promising.
 
 =head2 C«->» Method calls
 
-If you've read any Perl 6 code at all, it's immediately obvious that
+If you've read any Perl 6 code at all, it's immediately obvious that
 method call syntax now uses a dot instead of an arrow:
 
-    $person->name  # Perl 5
-    $person.name   # Perl 6
+    $person->name  # Perl 5
+    $person.name   # Perl 6
 
 The dot notation is both easier to type and more of an industry standard.
 But we also wanted to steal the arrow for something else.  (Concatenation
@@ -70,33 +70,33 @@ is now done with the C<~> operator, if you were wondering.)
 
 To call a method whose name is not known until runtime:
 
-    $object->$methodname(@args);  # Perl 5
-    $object."$methodname"(@args); # Perl 6
+    $object->$methodname(@args);  # Perl 5
+    $object."$methodname"(@args); # Perl 6
 
-If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
+If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
 a C<Method> object, rather than the simple string name of the method.
 
 =head2 Whitespace
 
-Perl 5 allows a surprising amount of flexibility in the use of whitespace,
+Perl 5 allows a surprising amount of flexibility in the use of whitespace,
 even with strict mode and warnings turned on:
 
-    # unidiomatic but valid Perl 5
+    # unidiomatic but valid Perl 5
     say"Hello ".ucfirst  ($people
         [$ i]
         ->
         name)."!"if$greeted[$i]<1;
 
-Perl 6 also endorses programmer freedom and creativity, but balanced
+Perl 6 also endorses programmer freedom and creativity, but balanced
 syntactic flexibility against its design goal of having a consistent,
 deterministic, extensible grammar that supports single-pass parsing and
 helpful error messages, integrates features like custom operators cleanly,
 and doesn't lead programmers to accidentally misstate their intent.
-Also, the practice of "code golf" is slightly de-emphasized; Perl 6 is
+Also, the practice of "code golf" is slightly de-emphasized; Perl 6 is
 designed to be more concise in concepts than in keystrokes.
 
 As a result, there are various places in the syntax where whitespace is
-optional in Perl 5, but is either mandatory or forbidden in Perl 6. Many of
+optional in Perl 5, but is either mandatory or forbidden in Perl 6. Many of
 those restrictions are unlikely to concern much real-life Perl code (e.g.,
 whitespace being disallowed between the sigil and name of a variable), but
 there are a few that will unfortunately conflict with some Perl hackers'
@@ -105,26 +105,26 @@ habitual coding styles:
 =begin item
 I<No space allowed before the opening parenthesis of an argument list.>
 
-    substr ($s, 4, 1); # Perl 5 (in Perl 6 this would try to pass a single
+    substr ($s, 4, 1); # Perl 5 (in Perl 6 this would try to pass a single
                        #         argument of type List to substr)
-    substr($s, 4, 1);  # Perl 6
-    substr $s, 4, 1;   # Perl 6 - alternative parentheses-less style
+    substr($s, 4, 1);  # Perl 6
+    substr $s, 4, 1;   # Perl 6 - alternative parentheses-less style
 
 =end item
 
 =begin item
 I<Space is B<required> immediately after keywords>
 
-    my($alpha, $beta);          # Perl 5, tries to call my() sub in Perl 6
-    my ($alpha, $beta);         # Perl 6
+    my($alpha, $beta);          # Perl 5, tries to call my() sub in Perl 6
+    my ($alpha, $beta);         # Perl 6
 
-    if($a < 0) { ... }          # Perl 5, dies in Perl 6
-    if ($a < 0) { ... }         # Perl 6
-    if $a < 0 { ... }           # Perl 6, more idiomatic
+    if($a < 0) { ... }          # Perl 5, dies in Perl 6
+    if ($a < 0) { ... }         # Perl 6
+    if $a < 0 { ... }           # Perl 6, more idiomatic
 
-    while($x-- > 5) { ... }     # Perl 5, dies in Perl 6
-    while ($x-- > 5) { ... }    # Perl 6
-    while $x-- > 5 { ... }      # Perl 6, more idiomatic
+    while($x-- > 5) { ... }     # Perl 5, dies in Perl 6
+    while ($x-- > 5) { ... }    # Perl 6
+    while $x-- > 5 { ... }      # Perl 6, more idiomatic
 
 =end item
 
@@ -132,48 +132,48 @@ I<Space is B<required> immediately after keywords>
 I<No space allowed after a prefix operator, or before a
 postfix/postcircumfix operator (including array/hash subscripts).>
 
-    $seen {$_} ++; # Perl 5
-    %seen{$_}++;   # Perl 6
+    $seen {$_} ++; # Perl 5
+    %seen{$_}++;   # Perl 6
 =end item
 
 =begin item
 I<No space allowed around the method call operator.>
 
-    $customer -> name; # Perl 5
-    $customer.name;    # Perl 6
+    $customer -> name; # Perl 5
+    $customer.name;    # Perl 6
 =end item
 
 =begin item
 I<Space required before an infix operator if it would
 conflict with an existing postfix/postcircumfix operator.>
 
-    $n<1;   # Perl 5 (in Perl 6 this would conflict with postcircumfix < >)
-    $n < 1; # Perl 6
+    $n<1;   # Perl 5 (in Perl 6 this would conflict with postcircumfix < >)
+    $n < 1; # Perl 6
 
 =end item
 
 However, note that you can use L<unspace|https://design.perl6.org/S02.html#Unspaces>
-to add whitespace in Perl 6 code in places where it is otherwise not
+to add whitespace in Perl 6 code in places where it is otherwise not
 allowed:
 
-    # Perl 5
+    # Perl 5
     my @books = $xml->parse_file($file)          # some comment
                     ->findnodes("/library/book");
 
-    # Perl 6
+    # Perl 6
     my @books = $xml.parse-file($file)\          # some comment
                     .findnodes("/library/book");
 
 See also L<S03#Minimal whitespace
 DWIMmery|https://design.perl6.org/S03.html#Minimal_whitespace_DWIMmery> and
 L<S04#Statement parsing|https://design.perl6.org/S04.html#Statement_parsing>
-in the Perl 6 design docs.
+in the Perl 6 design docs.
 
 
 =head2 Sigils
 
-In Perl 5, arrays and hashes use changing sigils depending on how they are
-being accessed. In Perl 6 the sigils are invariant, no matter how the
+In Perl 5, arrays and hashes use changing sigils depending on how they are
+being accessed. In Perl 6 the sigils are invariant, no matter how the
 variable is being used - you can think of them as part of the variable's
 name.
 
@@ -205,35 +205,35 @@ The C<&> sigil is now used consistently (and without the help of a
 backslash) to refer to the function object of a named subroutine/operator
 without invoking it, i.e. to use the name as a "noun" instead of a "verb":
 
-    my $sub = \&foo; # Perl 5
-    my $sub = &foo;  # Perl 6
+    my $sub = \&foo; # Perl 5
+    my $sub = &foo;  # Perl 6
 
-    callback => sub { say @_ }  # Perl 5 - can't pass built-in sub directly
-    callback => &say            # Perl 6 - & gives "noun" form of any sub
+    callback => sub { say @_ }  # Perl 5 - can't pass built-in sub directly
+    callback => &say            # Perl 6 - & gives "noun" form of any sub
 
-Since Perl 6 does not allow adding/removing symbols in a lexical scope once
-it has finished compiling, there is no equivalent to Perl 5's
-C<undef &foo;>, and the closest equivalent to Perl 5's C<defined &foo>
+Since Perl 6 does not allow adding/removing symbols in a lexical scope once
+it has finished compiling, there is no equivalent to Perl 5's
+C<undef &foo;>, and the closest equivalent to Perl 5's C<defined &foo>
 would be C<defined &::("foo")> (which uses the "dynamic symbol lookup"
 syntax). However, you can declare a mutable named subroutine with
 C<my &foo;> and then change its meaning at runtime by assigning to C<&foo>.
 
-In Perl 5, the ampersand sigil can additionally be used to call subroutines
+In Perl 5, the ampersand sigil can additionally be used to call subroutines
 in special ways with subtly different behavior compared to normal sub
-calls. In Perl 6 those special forms are no longer available:
+calls. In Perl 6 those special forms are no longer available:
 
 =begin item
 C<&foo(...)> I<for circumventing a function prototype>
 
-In Perl 6 there are no prototypes, and it no longer
+In Perl 6 there are no prototypes, and it no longer
 makes a difference whether you, say, pass a literal code block or a
 variable holding a code object as an argument:
 
-    # Perl 5:
+    # Perl 5:
     first_index { $_ > 5 } @values;
     &first_index($coderef, @values); # (disabling the prototype that parses a
                                      # literal block as the first argument)
-    # Perl 6:
+    # Perl 6:
     first { $_ > 5 }, @values, :k;   # the :k makes first return an index
     first $coderef, @values, :k;
 =end item
@@ -242,32 +242,32 @@ variable holding a code object as an argument:
 C<&foo;> I<and> C<goto &foo;> I<for re-using the caller's argument list /
 replacing the caller in the call stack>
 
-    sub foo { say "before"; &bar;     say "after" } # Perl 5
-    sub foo { say "before"; bar(|@_); say "after" } # Perl 6 - have to be explicit
+    sub foo { say "before"; &bar;     say "after" } # Perl 5
+    sub foo { say "before"; bar(|@_); say "after" } # Perl 6 - have to be explicit
 
     # TODO: Suggest .callsame once it has been implemented in Rakudo.
 
-    sub foo { say "before"; goto &bar } # Perl 5
+    sub foo { say "before"; goto &bar } # Perl 5
 
     # TODO: Suggest .nextsame and .nextwith once they've been implemented in Rakudo.
 =end item
 
 =head3 C<*> Glob
 
-=comment TODO: Research what exact use-cases still need typeglobs in Perl 5
+=comment TODO: Research what exact use-cases still need typeglobs in Perl 5
          today, and refactor this section to list them (with translations).
 
-In Perl 5, the C<*> sigil referred to the GLOB structure that Perl uses to
+In Perl 5, the C<*> sigil referred to the GLOB structure that Perl uses to
 store non-lexical variables, file handles, subs, and formats.
 
-(This should not be confused with the Perl 5 built-in C<glob()> function,
+(This should not be confused with the Perl 5 built-in C<glob()> function,
 which reads filenames from a directory).
 
 You are most likely to encounter a GLOB in code written on a early Perl
 version that does not support lexical filehandles, when a filehandle needed
 to be passed into a sub.
 
-    # Perl 5 - ancient method
+    # Perl 5 - ancient method
     sub read_2 {
         local (*H) = @_;
         return scalar(<H>), scalar(<H>);
@@ -275,10 +275,10 @@ to be passed into a sub.
     open FILE, '<', $path or die;
     my ($line1, $line2) = read_2(*FILE);
 
-You should refactor your Perl 5 code to remove the need for the GLOB,
-before translating into Perl 6.
+You should refactor your Perl 5 code to remove the need for the GLOB,
+before translating into Perl 6.
 
-    # Perl 5 - modern use of lexical filehandles
+    # Perl 5 - modern use of lexical filehandles
     sub read_2 {
         my ($fh) = @_;
         return scalar(<$fh>), scalar(<$fh>);
@@ -286,9 +286,9 @@ before translating into Perl 6.
     open my $in_file, '<', $path or die;
     my ($line1, $line2) = read_2($in_file);
 
-And here's just one possible Perl 6 translation:
+And here's just one possible Perl 6 translation:
 
-    # Perl 6
+    # Perl 6
     sub read-n($fh, $n) {
         return $fh.get xx $n;
     }
@@ -303,21 +303,21 @@ L<sigil|#@_Array>, and adverbs can be used to control the type of slice:
 =begin item
 I<Indexing>
 
-    say $months[2]; # Perl 5
-    say @months[2]; # Perl 6 - @ instead of $
+    say $months[2]; # Perl 5
+    say @months[2]; # Perl 6 - @ instead of $
 =end item
 
 =begin item
 I<Value-slicing>
 
-    say join ',', @months[6, 8..11]; # Perl 5 and Perl 6
+    say join ',', @months[6, 8..11]; # Perl 5 and Perl 6
 =end item
 
 =begin item
 I<Key/value-slicing>
 
-    say join ',', %months[6, 8..11];    # Perl 5
-    say join ',', @months[6, 8..11]:kv; # Perl 6 - @ instead of %; use :kv adverb
+    say join ',', %months[6, 8..11];    # Perl 5
+    say join ',', @months[6, 8..11]:kv; # Perl 6 - @ instead of %; use :kv adverb
 =end item
 
 Also note that the subscripting brackets are now a normal postcircumfix
@@ -337,30 +337,30 @@ construct):
 =begin item
 I<Indexing>
 
-    say $calories{"apple"}; # Perl 5
-    say %calories{"apple"}; # Perl 6 - % instead of $
+    say $calories{"apple"}; # Perl 5
+    say %calories{"apple"}; # Perl 6 - % instead of $
 
-    say $calories{apple}; # Perl 5
-    say %calories<apple>; # Perl 6 - angle brackets; % instead of $
-    say %calories«$key»;  # Perl 6 - double angles interpolate as a list of Str
+    say $calories{apple}; # Perl 5
+    say %calories<apple>; # Perl 6 - angle brackets; % instead of $
+    say %calories«$key»;  # Perl 6 - double angles interpolate as a list of Str
 =end item
 
 =begin item
 I<Value-slicing>
 
-    say join ',', @calories{'pear', 'plum'}; # Perl 5
-    say join ',', %calories{'pear', 'plum'}; # Perl 6 - % instead of @
-    say join ',', %calories<pear plum>;      # Perl 6 (prettier version)
+    say join ',', @calories{'pear', 'plum'}; # Perl 5
+    say join ',', %calories{'pear', 'plum'}; # Perl 6 - % instead of @
+    say join ',', %calories<pear plum>;      # Perl 6 (prettier version)
     my $keys = 'pear plum';
-    say join ',', %calories«$keys»;          # Perl 6 the split is done after interpolation
+    say join ',', %calories«$keys»;          # Perl 6 the split is done after interpolation
 =end item
 
 =begin item
 I<Key/value-slicing>
 
-    say join ',', %calories{'pear', 'plum'};    # Perl 5
-    say join ',', %calories{'pear', 'plum'}:kv; # Perl 6 - use :kv adverb
-    say join ',', %calories<pear plum>:kv;      # Perl 6 (prettier version)
+    say join ',', %calories{'pear', 'plum'};    # Perl 5
+    say join ',', %calories{'pear', 'plum'}:kv; # Perl 6 - use :kv adverb
+    say join ',', %calories<pear plum>:kv;      # Perl 6 (prettier version)
 =end item
 
 Also note that the subscripting curly braces are now a normal postcircumfix
@@ -371,30 +371,30 @@ adverbs.
 =head2 Reference creation
 
 =comment TODO: Rewrite this section to make it clear that the "referencing/
-         dereferencing" metaphor does not map cleanly to the actual Perl 6
+         dereferencing" metaphor does not map cleanly to the actual Perl 6
          container system, and focus more on how one would translate or
-         replace actual code that uses references in Perl 5.
+         replace actual code that uses references in Perl 5.
 
-In Perl 5, references to anonymous arrays and hashes and subs are returned
+In Perl 5, references to anonymous arrays and hashes and subs are returned
 during their creation. References to existing named variables and subs were
 generated with the C<\> operator.
 
-In Perl 6, anonymous arrays and hashes and subs still return their
+In Perl 6, anonymous arrays and hashes and subs still return their
 reference during creation. References to named subs are generated by
 preceding the sub name with a C<&> sigil. References to existing named
 variables are generated by C<item> context.
 
-    my $aref = [ 1, 2, 9 ];          # Both Perl 5&6
-    my $href = { A => 98, Q => 99 }; # Both Perl 5&6 [*See Note*]
+    my $aref = [ 1, 2, 9 ];          # Both Perl 5&6
+    my $href = { A => 98, Q => 99 }; # Both Perl 5&6 [*See Note*]
 
-    my $aref =     \@aaa  ; # Perl 5
-    my $aref = item(@aaa) ; # Perl 6
+    my $aref =     \@aaa  ; # Perl 5
+    my $aref = item(@aaa) ; # Perl 6
 
-    my $href =     \%hhh  ; # Perl 5
-    my $href = item(%hhh) ; # Perl 6
+    my $href =     \%hhh  ; # Perl 5
+    my $href = item(%hhh) ; # Perl 6
 
-    my $sref =     \&foo  ; # Perl 5
-    my $sref =      &foo  ; # Perl 6
+    my $sref =     \&foo  ; # Perl 5
+    my $sref =      &foo  ; # Perl 6
 
 B<NOTE:> If one or more values reference the topic variable, C<$_>, the
 right-hand side of the assignment will be interpreted as a L<Block|/type/Block>,
@@ -444,59 +444,59 @@ See L<Hash assignment|/type/Hash#Hash_assignment> for more details.
 
 =head2 Dereferencing
 
-In Perl 5, the syntax for dereferencing an entire reference is the
+In Perl 5, the syntax for dereferencing an entire reference is the
 type-sigil and curly braces, with the reference inside the curly braces.
 
-In Perl 6, the curly braces are changed to parentheses.
+In Perl 6, the curly braces are changed to parentheses.
 
-    # Perl 5
+    # Perl 5
         say      ${$scalar_ref};
         say      @{$arrayref  };
         say keys %{$hashref   };
         say      &{$subref    };
 
-    # Perl 6
+    # Perl 6
         say      $($scalar_ref);
         say      @($arrayref  );
         say keys %($hashref   );
         say      &($subref    );
 
-Note that in both Perl 5 and Perl 6, the surrounding curly braces or parens can
+Note that in both Perl 5 and Perl 6, the surrounding curly braces or parens can
 often be omitted, though the omission can reduce readability.
 
-In Perl 5, the arrow operator, C«->» , is used for single access to a
-composite's reference or to call a sub through its reference. In Perl 6,
+In Perl 5, the arrow operator, C«->» , is used for single access to a
+composite's reference or to call a sub through its reference. In Perl 6,
 we now use the dot operator C<.> for those tasks.
 
-    # Perl 5
+    # Perl 5
         say $arrayref->[7];
         say $hashref->{'fire bad'};
         say $subref->($foo, $bar);
 
-    # Perl 6
+    # Perl 6
         say $arrayref.[7];
         say $hashref.{'fire bad'};
         say $subref.($foo, $bar);
 
-In recent versions of Perl 5 (5.20 and later), a new feature allows the use of the arrow op
+In recent versions of Perl 5 (5.20 and later), a new feature allows the use of the arrow op
 for dereferencing. See
 L<http://search.cpan.org/~shay/perl-5.20.1/pod/perl5200delta.pod#Experimental_Postfix_Dereferencing>
-That new feature corresponds Perl 6 C<.list> and C<.hash> methods:
+That new feature corresponds Perl 6 C<.list> and C<.hash> methods:
 
-    # Perl 5.20
+    # Perl 5.20
         use experimental qw< postderef >;
         my @a = $arrayref->@*;
         my %h = $hashref->%*;
         my @slice = $arrayref->@[3..7];
 
-    # Perl 6
+    # Perl 6
         my @a = $arrayref.list;         # or @($arrayref)
         my %h = $hashref.hash;          # or %($hashref)
         my @slice = $arrayref[3..7];
 
 The "Zen" slice does the same thing:
 
-    # Perl 6
+    # Perl 6
         my @a = $arrayref[];
         my %h = $hashref{};
 
@@ -525,32 +525,32 @@ Unchanged:
 
 =head2 C«<=> cmp» Three-way comparisons
 
-In Perl 5, these operators returned -1, 0, or 1.
-In Perl 6, they return C<Order::Less>, C<Order::Same>, or C<Order::More>.
+In Perl 5, these operators returned -1, 0, or 1.
+In Perl 6, they return C<Order::Less>, C<Order::Same>, or C<Order::More>.
 
 C«cmp» is now named C«leg»; it forces string context for the comparison.
 
 C«<=>» still forces numeric context.
 
-C«cmp» in Perl 6 does either C«<=>» or C<leg>, depending on the existing
+C«cmp» in Perl 6 does either C«<=>» or C<leg>, depending on the existing
 type of its arguments.
 
 =head2 C<~~> Smart-match operator
 
 While the operator has not changed, the rules for what exactly is matched
 depends on the types of both arguments, and those rules are far from
-identical in Perl 5 and Perl 6. See
+identical in Perl 5 and Perl 6. See
 L<S03/Smart matching|https://design.perl6.org/S03.html#Smart_matching>
 
 =head2 C<& | ^> String Bitwise ops
 =head2 C<& | ^> Numeric Bitwise ops
 =head2 C<& | ^> Boolean ops
 
-In Perl 5, C<& | ^> were invoked according to the contents of their
+In Perl 5, C<& | ^> were invoked according to the contents of their
 arguments. For example, C<31 | 33> returns a different result than C<"31" |
 "33">.
 
-In Perl 6, those single-character ops have been removed, and replaced by
+In Perl 6, those single-character ops have been removed, and replaced by
 two-character ops which coerce their arguments to the needed context.
 
     # Infix ops (two arguments; one on each side of the op)
@@ -567,21 +567,21 @@ two-character ops which coerce their arguments to the needed context.
 
 Replaced by C«+<» and C«+>» .
 
-    say 42 << 3; # Perl 5
-    say 42 +< 3; # Perl 6
+    say 42 << 3; # Perl 5
+    say 42 +< 3; # Perl 6
 
 =head2 C«=>» Fat comma
 
-In Perl 5, C«=>» acted just like a comma, but also quoted its left-hand
+In Perl 5, C«=>» acted just like a comma, but also quoted its left-hand
 side.
 
-In Perl 6, C«=>» is the Pair operator, which is quite different in
+In Perl 6, C«=>» is the Pair operator, which is quite different in
 principle, but works the same in many situations.
 
 If you were using C«=>» in hash initialization, or in passing arguments to
 a sub that expects a hashref, then the usage is likely identical.
 
-    # Works in Perl 5 and Perl 6
+    # Works in Perl 5 and Perl 6
     my %hash = ( AAA => 1, BBB => 2 );
     get_the_loot( 'diamonds', { quiet_level => 'very', quantity => 9 }); # Note the curly braces
 
@@ -593,7 +593,7 @@ manually add quotes to its left-hand side. Or, you can change the sub's API
 to slurp a hash. A better long-term solution is to change the sub's API to
 expect Pairs. However, this requires you to change all sub calls at once.
 
-    # Perl 5
+    # Perl 5
     sub get_the_loot {
         my $loot = shift;
         my %options = @_;
@@ -601,13 +601,13 @@ expect Pairs. However, this requires you to change all sub calls at once.
     }
     # Note: no curly braces in this sub call
     get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 );
-    # Perl 6, original API
+    # Perl 6, original API
     sub get_the_loot( $loot, *%options ) { # The * means to slurp everything
         ...
     }
     get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 ); # Note: no curly braces in this API
 
-    # Perl 6, API changed to specify valid options
+    # Perl 6, API changed to specify valid options
     # The colon before the sigils means to expect a Pair,
     # with the key having the same name as the variable.
     sub get_the_loot( $loot, :$quiet_level?, :$quantity = 1 ) {
@@ -622,8 +622,8 @@ expect Pairs. However, this requires you to change all sub calls at once.
 Now spelled with two question marks instead of one question mark, and two
 exclamation points instead of one colon.
 
-    my $result = ( $score > 60 )  ? 'Pass'  : 'Fail'; # Perl 5
-    my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
+    my $result = ( $score > 60 )  ? 'Pass'  : 'Fail'; # Perl 5
+    my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
 
 =head2 C<.> (Dot op) Concatenation
 
@@ -631,26 +631,26 @@ Replaced by the tilde.
 
 Mnemonic: think of "stitching" together the two strings with needle and thread.
 
-    $food = 'grape' . 'fruit'; # Perl 5
-    $food = 'grape' ~ 'fruit'; # Perl 6
+    $food = 'grape' . 'fruit'; # Perl 5
+    $food = 'grape' ~ 'fruit'; # Perl 6
 
 =head2 C<x> List Repeat op or String Repeat op
 
-In Perl 5, C<x> was the Repetition operator.
+In Perl 5, C<x> was the Repetition operator.
 
-In scalar context, C<x> would repeat a string. In Perl 6, C<x> repeats
+In scalar context, C<x> would repeat a string. In Perl 6, C<x> repeats
 strings in any context.
 
 In list context, C<x> would repeat a list—but only if the left argument
-is parenthesized! In Perl 6, the new C<xx> op repeats lists in any context.
+is parenthesized! In Perl 6, the new C<xx> op repeats lists in any context.
 
 Mnemonic: x is short and xx is long, so xx is the one used for lists.
 
-    # Perl 5
+    # Perl 5
         print '-' x 80;             # Print row of dashes
         @ones = (1) x 80;           # A list of 80 1's
         @ones = (5) x @ones;        # Set all elements to 5
-    # Perl 6
+    # Perl 6
         print '-' x 80;             # Unchanged
         @ones = 1 xx 80;            # Parens no longer needed
         @ones = 5 xx @ones;         # Parens no longer needed
@@ -658,11 +658,11 @@ Mnemonic: x is short and xx is long, so xx is the one used for lists.
 
 =head2 C<..> C<...> Two Dots or Three Dots, Range op or Flipflop op
 
-In Perl 5, C<..> was one of two completely different operators, depending
+In Perl 5, C<..> was one of two completely different operators, depending
 on context.
 
 In list context, C<..> is the familiar range operator. Range has many new
-wrinkles in Perl 6, but ranges from Perl 5 code should not B<require>
+wrinkles in Perl 6, but ranges from Perl 5 code should not B<require>
 translation.
 
 In scalar context, C<..> and C<...> were the little-known Flipflop
@@ -670,8 +670,8 @@ operators. They have been replaced by C<ff> and C<fff>.
 
 =head2 String interpolation
 
-In Perl 5, C<"${foo}s"> deliminates a variable name from regular text next to it.
-In Perl 6, simply extend the curly braces to include the sigil too: C<"{$foo}s">
+In Perl 5, C<"${foo}s"> deliminates a variable name from regular text next to it.
+In Perl 6, simply extend the curly braces to include the sigil too: C<"{$foo}s">
 
 =head1 Compound Statements
 
@@ -683,13 +683,13 @@ Mostly unchanged; parens around the conditions are now optional, but if
 used, must not immediately follow the keyword, or it will be taken as a function
 call instead.  Binding the conditional expression to a variable is also a little different:
 
-    if (my $x = dostuff()) {...}  # Perl 5
-    if dostuff() -> $x {...}      # Perl 6
+    if (my $x = dostuff()) {...}  # Perl 5
+    if dostuff() -> $x {...}      # Perl 6
 
-(You can still use the C<my> form in Perl 6, but it will scope to the
+(You can still use the C<my> form in Perl 6, but it will scope to the
 outer block, not the inner.)
 
-The C<unless> conditional only allows for a single block in Perl 6;
+The C<unless> conditional only allows for a single block in Perl 6;
 it does not allow for an C<elsif> or C<else> clause.
 
 =head3 C<given>-C<when>
@@ -733,23 +733,23 @@ Mostly unchanged; parens around the conditions are now optional, but if
 used, must not immediately follow the keyword, or it will be taken as a function
 call instead.  Binding the conditional expression to a variable is also a little different:
 
-    while (my $x = dostuff()) {...}  # Perl 5
-    while dostuff() -> $x {...}      # Perl 6
+    while (my $x = dostuff()) {...}  # Perl 5
+    while dostuff() -> $x {...}      # Perl 6
 
-(You can still use the C<my> form in Perl 6, but it will scope to the
+(You can still use the C<my> form in Perl 6, but it will scope to the
 outer block, not the inner.)
 
 Note that reading line-by-line from a filehandle has changed.
 
-In Perl 5, it was done in a C<while> loop using the diamond operator. Using
+In Perl 5, it was done in a C<while> loop using the diamond operator. Using
 C<for> instead of C<while> was a common bug, because the C<for> causes the
 whole file to be sucked in at once, swamping the program's memory usage.
 
-In Perl 6, C<for> statement is B<lazy>, so we read line-by-line in a C<for>
+In Perl 6, C<for> statement is B<lazy>, so we read line-by-line in a C<for>
 loop using the C<.lines> method.
 
-    while (<IN_FH>)  { } # Perl 5
-    for $IN_FH.lines { } # Perl 6
+    while (<IN_FH>)  { } # Perl 5
+    for $IN_FH.lines { } # Perl 6
 
 =head3 C<do> C<while>/C<until>
 
@@ -777,17 +777,17 @@ represent what the construct does:
 Note first this common misunderstanding about the C<for> and C<foreach>
 keywords. Many programmers think that they distinguish between the C-style
 three-expression form and the list-iterator form; they do not! In fact,
-the keywords are interchangeable; the Perl 5 compiler looks for the
+the keywords are interchangeable; the Perl 5 compiler looks for the
 semi-colons within the parens to determine which type of loop to parse.
 
 The C-style three-factor form now uses the C<loop> keyword, and is
 otherwise unchanged. The parens *are* still required.
 
-    for  ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 5
-    loop ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 6
+    for  ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 5
+    loop ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 6
 
 
-The loop-iterator form of C<for> or C<foreach> is named C<for> in Perl 6.
+The loop-iterator form of C<for> or C<foreach> is named C<for> in Perl 6.
 C<foreach> is no longer a keyword.
 Parens are optional.
 
@@ -797,35 +797,35 @@ after the list and an added arrow operator.
 The iteration variable is now always lexical; C<my> is neither needed nor
 allowed.
 
-In Perl 5, the iteration variable is a read-write alias to the current list
+In Perl 5, the iteration variable is a read-write alias to the current list
 element.
 
-In Perl 6, that alias is read-only (for safety), unless you change C«->» to
+In Perl 6, that alias is read-only (for safety), unless you change C«->» to
 C«<->».  When translating, inspect the use of the loop variable to decide if
 read-write is needed.
 
-    for my $car (@cars)  {...} # Perl 5; read-write
-    for @cars  -> $car   {...} # Perl 6; read-only
-    for @cars <-> $car   {...} # Perl 6; read-write
+    for my $car (@cars)  {...} # Perl 5; read-write
+    for @cars  -> $car   {...} # Perl 6; read-only
+    for @cars <-> $car   {...} # Perl 6; read-write
 
 If the default topic C<$_> is being used, but needs to be read-write,
 then just use C«<->» and explicitly specify C«$_».
 
-    for (@cars)      {...} # Perl 5; default topic
-    for @cars        {...} # Perl 6; $_ is read-only
-    for @cars <-> $_ {...} # Perl 6; $_ is read-write
+    for (@cars)      {...} # Perl 5; default topic
+    for @cars        {...} # Perl 6; $_ is read-only
+    for @cars <-> $_ {...} # Perl 6; $_ is read-write
 
 =head4 C<each>
 
-Here is the equivalent to Perl 5’s C<while…each(%hash)> or C<while…each(@array)>
+Here is the equivalent to Perl 5’s C<while…each(%hash)> or C<while…each(@array)>
 (= iterating over both the keys or indices and values of a data structure) in
-Perl 6:
+Perl 6:
 
-    while (my ($i, $v) = each(@array)) { ... } # Perl 5
-    for @array.kv -> $i, $v { ... } # Perl 6
+    while (my ($i, $v) = each(@array)) { ... } # Perl 5
+    for @array.kv -> $i, $v { ... } # Perl 6
 
-    while (my ($k, $v) = each(%hash)) { ... } # Perl 5
-    for %hash.kv -> $k, $v { ... } # Perl 6
+    while (my ($k, $v) = each(%hash)) { ... } # Perl 5
+    for %hash.kv -> $k, $v { ... } # Perl 6
 
 =head2 Flow Control statements
 
@@ -840,7 +840,7 @@ Unchanged:
 There is no longer a C<continue> block.
 Instead, use a C<NEXT> block within the body of the loop.
 
-    # Perl 5
+    # Perl 5
         my $str = '';
         for (1..5) {
             next if $_ % 2 == 1;
@@ -849,7 +849,7 @@ Instead, use a C<NEXT> block within the body of the loop.
         continue {
             $str .= ':'
         }
-    # Perl 6
+    # Perl 6
         my $str = '';
         for 1..5 {
             next if $_ % 2 == 1;
@@ -872,8 +872,8 @@ a comma, by the remainder of the arguments will now
 require a comma between the block and the arguments e.g. C<map>, C<grep>,
 etc.
 
-    my @results = grep { $_ eq "bars" } @foo; # Perl 5
-    my @results = grep { $_ eq "bars" }, @foo; # Perl 6
+    my @results = grep { $_ eq "bars" } @foo; # Perl 5
+    my @results = grep { $_ eq "bars" }, @foo; # Perl 6
 
 
 =head2 C<delete>
@@ -882,11 +882,11 @@ Turned into an adverb of the
 L<C<{}> hash subscripting|#{}_Hash_indexing/slicing>
 and L<C<[]> array subscripting|#[]_Array_indexing/slicing> operators.
 
-    my $deleted_value = delete $hash{$key};  # Perl 5
-    my $deleted_value = %hash{$key}:delete;  # Perl 6 - use :delete adverb
+    my $deleted_value = delete $hash{$key};  # Perl 5
+    my $deleted_value = %hash{$key}:delete;  # Perl 6 - use :delete adverb
 
-    my $deleted_value = delete $array[$i];  # Perl 5
-    my $deleted_value = @array[$i]:delete;  # Perl 6 - use :delete adverb
+    my $deleted_value = delete $array[$i];  # Perl 5
+    my $deleted_value = @array[$i]:delete;  # Perl 6 - use :delete adverb
 
 =head2 C<exists>
 
@@ -894,29 +894,29 @@ Turned into an adverb of the
 L<C<{}> hash subscripting|#{}_Hash_indexing/slicing>
 and L<C<[]> array subscripting|#[]_Array_indexing/slicing> operators.
 
-    say "element exists" if exists $hash{$key};  # Perl 5
-    say "element exists" if %hash{$key}:exists;  # Perl 6 - use :exists adverb
+    say "element exists" if exists $hash{$key};  # Perl 5
+    say "element exists" if %hash{$key}:exists;  # Perl 6 - use :exists adverb
 
-    say "element exists" if exists $array[$i];  # Perl 5
-    say "element exists" if @array[$i]:exists;  # Perl 6 - use :exists adverb
+    say "element exists" if exists $array[$i];  # Perl 5
+    say "element exists" if @array[$i]:exists;  # Perl 6 - use :exists adverb
 
 =head1 Regular Expressions ( Regex / Regexp )
 
 =head2 Change C<=~> and C<!~> to C<~~> and C<!~~> .
 
-In Perl 5, matches and substitutions are done against a variable using the
+In Perl 5, matches and substitutions are done against a variable using the
 C<=~> regexp-binding op.
 
-In Perl 6, the C<~~> smartmatch op is used instead.
+In Perl 6, the C<~~> smartmatch op is used instead.
 
-    next if $line  =~ /static/  ; # Perl 5
-    next if $line  ~~ /static/  ; # Perl 6
+    next if $line  =~ /static/  ; # Perl 5
+    next if $line  ~~ /static/  ; # Perl 6
 
-    next if $line  !~ /dynamic/ ; # Perl 5
-    next if $line !~~ /dynamic/ ; # Perl 6
+    next if $line  !~ /dynamic/ ; # Perl 5
+    next if $line !~~ /dynamic/ ; # Perl 6
 
-    $line =~ s/abc/123/;          # Perl 5
-    $line ~~ s/abc/123/;          # Perl 6
+    $line =~ s/abc/123/;          # Perl 5
+    $line ~~ s/abc/123/;          # Perl 6
 
 Alternately, the new C<.match> and C<.subst> methods can be used. Note that
 C<.subst> is non-mutating. See
@@ -924,29 +924,29 @@ L<S05/Substitution|https://design.perl6.org/S05.html#Substitution>.
 
 =head2 Captures start with 0, not 1
 
-    /(.+)/ and print $1; # Perl 5
-    /(.+)/ and print $0; # Perl 6
+    /(.+)/ and print $1; # Perl 5
+    /(.+)/ and print $0; # Perl 6
 
 =head2 Move modifiers
 
 Move any modifiers from the end of the regex to the beginning. This may
 require you to add the optional C<m> on a plain match like C«/abc/».
 
-    next if $line =~    /static/i ; # Perl 5
-    next if $line ~~ m:i/static/  ; # Perl 6
+    next if $line =~    /static/i ; # Perl 5
+    next if $line ~~ m:i/static/  ; # Perl 6
 
 =head2 Add :P5 or :Perl5 adverb
 
 If the actual regex is complex, you may want to use it as-is, by adding the
 C<P5> modifier.
 
-    next if $line =~    m/[aeiou]/   ; # Perl 5
-    next if $line ~~ m:P5/[aeiou]/   ; # Perl 6, using P5 modifier
-    next if $line ~~ m/  <[aeiou]> / ; # Perl 6, native new syntax
+    next if $line =~    m/[aeiou]/   ; # Perl 5
+    next if $line ~~ m:P5/[aeiou]/   ; # Perl 6, using P5 modifier
+    next if $line ~~ m/  <[aeiou]> / ; # Perl 6, native new syntax
 
 =head2 Special matchers generally fall under the <> syntax
 
-There are many cases of special matching syntax that Perl 5 regexes
+There are many cases of special matching syntax that Perl 5 regexes
 support. They won't all be listed here, but often instead of being
 surrounded by C<()>, the assertions will be surrounded by C«<>».
 
@@ -983,12 +983,12 @@ For look-around assertions:
 
 =head2 Longest token matching (LTM) displaces alternation
 
-In Perl 6 regexen, C<|> does LTM, which decides which alternation wins
+In Perl 6 regexen, C<|> does LTM, which decides which alternation wins
 an ambiguous match based off of a set of rules, rather than about which
 was written first.
 
 The simplest way to deal with this is just to change any C<|> in your
-Perl 5 regex to a C<||>.
+Perl 5 regex to a C<||>.
 
 TODO more rules. Use L<< C<translate_regex.pl> from Blue
 Tiger|https://github.com/Util/Blue_Tiger/ >> in the meantime.
@@ -1011,26 +1011,26 @@ but putting things in a quietly {} block will silence.
 The functions which were altered by C<autodie> to throw exceptions on
 error, now throw exceptions by default unless you test the return value explicitly.
 
-    # Perl 5
+    # Perl 5
     open my $i_fh, '<', $input_path;  # Fails silently on error
     use autodie;
     open my $o_fh, '>', $output_path; # Throws exception on error
 
-    # Perl 6
+    # Perl 6
     my $i_fh = open $input_path,  :r; # Throws exception on error
     my $o_fh = open $output_path, :w; # Throws exception on error
 
 =head3 C<base>
 =head3 C<parent>
 
-Both C<use base> and C<use parent> have been replaced in Perl 6 by the
+Both C<use base> and C<use parent> have been replaced in Perl 6 by the
 C<is> keyword, in the class declaration.
 
-    # Perl 5
+    # Perl 5
     package Cat;
     use base qw(Animal);
 
-    # Perl 6
+    # Perl 6
     class Cat is Animal;
 
 =head3 C<bigint> C<bignum> C<bigrat>
@@ -1044,17 +1044,17 @@ an arbitrary-precision denominator, C<FatRat> is available.
 
 =head3 X<C<constant>|constant>
 
-In Perl 6, C<constant> is a declarator for variables, just like C<my>,
+In Perl 6, C<constant> is a declarator for variables, just like C<my>,
 except the variable is permanently locked to the result of its
 initialization expression (evaluated at compile time).
 
 So, change the C«=>» to C<=> , and add a sigil.
 
-    use constant DEBUG => 0; # Perl 5
-    constant $DEBUG = 0;     # Perl 6
+    use constant DEBUG => 0; # Perl 5
+    constant $DEBUG = 0;     # Perl 6
 
-    use constant pi => 4 * atan2(1, 1); # Perl 5
-    # pi, e, i are built-in constants in  Perl 6
+    use constant pi => 4 * atan2(1, 1); # Perl 5
+    # pi, e, i are built-in constants in  Perl 6
 
 =head3 C<encoding>
 
@@ -1072,20 +1072,20 @@ Manipulate @INC at compile time
 
 No longer relevant.
 
-In Perl 6, method calls now always use the C3 method resolution order.
+In Perl 6, method calls now always use the C3 method resolution order.
 
 =head3 C<utf8>
 
 No longer relevant.
 
-In Perl 6, source code is expected to be in utf8 encoding.
+In Perl 6, source code is expected to be in utf8 encoding.
 
 =head3 C<vars>
 
-Discouraged in Perl 5. See L<http://perldoc.perl.org/vars.html>.
+Discouraged in Perl 5. See L<http://perldoc.perl.org/vars.html>.
 
-You should refactor your Perl 5 code to remove the need for C<use vars>,
-before translating into Perl 6.
+You should refactor your Perl 5 code to remove the need for C<use vars>,
+before translating into Perl 6.
 
 
 
@@ -1131,13 +1131,13 @@ Replaced with the C<++BUG> metasyntactic option.
 
 Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
 
-    # Perl 5
+    # Perl 5
         #!/usr/bin/perl -s
         if ($xyz) { print "$xyz\n" }
     ./example.pl -xyz=5
     5
 
-    # Perl 6
+    # Perl 6
         sub MAIN( Int :$xyz ) {
             say $xyz if $xyz.defined;
         }
@@ -1164,14 +1164,14 @@ This is now the default behavior.
 
 =head2 Reading the lines of a text file into an array
 
-In Perl 5, a common idiom for reading the lines of a text file goes
+In Perl 5, a common idiom for reading the lines of a text file goes
 something like this:
 
     open my $fh, "<", "file" or die "$!";
     my @lines = <$fh>;
     close $fh;
 
-In Perl 6, this has been simplified to
+In Perl 6, this has been simplified to
 
     my @lines = "file".IO.lines;
 
@@ -1192,7 +1192,7 @@ e.g.:
 
 =head2 Trapping the standard output of executables.
 
-Whereas in Perl 5 you would do:
+Whereas in Perl 5 you would do:
 
     my $arg = 'Hello';
     my $captured = `echo \Q$arg\E`;
@@ -1204,7 +1204,7 @@ Or using String::ShellQuote (because C<\Q…\E> is not completely right):
     my $captured = `echo $arg`;
     my $captured = qx(echo $arg);
 
-In Perl 6, you will probably want to run commands without using the shell:
+In Perl 6, you will probably want to run commands without using the shell:
 
     my $arg = 'Hello';
     my $captured = run('echo', $arg, :out).out.slurp-rest;
@@ -1232,13 +1232,13 @@ Perl modules is C<PERL5LIB>.
 
     $ PERL5LIB="/some/module/lib" perl program.pl
 
-In Perl 6 this is similar, one merely needs to change a number!  As you
+In Perl 6 this is similar, one merely needs to change a number!  As you
 probably guessed, you just need to use X<C<PERL6LIB>|PERL6LIB>:
 
     $ PERL6LIB="/some/module/lib" perl6 program.p6
 
-In Perl 5 one uses the ':' (colon) as a directory separator for C<PERL5LIB>, but in
-Perl 6 one uses the ',' (comma).  For example:
+In Perl 5 one uses the ':' (colon) as a directory separator for C<PERL5LIB>, but in
+Perl 6 one uses the ',' (comma).  For example:
 
     $ export PERL5LIB=/module/dir1:/module/dir2;
 
@@ -1246,7 +1246,7 @@ but
 
     $ export PERL6LIB=/module/dir1,/module/dir2;
 
-(Perl 6 does not recognize either the C<PERL5LIB> or the older Perl environment
+(Perl 6 does not recognize either the C<PERL5LIB> or the older Perl environment
 variable C<PERLLIB>.)
 
 As with Perl5, if you don't specify C<PERL6LIB>, you need to specify the
@@ -1254,22 +1254,22 @@ library path within the program via the C<use lib> pragma:
 
     use lib '/some/module/lib'
 
-Note that C<PERL6LIB> is more of a developer convenience in Perl 6 (as
+Note that C<PERL6LIB> is more of a developer convenience in Perl 6 (as
 opposed to the equivalent usage of C<PERL5LIB> in Perl5) and shouldn't be
 used by module consumers as it could be removed in the future.  This is
-because Perl 6's module loading isn't directly compatible with operating
+because Perl 6's module loading isn't directly compatible with operating
 system paths.
 
 =head1 Misc.
 
 =head2 C<'0'> is True
 
-Unlike Perl 5, a string containing nothing but zero ('0') is C<True>. As Perl 6
+Unlike Perl 5, a string containing nothing but zero ('0') is C<True>. As Perl 6
 has types in core, that makes more sense. This also means the common pattern:
 
     ... if defined $x and length $x; # or just length() in modern perls
 
-In Perl 6 becomes a simple
+In Perl 6 becomes a simple
 
     ... if $x;
 
@@ -1277,7 +1277,7 @@ In Perl 6 becomes a simple
 
 Gone.
 
-The Perl 6 design allows for automatic transparent saving-and-loading of
+The Perl 6 design allows for automatic transparent saving-and-loading of
 compiled bytecode.
 
 Rakudo supports this only for modules so far.
@@ -1285,12 +1285,12 @@ Rakudo supports this only for modules so far.
 =head2 Importing specific functions from a module
 X<|import>
 
-In Perl 5 it is possible to selectively import functions from a given module
+In Perl 5 it is possible to selectively import functions from a given module
 like so:
 
     use ModuleName qw{foo bar baz};
 
-In Perl 6 one specifies the functions which are to be exported by using the
+In Perl 6 one specifies the functions which are to be exported by using the
 C<is export> role on the relevant subs and I<all> subs with this role are
 then exported.  Hence, the following module C<Bar> exports the subs C<foo>
 and C<bar> but not C<baz>:
@@ -1310,7 +1310,7 @@ will be available
 
 If one tries to use C<baz> an "Undeclared routine" error is raised at compile time.
 
-So, how does one recreate the Perl 5 behaviour of being able to selectively
+So, how does one recreate the Perl 5 behaviour of being able to selectively
 import functions?  For this one needs to define an C<EXPORT> sub inside the
 module which specifies the functions to be exported and (in the current
 implementation of Rakudo (2015.03)) remove the C<module Bar> statement.
@@ -1373,7 +1373,7 @@ statement:
 
 In order to get this to work, one obviously has to jump through many hoops.
 In the standard use-case where one specifies the functions to be exported
-via the C<is export> role, Perl 6 automatically creates the C<EXPORT> sub in
+via the C<is export> role, Perl 6 automatically creates the C<EXPORT> sub in
 the correct manner for you, so one should consider very carefully whether or
 not writing one's own C<EXPORT> routine is worthwhile.
 
@@ -1381,11 +1381,11 @@ not writing one's own C<EXPORT> routine is worthwhile.
 
 =head3 C<Data::Dumper>
 
-In Perl 5, the L<Data::Dumper|https://metacpan.org/pod/Data::Dumper>
+In Perl 5, the L<Data::Dumper|https://metacpan.org/pod/Data::Dumper>
 module was used for serialization, and for
 debugging views of program data structures by the programmer.
 
-In Perl 6, these tasks are accomplished with the C<.perl> method, which
+In Perl 6, these tasks are accomplished with the C<.perl> method, which
 every object has.
 
     # Given:
@@ -1393,23 +1393,23 @@ every object has.
             { NAME => 'apple',   type => 'fruit' },
             { NAME => 'cabbage', type => 'no, please no' },
         );
-    # Perl 5
+    # Perl 5
         use Data::Dumper;
         $Data::Dumper::Useqq = 1;
         print Dumper \@array_of_hashes; # Note the backslash.
-    # Perl 6
+    # Perl 6
         say @array_of_hashes.perl; # .perl on the array, not on its reference.
 
-In Perl 5, Data::Dumper has a more complex optional calling convention,
+In Perl 5, Data::Dumper has a more complex optional calling convention,
 which allows for naming the VARs.
 
-In Perl 6, placing a colon in front of the variable's sigil turns it into a
+In Perl 6, placing a colon in front of the variable's sigil turns it into a
 Pair, with a key of the var name, and a value of the var value.
 
     # Given:
         my ( $foo, $bar ) = ( 42, 44 );
         my @baz = ( 16, 32, 64, 'Hike!' );
-    # Perl 5
+    # Perl 5
         use Data::Dumper;
         print Data::Dumper->Dump(
             [     $foo, $bar, \@baz   ],
@@ -1424,7 +1424,7 @@ Pair, with a key of the var name, and a value of the var value.
                  64,
                  'Hike!'
                );
-    # Perl 6
+    # Perl 6
         say [ :$foo, :$bar, :@baz ].perl;
     # Output
         ["foo" => 42, "bar" => 44, "baz" => [16, 32, 64, "Hike!"]]
@@ -1434,7 +1434,7 @@ Pair, with a key of the var name, and a value of the var value.
 
 Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
 
-    # Perl 5
+    # Perl 5
         use 5.010;
         use Getopt::Long;
         GetOptions(
@@ -1457,7 +1457,7 @@ Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
         Value "abc" invalid for option length (number expected)
         Died at c.pl line 3.
 
-    # Perl 6
+    # Perl 6
         sub MAIN( Int :$length = 24, :file($data) = 'file.dat', Bool :$verbose ) {
             say $length if $length.defined;
             say $data   if $data.defined;
@@ -1475,7 +1475,7 @@ Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
         Usage:
           c.p6 [--length=<Int>] [--file=<Any>] [--verbose]
 
-Note that Perl 6 auto-generates a full usage message on error in
+Note that Perl 6 auto-generates a full usage message on error in
 command-line parsing.
 
 
@@ -1483,7 +1483,7 @@ command-line parsing.
 
 =head1 Automated Translation
 
-A quick way to find the Perl 6 version of a Perl 5 construct, is to run it
+A quick way to find the Perl 6 version of a Perl 5 construct, is to run it
 through an automated translator.
 
 B<NOTE:> None of these translators are yet complete.
@@ -1492,8 +1492,8 @@ B<NOTE:> None of these translators are yet complete.
 
 This project is dedicated to automated modernization of Perl code. It does
 not (yet) have a web front-end, and so must be locally installed to be
-useful. It also contains a separate program to translate Perl 5 regexes
-into Perl 6.
+useful. It also contains a separate program to translate Perl 5 regexes
+into Perl 6.
 
 L<https://github.com/Util/Blue_Tiger/>
 
@@ -1501,16 +1501,16 @@ L<https://github.com/Util/Blue_Tiger/>
 
 Online Translator!
 
-This project is a suite of Perl cross-compilers, including Perl 5-to-6
+This project is a suite of Perl cross-compilers, including Perl 5-to-6
 translation. It has a web front-end, and so can be used without
-installation. It only supports a subset of Perl 5 syntax so far.
+installation. It only supports a subset of Perl 5 syntax so far.
 
 L<http://fglock.github.io/Perlito/perlito/perlito5.html>
 
 =head2 MAD
 
-Larry Wall's own code for translating Perl 5 to Perl 6 has bit-rotted, and
-is not (currently) viable on recent releases of Perl 5.
+Larry Wall's own code for translating Perl 5 to Perl 6 has bit-rotted, and
+is not (currently) viable on recent releases of Perl 5.
 
 MAD (Misc Attribute Definition) is a configuration option when building
 Perl from a source distribution. The `perl` executable analyses and
@@ -1518,16 +1518,16 @@ translates your Perl sourcecode into an op-tree, and then executes the
 program by walking the op-tree. Normally, most of the details from the
 analysis are thrown away during this process. When MAD is enabled, the
 `perl` executable will save those details to an XML file, which can then be
-read and further processed into Perl 6 code by a MAD parser.
+read and further processed into Perl 6 code by a MAD parser.
 
-Please consult #perl6 to find out the best release of Perl 5 to use for
+Please consult #perl6 to find out the best release of Perl 5 to use for
 your MAD science experiments.
 
-=head2 Perl-ToPerl6
+=head2 Perl-ToPerl 6
 
-Jeff Goff's Perl::ToPerl6 module for Perl 5 is designed around
+Jeff Goff's Perl::ToPerl 6 module for Perl 5 is designed around
 Perl::Critic's framework. It aims to convert Perl5 to compilable (if not
-necessarily running) Perl 6 code with the bare minimum of changes. Code
+necessarily running) Perl 6 code with the bare minimum of changes. Code
 transformers are configurable and pluggable, so you can create and
 contribute your own transformers, and customize existing transformers to
 your own needs. You can install the latest release from CPAN, or follow
@@ -1547,7 +1547,7 @@ some point.
 
 ### Guidelines for contributions:
 
-Headers should contain the text that a Perl 5 user might search for, since
+Headers should contain the text that a Perl 5 user might search for, since
 those headings will be in the Table of Contents generated for the top of
 the document.
 

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -2,23 +2,23 @@
 
 =TITLE 5to6-perlfunc
 
-=SUBTITLE Perl 5 to Perl 6 guide - functions
+=SUBTITLE Perl 5 to Perl 6 guide - functions
 
 =head1 DESCRIPTION
 
-A (hopefully) comprehensive list of Perl 5 builtin functions with their
-Perl 6 equivalents with notes on variations between them where
+A (hopefully) comprehensive list of Perl 5 builtin functions with their
+Perl 6 equivalents with notes on variations between them where
 necessary.
 
 =head1 NOTE
 
 I will I<not> be explaining the functions in detail. This document is an
-attempt to guide you from the functions in Perl 5's perlfunc document to
-their equivalents in Perl 6. For full documentation on the Perl 6
-functions, please see the Perl 6 documentation.
+attempt to guide you from the functions in Perl 5's perlfunc document to
+their equivalents in Perl 6. For full documentation on the Perl 6
+functions, please see the Perl 6 documentation.
 
-One general comment: Perl 6 takes its objects a lot more seriously than
-Perl 5. In Perl 6, everything is an object, although the language is
+One general comment: Perl 6 takes its objects a lot more seriously than
+Perl 5. In Perl 6, everything is an object, although the language is
 flexible enough to not force you to work in an object oriented manner if
 you do not wish to do so. What this does mean, however, is that a lot of
 things that are function calls of the form C<function(@args)> are now
@@ -42,10 +42,10 @@ function in the style of C<@args.func>.
 
 =item -X
 
-Perl 6 gives you a couple of options when it comes to file tests. You can do a
+Perl 6 gives you a couple of options when it comes to file tests. You can do a
 smart match (C<~~>) or you can call a method.
 
-In Perl 6, you don't need to actually open a filehandle in the
+In Perl 6, you don't need to actually open a filehandle in the
 traditional way (although you can) to do a filetest. You can simply append
 C<.IO> to the filename. For instance, here is how to check if a file is
 readable using smart match:
@@ -77,8 +77,8 @@ Three tests, however, I<only> have method equivalents:
     $fh.accessed; # -A $fh
     $fh.changed;  # -C $fh
 
-The remaining filetests in Perl 5 do not appear to be implemented
-in Perl 6.
+The remaining filetests in Perl 5 do not appear to be implemented
+in Perl 6.
 
 The documentation for this can be found at
 L<File test operators|/type/IO::Path#File_test_operators>.
@@ -131,7 +131,7 @@ For instance, these are equivalent:
 
 =item bind SOCKET,NAME
 
-[NEEDS FURTHER RESEARCH] No sign of a socket-related C<bind()> in Perl 6. At a
+[NEEDS FURTHER RESEARCH] No sign of a socket-related C<bind()> in Perl 6. At a
 guess, whatever socket binding is needed happens when you create a new socket
 object.
 
@@ -146,11 +146,11 @@ socket. E. g. C<my $fh = open("path/to/file", :bin);>
 
 =item bless REF,CLASSNAME
 
-With the changes in class creation in Perl 6, this may find less use
-than in Perl 5, and is a method as well as a function. The Perl 6 docs
+With the changes in class creation in Perl 6, this may find less use
+than in Perl 5, and is a method as well as a function. The Perl 6 docs
 say "Creates a new object of the same type as the invocant, uses the
 named arguments to initialize attributes, and returns the created
-object." If you're porting a module from Perl 5 to Perl 6, it's quite
+object." If you're porting a module from Perl 5 to Perl 6, it's quite
 possible you'll want to use C<new> for creating objects rather than
 C<bless>, although there may be some situations in which the latter may
 still be useful.
@@ -159,7 +159,7 @@ still be useful.
 
 =item break
 
-Not in Perl 6. For breaking out of C<given> blocks, you should probably take a
+Not in Perl 6. For breaking out of C<given> blocks, you should probably take a
 look at C<proceed> and C<succeed>
 L<here|/language/control#proceed_and_succeed>.
 
@@ -167,8 +167,8 @@ L<here|/language/control#proceed_and_succeed>.
 
 =item caller EXPR
 
-There are a couple different ways to get at caller information in Perl 6.
-The basic functionality is provided through L<callframe> now. However, Perl 6
+There are a couple different ways to get at caller information in Perl 6.
+The basic functionality is provided through L<callframe> now. However, Perl 6
 constructs call frames for regular blocks, not just for subroutines, so there
 are more frames to look through. The following will retrieve the basic
 information that C<caller> can return:
@@ -182,8 +182,8 @@ information that C<caller> can return:
     my $file    = $frame.file;
     my $line    = $frame.line;
 
-Many of the other details returned by C<caller> are specific to Perl 5 and have
-no meaning in Perl 6.
+Many of the other details returned by C<caller> are specific to Perl 5 and have
+no meaning in Perl 6.
 
 You can also get some of the information for the current frame or routine frame
 by using the dynamic variables L<&?ROUTINE>, L<&?BLOCK>, L<$?PACKAGE>,
@@ -194,13 +194,13 @@ way to browse through the call stack.
 
 =item chdir EXPR
 
-Seems to work as it does in Perl 5.
+Seems to work as it does in Perl 5.
 
 =head2 chmod
 
 =item chmod LIST
 
-Functions as under Perl 5, with the difference that octal numbers are
+Functions as under Perl 5, with the difference that octal numbers are
 represented differently (C<0o755> rather than C<0755>). You may also use
 it as a method, e. g. C<$fh.chmod(0o755)>.
 
@@ -208,7 +208,7 @@ it as a method, e. g. C<$fh.chmod(0o755)>.
 
 =item chomp VARIABLE
 
-The behavior of C<chomp> is different than in Perl 5. It leaves the
+The behavior of C<chomp> is different than in Perl 5. It leaves the
 target unaffected and I<returns> the target with a final logical newline
 removed. I. e. C<$x = "howdy\n";$y = chomp($x);> results in C<$x>
 containing "howdy\n" and C<$y> containing "howdy". Also works as a
@@ -218,7 +218,7 @@ method, i. e. C<$y = $x.chomp>.
 
 =item chop VARIABLE
 
-As with C<chomp>, in Perl 6, this returns the chopped string, rather than chopping in
+As with C<chomp>, in Perl 6, this returns the chopped string, rather than chopping in
 place. I. e. C<$x = "howdy";$y = chop($x);> results in C<$x> being "howdy" and
 C<$y> being "howd". Also works as a method: C<$y = $x.chop>
 
@@ -226,13 +226,13 @@ C<$y> being "howd". Also works as a method: C<$y = $x.chop>
 
 =item chown LIST
 
-C<chown> is not in Perl 6.
+C<chown> is not in Perl 6.
 
 =head2 chr
 
 =item chr NUMBER
 
-Similar to the Perl 5 version, coerces the target to an integer, and uses that
+Similar to the Perl 5 version, coerces the target to an integer, and uses that
 as a Unicode code point to return the relevant character. Can be used as a
 function and a method:
 
@@ -243,13 +243,13 @@ function and a method:
 
 =item chroot FILENAME
 
-Apparently this is not in Perl 6.
+Apparently this is not in Perl 6.
 
 =head2 close
 
 =item close FILEHANDLE
 
-As in Perl 5, closes a filehandle. Returns a boolean value. Both C<close
+As in Perl 5, closes a filehandle. Returns a boolean value. Both C<close
 $fh> and C<$fh.close> will work.
 
 =head2 closedir
@@ -273,21 +273,21 @@ you would call on some variety of IO::Socket object.
 =item continue
 
 Instead of a C<continue> block, you should use a C<NEXT> block. The
-closest analog to a bare C<continue;> in Perl 5 appears to be
+closest analog to a bare C<continue;> in Perl 5 appears to be
 C<proceed>/C<succeed>.
 
 =head2 cos
 
 =item cos EXPR
 
-Works as in Perl 5, but can be also used as a method, i. e.
+Works as in Perl 5, but can be also used as a method, i. e.
 C<(1/60000).cos>.
 
 =head2 crypt
 
 =item crypt PLAINTEXT,SALT
 
-This appears not to have made it into Perl 6.
+This appears not to have made it into Perl 6.
 
 =head2 dbm functions
 
@@ -295,8 +295,8 @@ This appears not to have made it into Perl 6.
 
 =item dbmopen HASH,DBNAME,MASK
 
-These functions have largely been superseded in Perl 5, and are unlikely to
-ever turn up in Perl 6 (although any assumptions about the Perl 6 database
+These functions have largely been superseded in Perl 5, and are unlikely to
+ever turn up in Perl 6 (although any assumptions about the Perl 6 database
 implementation may be premature).
 
 =head2 defined
@@ -313,7 +313,7 @@ used as a method: C<$num.defined>
 
 =item delete EXPR
 
-Perl 6 replaces this with the new adverb syntax, specifically the
+Perl 6 replaces this with the new adverb syntax, specifically the
 C<:delete> adverb. E. g. C<my $deleted_value = %hash{$key}:delete;> and
 C<my $deleted_value = @array[$i]:delete;>.
 
@@ -321,10 +321,10 @@ C<my $deleted_value = @array[$i]:delete;>.
 
 =item die LIST
 
-Works similarly to the Perl 5 version, but Perl 6's Exception mechanism
-may give you more power and flexibility than is available in Perl 5.
+Works similarly to the Perl 5 version, but Perl 6's Exception mechanism
+may give you more power and flexibility than is available in Perl 5.
 See L<exceptions|/language/exceptions>. To omit the stacktrace
-and location, like Perl 5's C<die "...\n">, use:
+and location, like Perl 5's C<die "...\n">, use:
 
     note "...";
     exit 1;
@@ -333,12 +333,12 @@ and location, like Perl 5's C<die "...\n">, use:
 
 =item do BLOCK
 
-Similar to the Perl 5 version. Note that there must be a space between the
+Similar to the Perl 5 version. Note that there must be a space between the
 C<do> and the block.
 
 =item do EXPR
 
-Has been replaced in Perl 6 by C<EVALFILE>.
+Has been replaced in Perl 6 by C<EVALFILE>.
 
 =head2 dump
 
@@ -366,7 +366,7 @@ some information at L<https://en.wikibooks.org/wiki/Perl_6_Programming/Blocks_an
 
 =item eof FILEHANDLE
 
-In Perl 6, this is not usable as a function, but only as a method. I. e.
+In Perl 6, this is not usable as a function, but only as a method. I. e.
 C<$filehandle.eof>. Returns C<True> if at end of file.
 
 =head2 eval
@@ -387,8 +387,8 @@ No longer seems to exist.
 
 =item exec LIST
 
-Nothing in Perl 6 exactly replicates the Perl 5 C<exec>. C<shell> and
-C<run> are similar to Perl 5's C<system>, but C<exec>'s behavior of not
+Nothing in Perl 6 exactly replicates the Perl 5 C<exec>. C<shell> and
+C<run> are similar to Perl 5's C<system>, but C<exec>'s behavior of not
 returning after executing a system command would have to be emulated by
 something like C<shell($command);exit();> or possibly C<exit
 shell($command);>
@@ -397,7 +397,7 @@ shell($command);>
 
 =item exists EXPR
 
-In Perl 6, this is not a function, but an adverb:
+In Perl 6, this is not a function, but an adverb:
 
     %hash{$key}:exists;
     @array[$i]:exists;
@@ -406,25 +406,25 @@ In Perl 6, this is not a function, but an adverb:
 
 =item exit EXPR
 
-Appears to do the same thing as in Perl 5.
+Appears to do the same thing as in Perl 5.
 
 =head2 exp
 
 =item exp EXPR
 
-Same as in Perl 5, but can also be used as a method: C<5.exp>;
+Same as in Perl 5, but can also be used as a method: C<5.exp>;
 
 =head2 fc
 
 =item fc EXPR
 
-Looks like it does the same thing as in Perl 5.
+Looks like it does the same thing as in Perl 5.
 
 =head2 fcntl
 
 =item fcntl FILEHANDLE,FUNCTION,SCALAR
 
-Appears not to be in Perl 6.
+Appears not to be in Perl 6.
 
 =head2 __FILE__
 
@@ -459,13 +459,13 @@ native { * }; say fork;>.
 
 =item formline PICTURE,LIST
 
-Perl 6 does not have built-in formats.
+Perl 6 does not have built-in formats.
 
 =head2 getc
 
 =item getc FILEHANDLE
 
-Reads a single character from the input stream as in Perl 5. May now
+Reads a single character from the input stream as in Perl 5. May now
 also be used as a method: C<$filehandle.getc>
 
 =head2 getlogin
@@ -598,7 +598,7 @@ C<DateTime> object for the current time, for instance, use C<my $gmtime
 
 =item grep EXPR,LIST
 
-Still in Perl 6, with the caveat that the block form now requires a
+Still in Perl 6, with the caveat that the block form now requires a
 comma after the block. I.e. C<@foo = grep { $_ = "bars" }, @baz>. Can
 also be used as a method: C<@foo = @bar.grep(/^f/)>
 
@@ -619,7 +619,7 @@ may not be the best way to go for this.
 
 =item import LIST
 
-Was never a builtin function in Perl 5 in the first place. In Perl 6,
+Was never a builtin function in Perl 5 in the first place. In Perl 6,
 typically, one declares functions as exportable or not, and all the
 exportable ones are exported. Nevertheless, selective importing is
 possible, but beyond the scope of this document. For details, see
@@ -629,16 +629,16 @@ L<this section|/language/5to6-nutshell#Importing_specific_functions_from_a_modul
 
 =item index STR,SUBSTR,POSITION
 
-Works as in Perl 5. Can also now be used as a method:
+Works as in Perl 5. Can also now be used as a method:
 C<"howdy!".index("how"); # 0>
 
 =head2 int
 
 =item int EXPR
 
-There is a C<truncate> function in Perl 6 (also usable as a method) that
-does what Perl 5's C<int> does. You may want to use that as a direct
-translation of Perl 5 code, but in Perl 6, you can just as easily call
+There is a C<truncate> function in Perl 6 (also usable as a method) that
+does what Perl 5's C<int> does. You may want to use that as a direct
+translation of Perl 5 code, but in Perl 6, you can just as easily call
 the C<.Int> method on the number. C<3.9.Int; # 3> and C<3.9.truncate>
 are equivalent.
 
@@ -646,19 +646,19 @@ are equivalent.
 
 =item ioctl FILEHANDLE,FUNCTION,SCALAR
 
-Currently unimplemented in Perl 6.
+Currently unimplemented in Perl 6.
 
 =head2 join
 
 =item join EXPR,LIST
 
-Works as in Perl 5, and also works as a method: C<@x.join(",")>
+Works as in Perl 5, and also works as a method: C<@x.join(",")>
 
 =head2 keys
 
 =item keys HASH
 
-Works as in Perl 5, and can also be used as a method: C<%hash.keys>
+Works as in Perl 5, and can also be used as a method: C<%hash.keys>
 
 =head2 kill
 
@@ -666,7 +666,7 @@ Works as in Perl 5, and can also be used as a method: C<%hash.keys>
 
 =item kill SIGNAL
 
-Now part of the L<Proc::Async> class, but looks to work as in Perl 5.
+Now part of the L<Proc::Async> class, but looks to work as in Perl 5.
 
 =head2 last
 
@@ -676,19 +676,19 @@ Now part of the L<Proc::Async> class, but looks to work as in Perl 5.
 
 =item last
 
-Same as in Perl 5.
+Same as in Perl 5.
 
 =head2 lc
 
 =item lc EXPR
 
-Works as in Perl 5, and also as a method: C<"UGH".lc>
+Works as in Perl 5, and also as a method: C<"UGH".lc>
 
 =head2 lcfirst
 
 =item lcfirst EXPR
 
-Does not exist in Perl 6.
+Does not exist in Perl 6.
 
 =head2 length
 
@@ -707,8 +707,8 @@ Replaced by C<$?LINE>.
 
 =item link OLDFILE,NEWFILE
 
-In Perl 6, part of the IO::Path class. The only difference between Perl
-5 and Perl 6 is that the argument order has changed. It's now
+In Perl 6, part of the IO::Path class. The only difference between Perl
+5 and Perl 6 is that the argument order has changed. It's now
 C<link($original, $linked_file)>.
 
 =head2 listen
@@ -722,7 +722,7 @@ you would call on some variety of IO::Socket object.
 
 =item local EXPR
 
-The Perl 6 equivalent is C<temp>.
+The Perl 6 equivalent is C<temp>.
 
 =head2 localtime
 
@@ -745,11 +745,11 @@ $yday = $d.day-of-year; # 1..366
 
 =end code
 
-Please note that ranges are not 0-based in Perl 6, as shown in the
+Please note that ranges are not 0-based in Perl 6, as shown in the
 comments in the example.
 
-There does not currently appear to be a way to get Perl 5's
-C<$isdst>. Also, the result of C<scalar(localtime)> that Perl 5
+There does not currently appear to be a way to get Perl 5's
+C<$isdst>. Also, the result of C<scalar(localtime)> that Perl 5
 provides is not available. C<$d.Str> will give something along the
 lines of "2015-06-29T12:49:31-04:00".
 
@@ -757,13 +757,13 @@ lines of "2015-06-29T12:49:31-04:00".
 
 =item lock THING
 
-In Perl 6, a method in the C<Lock> class.
+In Perl 6, a method in the C<Lock> class.
 
 =head2 log
 
 =item log EXPR
 
-Available in Perl 6. Also works as a method. I. e. C<log(2)> is
+Available in Perl 6. Also works as a method. I. e. C<log(2)> is
 equivalent to C<2.log>.
 
 =head2 lstat
@@ -776,15 +776,15 @@ equivalent to C<2.log>.
 
 =item lstat
 
-Likely implemented somewhere in one of the C<IO> classes in Perl 6, but
+Likely implemented somewhere in one of the C<IO> classes in Perl 6, but
 it is not clear where at this time.
 
 =head2 m//
 
 =item m//
 
-Regular expression syntax is somewhat different in Perl 6, but the match
-operator still exists. If you're trying to rewrite some Perl 5 code, the
+Regular expression syntax is somewhat different in Perl 6, but the match
+operator still exists. If you're trying to rewrite some Perl 5 code, the
 most important difference is that C<=~> is replaced by the smart match
 operator, C<~~>. Similarly, C<!~> is replaced by C<!~~>. Options for
 regex operators are adverbs and are complicated. For details, see
@@ -796,7 +796,7 @@ L<Adverbs|/language/regexes#Adverbs>
 
 =item map EXPR,LIST
 
-As a function, the only difference between Perl 5 and Perl 6 is that, if
+As a function, the only difference between Perl 5 and Perl 6 is that, if
 you're using a block, the block must be followed by a comma. Can also be
 used as a method: C<@new = @old.map: { $_ * 2 }>
 
@@ -806,11 +806,11 @@ used as a method: C<@new = @old.map: { $_ * 2 }>
 
 =item mkdir FILENAME
 
-Works as in Perl 5.
+Works as in Perl 5.
 
 =item mkdir
 
-The zero argument (implicit C<$_>) version is not permitted in Perl 6.
+The zero argument (implicit C<$_>) version is not permitted in Perl 6.
 
 =head2 msg*
 
@@ -822,7 +822,7 @@ The zero argument (implicit C<$_>) version is not permitted in Perl 6.
 
 =item msgsnd ID,MSG,FLAGS
 
-Not builtins in Perl 6. May appear in an external module at some point. Maybe.
+Not builtins in Perl 6. May appear in an external module at some point. Maybe.
 
 =head2 my
 
@@ -834,7 +834,7 @@ Not builtins in Perl 6. May appear in an external module at some point. Maybe.
 
 =item my TYPE VARLIST : ATTRS
 
-Works as in Perl 5.
+Works as in Perl 5.
 
 =head2 next
 
@@ -844,7 +844,7 @@ Works as in Perl 5.
 
 =item next
 
-The same in Perl 6.
+The same in Perl 6.
 
 =head2 no
 
@@ -856,7 +856,7 @@ The same in Perl 6.
 
 =item no VERSION
 
-In Perl 6, this is usable for pragmas such as C<strict>, but not for
+In Perl 6, this is usable for pragmas such as C<strict>, but not for
 modules. It's unclear whether it can be used for versions, but since
 that's currently something of a moot point, I would guess not.
 
@@ -878,7 +878,7 @@ Replaced by the adverbial form C<:8>. E. g. C<:8("100")> returns 64.
 
 =item open FILEHANDLE
 
-The most obvious change from Perl 5 is the file mode syntax. To open a
+The most obvious change from Perl 5 is the file mode syntax. To open a
 file for reading only, you would say C<open("file", :r)>. For write-
 only, read-write, and append, you would use C<:w>, C<:rw>, and C<:a>
 respectively. There are also options for encoding and how the filehandle
@@ -888,7 +888,7 @@ deals with newlines. Details L<here|/routine/open>.
 
 =item opendir DIRHANDLE,EXPR
 
-Not a builtin function in Perl 6. You would use the IO::Path class:
+Not a builtin function in Perl 6. You would use the IO::Path class:
 
     my $dir = IO::Path.new("directory");
 
@@ -898,7 +898,7 @@ Not a builtin function in Perl 6. You would use the IO::Path class:
 
 =item ord EXPR
 
-Same as in Perl 5. May be used as a method: C<"howdy!".ord; # 104>
+Same as in Perl 5. May be used as a method: C<"howdy!".ord; # 104>
 
 =head2 our
 
@@ -910,14 +910,14 @@ Same as in Perl 5. May be used as a method: C<"howdy!".ord; # 104>
 
 =item our TYPE VARLIST : ATTRS
 
-The same in Perl 6.
+The same in Perl 6.
 
 =head2 pack
 
 =item pack TEMPLATE,LIST
 
-Available in Perl 6. The template options are currently more restricted
-than they are in Perl 5. The current documented list can be found at
+Available in Perl 6. The template options are currently more restricted
+than they are in Perl 5. The current documented list can be found at
 L<unpack|/routine/unpack>.
 
 =head2 package
@@ -930,14 +930,14 @@ L<unpack|/routine/unpack>.
 
 =item package NAMESPACE VERSION BLOCK
 
-S10 indicates that C<package> can be used in Perl 6, but only with a
+S10 indicates that C<package> can be used in Perl 6, but only with a
 block. I. e. C<package Foo { ... }> means that the code within the block
 would be in package Foo. There is a special case where a declaration of
 the form C<package Foo;> as the first statement in a file indicates that
-the rest of the file is Perl 5 code, but the usefulness of this is
+the rest of the file is Perl 5 code, but the usefulness of this is
 unclear. In fact, as modules and classes are declared with distinct
 keywords (such as C<class>), it's unlikely you will use C<package>
-directly in Perl 6.
+directly in Perl 6.
 
 =head2 __PACKAGE__
 
@@ -956,14 +956,14 @@ clearly documented.
 
 =item pop ARRAY
 
-Works in Perl 6, and can also be used as a method. I. e. C<my $x = pop
+Works in Perl 6, and can also be used as a method. I. e. C<my $x = pop
 @a;> and C<my $x = @a.pop;> are equivalent.
 
 =head2 pos
 
 =item pos SCALAR
 
-Not available in Perl 6. The closest equivalent is the C<:c> adverb,
+Not available in Perl 6. The closest equivalent is the C<:c> adverb,
 which defaults to C<$/.to> if C<$/> is true, and C<0> if it isn't. For
 information on C<:c>, see
 L<Continue|/language/regexes#Continue>.
@@ -978,7 +978,7 @@ L<Continue|/language/regexes#Continue>.
 
 =item print
 
-C<print> can be used as a function in Perl 6, defaulting to standard
+C<print> can be used as a function in Perl 6, defaulting to standard
 out. To use C<print> as a function with a filehandle I<instead> of
 standard out, you need to put a colon after the filehandle. I. e.
 C<print $fh: "Howdy!">. The use of the colon as an "invocant marker"
@@ -993,13 +993,13 @@ Alternately, you can use a method call: C<$fh.print("howdy!")>
 
 =item printf
 
-Works in Perl 6. For the formats, see the documentation for C<sprintf>.
+Works in Perl 6. For the formats, see the documentation for C<sprintf>.
 
 =head2 prototype
 
 =item prototype FUNCTION
 
-No available in Perl 6. The closest equivalent seems to be
+No available in Perl 6. The closest equivalent seems to be
 C<.signature>. E. g. C<say &sprintf.signature> results in "(Cool
 $format, *@args)".
 
@@ -1007,8 +1007,8 @@ $format, *@args)".
 
 =item push ARRAY,LIST
 
-Works as in Perl 5, as well as being available as a method:
-C<@a.push("foo");>. I<Note:> the flattening behaviour is different in Perl 6:
+Works as in Perl 5, as well as being available as a method:
+C<@a.push("foo");>. I<Note:> the flattening behaviour is different in Perl 6:
 C<@b.push: @a> will push C<@a> into C<@b> as a single element. See also the
 L<append method|/type/Array#method_append>.
 
@@ -1022,11 +1022,11 @@ L<append method|/type/Array#method_append>.
 
 =item qx/STRING/
 
-These survive the transition to Perl 6. Some notes:
+These survive the transition to Perl 6. Some notes:
 
     q/.../ # is still equivalent to using single quotes.
     qq/.../ # is still equivalent to using double quotes.
-    qw/.../ # is more commonly rendered as C<< <...> >> in Perl 6.
+    qw/.../ # is more commonly rendered as C<< <...> >> in Perl 6.
 
 There are some added quoting constructs and equivalents, as explained at
 L<quoting|/language/quoting>.
@@ -1049,10 +1049,10 @@ L<https://design.perl6.org/S05.html#Extensible_metasyntax_(%3C...%3E)>
 
 =item rand EXPR
 
-C<rand> by itself works as it does in Perl 5, but you can no longer give
+C<rand> by itself works as it does in Perl 5, but you can no longer give
 it an argument. You can, however, use it as a method on a number to get
-that behavior. I. e. the Perl 5 C<rand(100)> is equivalent to
-C<100.rand> in Perl 6. Additionally, you can get a random integer by
+that behavior. I. e. the Perl 5 C<rand(100)> is equivalent to
+C<100.rand> in Perl 6. Additionally, you can get a random integer by
 using something like C<(^100).pick>. For I<why> you are able to do that,
 see L<^ operator|/language/operators#prefix_%5E> and
 L<pick|/routine/pick>.
@@ -1061,9 +1061,9 @@ L<pick|/routine/pick>.
 
 =item read FILEHANDLE,SCALAR,LENGTH,OFFSET
 
-C<read> is found in C<IO::Handle> and C<IO::Socket> in Perl 6. It reads
+C<read> is found in C<IO::Handle> and C<IO::Socket> in Perl 6. It reads
 the specified number of bytes (rather than characters) from the relevant
-handle or socket. The use of an offset available in Perl 5 is not
+handle or socket. The use of an offset available in Perl 5 is not
 documented to exist at this time.
 
 =head2 readdir
@@ -1077,7 +1077,7 @@ take a look at L<dir routine|/type/IO::Path#routine_dir>.
 
 =item readline
 
-Not available in Perl 6. You most likely want to use the C<.lines>
+Not available in Perl 6. You most likely want to use the C<.lines>
 method in some way. For more detailed information on reading from files,
 see L<io|/language/io>.
 
@@ -1085,7 +1085,7 @@ see L<io|/language/io>.
 
 =item readlink EXPR
 
-Appears to be gone from Perl 6.
+Appears to be gone from Perl 6.
 
 =head2 readpipe
 
@@ -1093,7 +1093,7 @@ Appears to be gone from Perl 6.
 
 =item readpipe
 
-Doesn't appear to be working in Perl 6, but C<qx//> is functional, so it might
+Doesn't appear to be working in Perl 6, but C<qx//> is functional, so it might
 be lurking around in some class that isn't obvious.
 
 =head2 recv
@@ -1110,7 +1110,7 @@ Appears to be in IO::Socket. Not extensively documented at this time.
 
 =item redo
 
-Unchanged in Perl 6.
+Unchanged in Perl 6.
 
 =head2 ref
 
@@ -1125,33 +1125,33 @@ currently exist...
 
 =item rename OLDNAME,NEWNAME
 
-Still available in Perl 6.
+Still available in Perl 6.
 
 =head2 requires
 
 =item require VERSION
 
-Seems that C<require> may work for modules in Perl 6, but unclear if it
+Seems that C<require> may work for modules in Perl 6, but unclear if it
 will work with version numbers.
 
 =head2 reset
 
 =item reset EXPR
 
-Seeing no evidence of this in Perl 6 and, in fact, S29 asks if there was a
+Seeing no evidence of this in Perl 6 and, in fact, S29 asks if there was a
 good use for this. I'm guessing it's probably gone.
 
 =head2 return
 
 =item return EXPR
 
-Appears to be available in Perl 6, although not clearly documented.
+Appears to be available in Perl 6, although not clearly documented.
 
 =head2 reverse
 
 =item reverse LIST
 
-In Perl 6, this only reverses the elements of a list. C<reverse(@a)>
+In Perl 6, this only reverses the elements of a list. C<reverse(@a)>
 or C<@a.reverse>. To reverse the characters in a string, use the
 C<.flip> method.
 
@@ -1167,23 +1167,23 @@ it's not clear what it would be.
 
 =item rindex STR,SUBSTR,POSITION
 
-Works as in Perl 5, and may also be used as a method. E. g. C<$x =
+Works as in Perl 5, and may also be used as a method. E. g. C<$x =
 "babaganush";say $x.rindex("a");say $x.rindex("a", 3); # 5, 3>
 
 =head2 rmdir
 
 =item rmdir FILENAME
 
-Works in Perl 6 and can also be used as a method. C<rmdir "Foo";> and
+Works in Perl 6 and can also be used as a method. C<rmdir "Foo";> and
 C<"Foo".IO.rmdir;> are equivalent.
 
 =head2 s///
 
 =item s///
 
-Regular expression syntax is somewhat different in Perl 6, but the
+Regular expression syntax is somewhat different in Perl 6, but the
 substitution operator exists. If you're trying to rewrite some
-Perl 5 code, the most important difference is that C<=~> is replaced
+Perl 5 code, the most important difference is that C<=~> is replaced
 by the smart match operator, C<~~>. Similarly, C<!~> is C<!~~>.
 Options for regex operators are adverbs and are complicated. For
 details, see L<Adverbs page|/language/regexes#Adverbs>
@@ -1306,7 +1306,7 @@ equivalent.
 
 =item sleep EXPR
 
-Still works as in Perl 5. As of this writing, works as a method, but
+Still works as in Perl 5. As of this writing, works as a method, but
 that is deprecated and will be removed soon.
 
 =head2 sockets
@@ -1321,7 +1321,7 @@ Not currently documented, but will likely wind up in C<IO::Socket>.
 
 =item sort SUBNAME LIST
 
-C<sort> exists in Perl 6, but is somewhat different. C<$a> and C<$b> are
+C<sort> exists in Perl 6, but is somewhat different. C<$a> and C<$b> are
 no longer special (See L<5to6-perlvar>) and sort routines no
 longer return positive integers, negative integers, or 0, but rather
 C<Order::Increase>, C<Order::Same>, or C<Order::Decrease> objects. See
@@ -1344,7 +1344,7 @@ method I. e. C<sort(@a)> is equivalent to C<@a.sort>.
 
 =item splice EXPR
 
-Available in Perl 6. Can also be used as a method. C<< splice(@foo, 2, 3,
+Available in Perl 6. Can also be used as a method. C<< splice(@foo, 2, 3,
 <M N O P>); >> is equivalent to C<< @foo.splice(2, 3, <M N O P>); >>.
 
 =head2 split
@@ -1356,7 +1356,7 @@ Available in Perl 6. Can also be used as a method. C<< splice(@foo, 2, 3,
 =item split /PATTERN/
 
 
-Works mostly as in Perl 5. There are some exceptions, though. To get the
+Works mostly as in Perl 5. There are some exceptions, though. To get the
 special behavior of using the empty string, you must actually use the
 empty string - the special case of the empty pattern C<//> being treated
 as the empty string does not apply. If you use a regex for the split, it
@@ -1364,7 +1364,7 @@ will use the regex, while a literal string will be treated literally. If
 you wish to have the delimiters included in the resulting list, you need
 to use the named parameter C<:all>, like this: C<split(';', "a;b;c",
 :all) # a ; b ; c> Empty chunks are not removed from the result list as
-they are in Perl 5. For that behavior, see C<comb>. Details on C<split>
+they are in Perl 5. For that behavior, see C<comb>. Details on C<split>
 are L<here|/routine/split>. Unsurprisingly, C<split>
 also now works as a method: C<"a;b;c".split(';')>
 
@@ -1377,7 +1377,7 @@ described above.
 
 =item sprintf FORMAT, LIST
 
-Works as in Perl 5. The formats currently available are:
+Works as in Perl 5. The formats currently available are:
 
 =table
     %   a literal percent sign
@@ -1403,7 +1403,7 @@ Compatibility:
     O   a synonym for %lo
     F   a synonym for %f
 
-Perl 5 (non-)compatibility:
+Perl 5 (non-)compatibility:
 
 =table
     n   produces a runtime exception
@@ -1429,7 +1429,7 @@ Works as a function and a method. C<sqrt(4)> and C<4.sqrt> are equivalent.
 
 =item srand EXPR
 
-Available in Perl 6.
+Available in Perl 6.
 
 =head2 stat
 
@@ -1452,7 +1452,7 @@ this time.
 
 =item state TYPE VARLIST : ATTRS
 
-Available in Perl 6, see L<state|/syntax/state>.
+Available in Perl 6, see L<state|/syntax/state>.
 
 =head2 study
 
@@ -1476,8 +1476,8 @@ Unsurprisingly, we still have subroutines! You can have a signature in
 your subroutine which allows you to specify arguments. Nevertheless, in
 the absence of a signature (and only in the absence of a signature),
 C<@_> still contains what is passed to the function. So, in theory, you
-don't need to change that aspect of a function if porting from Perl 5 to
-Perl 6 (although you should probably consider the option of using a
+don't need to change that aspect of a function if porting from Perl 5 to
+Perl 6 (although you should probably consider the option of using a
 signature). For all the gory details, see
 L<functions|/language/functions>.
 
@@ -1502,7 +1502,7 @@ C<"hola!".substr(1, 3)> both return "ola".
 
 =item symlink OLDFILE,NEWFILE
 
-Part of IO::Path in Perl 6. The only difference between Perl 5 and Perl
+Part of IO::Path in Perl 6. The only difference between Perl 5 and Perl
 6 is that the argument order has changed. It's now C<link($original,
 $linked_file)>.
 
@@ -1510,7 +1510,7 @@ $linked_file)>.
 
 =item syscall NUMBER, LIST
 
-Not a builtin in Perl 6. Most likely out in a module somewhere, but it's
+Not a builtin in Perl 6. Most likely out in a module somewhere, but it's
 currently unclear where.
 
 =head2 sys*
@@ -1575,21 +1575,21 @@ terms has not been obviously specified.
 
 "Returns an Int representing the current time." Although I<how> it represents the
 current time isn't in the documentation currently, it appears to still be
-seconds since epoch, as in Perl 5.
+seconds since epoch, as in Perl 5.
 
 =head2 times
 
 =item times
 
-Not available in Perl 6.
+Not available in Perl 6.
 
 =head2 tr///
 
 =item tr///
 
-Works similarly to how it does in Perl 5. The one caveat is that ranges are specified differently.
+Works similarly to how it does in Perl 5. The one caveat is that ranges are specified differently.
 Instead of using a range "a-z", you would use "a..z", i. e. with Perl's
-range operator. In Perl 6, C<tr///> has a method version, which is
+range operator. In Perl 6, C<tr///> has a method version, which is
 better documented, called C<.trans>. C<.trans> uses a list of pairs, as
 follows: C<< $x.trans(['a'..'c'] => ['A'..'C'], ['d'..'q'] =>
 ['D'..'Q'], ['r'..'z'] => ['R'..'Z']); >> A much more extensive
@@ -1617,7 +1617,7 @@ Works as a function and a method. C<uc("ha")> and C<"ha".uc> both return "HA".
 
 =item ucfirst
 
-Perl 6 has done away with C<ucfirst>. The title case function C<tc> probably
+Perl 6 has done away with C<ucfirst>. The title case function C<tc> probably
 does what you need here. L<tc|/routine/tc> function.
 
 =head2 umask
@@ -1630,12 +1630,12 @@ Is an C<IO> method. C<IO.umask> returns the umask.
 
 =item undef EXPR
 
-There is no C<undef> in Perl 6. You can't undefine a function, and the closest
+There is no C<undef> in Perl 6. You can't undefine a function, and the closest
 equivalent value is probably C<Nil>, but you'll likely have no use for that.
 If you were using something like C<(undef, $file, $line) = caller;>, you would
-just get the filename and line number directly in Perl 6 instead of discarding
+just get the filename and line number directly in Perl 6 instead of discarding
 the first result of C<caller>. C<caller> has been replaced by C<callframe> in
-Perl 6, so the equivalent statement would be C<($file, $line) =
+Perl 6, so the equivalent statement would be C<($file, $line) =
 callframe.annotations<file line>;>
 
 =head2 unlink
@@ -1655,8 +1655,8 @@ The zero argument (implicit C<$_>) version of unlink is not available in Perl
 
 =item unpack TEMPLATE
 
-Available in Perl 6. The template options are currently more restricted
-than they are in Perl 5. The current documented list can be found
+Available in Perl 6. The template options are currently more restricted
+than they are in Perl 5. The current documented list can be found
 L<here|/routine/unpack>.
 
 
@@ -1666,7 +1666,7 @@ L<here|/routine/unpack>.
 
 =item unshift EXPR,LIST
 
-Available in Perl 6. Can be used as a method. C<unshift(@a, "blah")> is
+Available in Perl 6. Can be used as a method. C<unshift(@a, "blah")> is
 equivalent to C<@a.unshift("blah")>.
 
 =head2 untie
@@ -1674,7 +1674,7 @@ equivalent to C<@a.unshift("blah")>.
 =item untie VARIABLE
 
 [NEEDS FURTHER RESEARCH] Functions for tying variables seem to be replaced in
-Perl 6 by container types, as mentioned in S29. This has become no clearer
+Perl 6 by container types, as mentioned in S29. This has become no clearer
 since I wrote the entry for C<tie>, above.
 
 =head2 use
@@ -1689,8 +1689,8 @@ since I wrote the entry for C<tie>, above.
 
 =item use VERSION
 
-Available in Perl 6, but, oddly, not yet documented. One assumes it
-works similarly, if not identically, to the way it does in Perl 5
+Available in Perl 6, but, oddly, not yet documented. One assumes it
+works similarly, if not identically, to the way it does in Perl 5
 
 =head2 utime
 
@@ -1708,7 +1708,7 @@ C<IO::Path>, but it is not currently evident.
 
 =item values EXPR
 
-Available in Perl 6. Can also be used as a method. C<values %hash> is
+Available in Perl 6. Can also be used as a method. C<values %hash> is
 equivalent to C<%hash.values>.
 
 
@@ -1727,7 +1727,7 @@ happened.
 [NEEDS FURTHER RESEARCH] Unclear where this has gone. There's a C<wait>
 method in C<Supply>, and an C<await> method in both C<Channel> and
 C<Promise>. Which, if any or all, of these is a direct equivalent of
-Perl 5's C<wait> is unclear.
+Perl 5's C<wait> is unclear.
 
 =head2 waitpid
 
@@ -1739,11 +1739,11 @@ As with C<wait>, the disposition of this is unclear.
 
 =item wantarray
 
-There is no C<wantarray> in Perl 6, because L<reasons|/language/faq#Why_is_wantarray_or_want_gone?_Can_I_return_different_things_in_different_contexts?>.
+There is no C<wantarray> in Perl 6, because L<reasons|/language/faq#Why_is_wantarray_or_want_gone?_Can_I_return_different_things_in_different_contexts?>.
 
 There are very easy ways to cover many of the use cases which wantarray filled.
 
-First, since Perl 6 does not need special reference syntax to contain
+First, since Perl 6 does not need special reference syntax to contain
 a C<List> or C<Array> in a C<Scalar>, simply returning a list may be
 all that is needed:
 
@@ -1773,7 +1773,7 @@ to generate something which is not asked for.
 
 Another use case is to create methods which are mutators when called
 in void context but produce copies during assignment.  It is generally
-considered better form in Perl 6 not to do so, since users can quite
+considered better form in Perl 6 not to do so, since users can quite
 easily turn any copy-producing method into a mutator using the C<.=>
 operator:
 
@@ -1824,7 +1824,7 @@ L<Exceptions|/language/exceptions>.
 
 =item write
 
-Formats are gone from Perl 6, so this no longer works.
+Formats are gone from Perl 6, so this no longer works.
 
 =head2 y///
 

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -2,47 +2,47 @@
 
 =TITLE 5to6-perlop
 
-=SUBTITLE Perl 5 to Perl 6 guide - operators
+=SUBTITLE Perl 5 to Perl 6 guide - operators
 
 =head1 DESCRIPTION
 
-A (hopefully) comprehensive list of Perl 5 operators with their Perl 6
+A (hopefully) comprehensive list of Perl 5 operators with their Perl 6
 equivalents with notes on variations between them where necessary.
 
 =head1 NOTE
 
 I will I<not> be explaining the operators in detail. This document is an
-attempt to guide you from the operators in Perl 5's perlop document to
-their equivalents in Perl 6. For full documentation on the Perl 6
-equivalents, please see the Perl 6 documentation.
+attempt to guide you from the operators in Perl 5's perlop document to
+their equivalents in Perl 6. For full documentation on the Perl 6
+equivalents, please see the Perl 6 documentation.
 
 =head2 Operator Precedence and Associativity
 
-The operator precedence table is somewhat different in Perl 6 than it is in
-Perl 5, so I will not detail it here. If you need to know the precedence and
-associativity of a given operator in Perl 6, refer to
+The operator precedence table is somewhat different in Perl 6 than it is in
+Perl 5, so I will not detail it here. If you need to know the precedence and
+associativity of a given operator in Perl 6, refer to
 L<Operator Precedence|/language/operators#Operator_Precedence>.
 
 =head2 Terms and List Operators
 
-The things listed in Perl 5's perlop document as unary and list operators in
+The things listed in Perl 5's perlop document as unary and list operators in
 this section tend to be things that can also be thought of as functions, such
 as C<print> and C<chdir>. As such, you can find information about them in
 L<5to6-perlfunc.pod6|/language/5to6-perlfunc>. Parentheses are still used for grouping.
 
 =head2 The Arrow Operator
 
-As you typically will not be using references in Perl 6, the arrow is
+As you typically will not be using references in Perl 6, the arrow is
 probably less useful as a dereferencing operator. If you do need to
 dereference something, however, the arrow is the dot. It is also the dot
-for method calls. So, Perl 5's C<< $arrayref->[7] >> becomes
-C<$arrayref.[7]> in Perl 6 and, similarly, C<< $user->name >> becomes
+for method calls. So, Perl 5's C<< $arrayref->[7] >> becomes
+C<$arrayref.[7]> in Perl 6 and, similarly, C<< $user->name >> becomes
 C<$user.name>. The C<< => >> arrow is used for constructing Pairs, see
 L<Pair term documentation|/language/terms#Pair>.
 
 =head2 Auto-increment and Auto-decrement
 
-Work as in Perl 5. The one possible caveat is that they function by
+Work as in Perl 5. The one possible caveat is that they function by
 calling the C<succ> method for C<++> and the C<pred> method for C<-->.
 For builtin numeric types, this is unlikely to do something unusual, but
 custom types can define their own C<succ> and C<pred> methods, so in
@@ -51,22 +51,22 @@ I<actually> do.
 
 =head2 Exponentiation
 
-Works as you would expect. The caveat in Perl 5's perlop about C<**>
+Works as you would expect. The caveat in Perl 5's perlop about C<**>
 binding more tightly than unary minus (i. e. "-2**4" evaluates as "-(2**4)"
-rather than "(-2)**4)") seems to hold true for Perl 6.
+rather than "(-2)**4)") seems to hold true for Perl 6.
 
 =head2 Symbolic Unary Operators
 
-As in Perl 5, unary C<!> and C<-> do logical arithmetic negation,
+As in Perl 5, unary C<!> and C<-> do logical arithmetic negation,
 respectively. C<?^> is used for bitwise logical negation, which the
 documentation indicates is equivalent to C<!>. It may be relevant to
 note that these coerce their arguments to C<Bool> and C<Numeric>,
 respectively.
 
-Unary C<~> is the string context operator in Perl 6, so use prefix C<+^>
+Unary C<~> is the string context operator in Perl 6, so use prefix C<+^>
 for bitwise integer negation. Assumes two's complement.
 
-C<+> I<does> have an effect in Perl 6, coercing its argument to to the
+C<+> I<does> have an effect in Perl 6, coercing its argument to to the
 Numeric type.
 
 Unary <\> is no more. If you really want to take a reference to an existing
@@ -78,16 +78,16 @@ creation.
 =head2 Binding Operators
 
 C<=~> and C<!~> have been replaced by C<~~> and C<!~~>, respectively. Those of
-you who consider smart matching broken in Perl 5 will be happy to hear that it
-works much better in Perl 6, as the stronger typing means less guesswork.
+you who consider smart matching broken in Perl 5 will be happy to hear that it
+works much better in Perl 6, as the stronger typing means less guesswork.
 
 =head2 Multiplicative Operators
 
 Binary C<*>, C</>, and C<%> do multiplication, division, and modulo,
-respectively, as in Perl 5.
+respectively, as in Perl 5.
 
-Binary C<x> is slightly different in Perl 6, and has a companion.
-C<print '-' x 80;> gives you a string of 80 dashes, but for the Perl 5
+Binary C<x> is slightly different in Perl 6, and has a companion.
+C<print '-' x 80;> gives you a string of 80 dashes, but for the Perl 5
 behavior of C<@ones = (1) x 80;> giving you a list of 80 "1"s, you would
 use C<@ones = 1 xx 80;>.
 
@@ -97,7 +97,7 @@ Binary C<+> and C<-> do addition and subtraction, respectively, as you would
 expect..
 
 As C<.> is the method call operator, so binary C<~> acts as the
-concatenation operator in Perl 6.
+concatenation operator in Perl 6.
 
 =head2 Shift Operators
 
@@ -109,24 +109,24 @@ As noted above, you'll find these in L<5to6-perlfunc.pod6|/language/5to6-perlfun
 
 =head2 Relational Operators
 
-These all work as in Perl 5.
+These all work as in Perl 5.
 
 =head2 Equality Operators
 
-C<==> and C<!=> both work as in Perl 5.
+C<==> and C<!=> both work as in Perl 5.
 
-C<< <=> >> and C<cmp> have different behavior in Perl 6. C<< <=> >> does
+C<< <=> >> and C<cmp> have different behavior in Perl 6. C<< <=> >> does
 a numeric comparison, but returns <Order::Less>, <Order::Same>, or
-<Order::More> instead of Perl 5's C<-1>, C<0>, or C<1>. To get the Perl
+<Order::More> instead of Perl 5's C<-1>, C<0>, or C<1>. To get the Perl
 5 behavior (with the change that it returns the C<Order> objects, rather
 than integers) of C<cmp>, you would use the C<leg> operator.
 
 C<cmp> does either C<< <=> >> or C<leg>, depending on the existing type
 of its arguments.
 
-C<~~> is the smart match operator as in Perl 5, but it's also I<just>
-the match operator in Perl 6, as noted above. For how smart matching
-works in Perl 6, see L<https://design.perl6.org/S03.html#Smart_matching>.
+C<~~> is the smart match operator as in Perl 5, but it's also I<just>
+the match operator in Perl 6, as noted above. For how smart matching
+works in Perl 6, see L<https://design.perl6.org/S03.html#Smart_matching>.
 
 =head2 Smartmatch Operator
 
@@ -134,11 +134,11 @@ See the entry on C<~~> directly above.
 
 =head2 Bitwise And
 
-Binary C<&> is C<+&> in Perl 6.
+Binary C<&> is C<+&> in Perl 6.
 
 =head2 Bitwise Or and Exclusive Or
 
-Bitwise OR has changed from C<|> in Perl 5 to C<+|> in Perl 6.
+Bitwise OR has changed from C<|> in Perl 5 to C<+|> in Perl 6.
 Similarly, bitwise XOR C<^> is C<+^>
 
 =head2 C-style Logical And
@@ -151,7 +151,7 @@ Unchanged.
 
 =head2 Logical Defined-Or
 
-Remains in Perl 6 as C<//>. Returns the first defined operand, or else
+Remains in Perl 6 as C<//>. Returns the first defined operand, or else
 the last operand. Also, there is a low precedence version, called
 C<orelse>.
 
@@ -168,14 +168,14 @@ that may be useful. These are:
 
 In scalar context, C<..> and C<...> work as flip-flop operators in Perl
 5, but are little-known, and probably even less used. Those operations
-have been taken over by C<ff> and C<fff> in Perl 6, but are not clearly
+have been taken over by C<ff> and C<fff> in Perl 6, but are not clearly
 documented at this time.
 
 =head2 Conditional Operator
 
 C<?:> has been replaced by C<?? !!>. I. e. where you would use C<$x
-= $ok ? $y : $z;> in Perl 5, you would use C<$x = $ok ?? $y !! $z;>
-in Perl 6.
+= $ok ? $y : $z;> in Perl 5, you would use C<$x = $ok ?? $y !! $z;>
+in Perl 6.
 
 =head2 Assignment Operators
 
@@ -186,7 +186,7 @@ the left, while C<~=> is the string concatenation assignment, as you
 might expect with the changes in C<.> and C<~>. Also, the bitwise
 assignment operators are likely not separated into numeric and string
 versions (C<&=>, etc., vs. C<&.=>, etc.), as that feature is currently
-experimental in Perl 5 itself - although, again, this is not
+experimental in Perl 5 itself - although, again, this is not
 specifically documented.
 
 =head2 Comma Operator
@@ -197,11 +197,11 @@ in function calls. Also, there is a C<:> variant that turns function
 calls into method calls - see
 L<this page|/language/operators#infix_%3A>.
 
-The C<< => >> operator works similarly to the Perl 5 "fat comma"
+The C<< => >> operator works similarly to the Perl 5 "fat comma"
 behavior in that it allows an unquoted identifier on its left side, but
-in Perl 6 constructs Pair objects, rather than just functioning as a
+in Perl 6 constructs Pair objects, rather than just functioning as a
 separator. If you are trying to just literally translate a line of Perl
-5 code to Perl 6, it should behave as expected.
+5 code to Perl 6, it should behave as expected.
 
 =head2 List Operators (Rightward)
 
@@ -215,7 +215,7 @@ to C<Bool>.
 
 =head2 Logical And
 
-Lower precedence version of C<&&> as in Perl 5.
+Lower precedence version of C<&&> as in Perl 5.
 
 =head2 Logical or and Exclusive Or
 
@@ -238,7 +238,7 @@ closing curly brace → \".
 
 C<q> does what you expect, allowing backslash escapes. E. g. C<q{This is
 not a closing curly brace → \}, but this is → }> returning "This is
-not a closing curly brace → }, but this is →". As in Perl 5, you can
+not a closing curly brace → }, but this is →". As in Perl 5, you can
 get this behavior with single quotes.
 
 C<qq> allows interpolation of variables. However, by default, only
@@ -248,25 +248,25 @@ interpolate, you need to put square brackets after them. E. g. C<< @a =
 example@example.com". Hashes interpolate in a possibly unexpected
 manner: C<< %a = 1 => 2, 3 => 4;say "%a[]"; >> results in a space
 separating the pairs and tabs separating the key from the value in each
-pair (apparently). You can also interpolate Perl 6 code in strings using
+pair (apparently). You can also interpolate Perl 6 code in strings using
 curly braces. For all the details, see
 L<Interpolation|/language/quoting#Interpolation%3A_qq>.
 
-C<qw> works as in Perl 5, and can also be rendered as C<< <...> >>. E.
+C<qw> works as in Perl 5, and can also be rendered as C<< <...> >>. E.
 g. C<qw/a b c/> is equivalent to C<< <a b c> >>.
 
 There is also a version of C<qw> that interpolates, which is C<qqw>. So
 C<my $a = 42;say qqw/$a b c/;> gives you "42 b c".
 
 Shell quoting is available through C<qx>, but you should note that
-backticks do not do shell quoting as in Perl 5, and Perl variables are
+backticks do not do shell quoting as in Perl 5, and Perl variables are
 I<not> interpolated in C<qx> strings. If you need to interpolate Perl
 variables in a shell command string, you can use C<qqx> instead.
 
-The C<qr> operator is gone from Perl 6.
+The C<qr> operator is gone from Perl 6.
 
 C<tr///> is not well documented, but seems to work similarly to how it
-does in Perl 5. The one caveat is that ranges are specified differently.
+does in Perl 5. The one caveat is that ranges are specified differently.
 Instead of using a range "a-z", you would use "a..z", i. e. with Perl's
 range operator. C<tr///> has a method version, which is better
 documented, called C<.trans>. C<.trans> uses a list of pairs, as
@@ -276,7 +276,7 @@ description of the uses of C<.trans> can be found at
 L<https://design.perl6.org/S05.html#Transliteration>. The C<y///>
 equivalent has been done away with.
 
-Heredocs are specified differently in Perl 6. You use C<:to> with your quoting
+Heredocs are specified differently in Perl 6. You use C<:to> with your quoting
 operator, e. g. C<q:to/END/;> would start a heredoc ending with "END".
 Similarly, you get escaping and interpolation based on your quoting operator,
 i. e. literals with C<Q>, backslash escapes with C<q>, and interpolation with
@@ -284,10 +284,10 @@ C<qq>.
 
 =head2 I/O Operators
 
-The full details on Input/Output in Perl 6 can be found at
+The full details on Input/Output in Perl 6 can be found at
 L<io|/language/io>.
 
-As C<< <...> >> is the quote-words construct in Perl 6, C<< <> >> is not
+As C<< <...> >> is the quote-words construct in Perl 6, C<< <> >> is not
 used for reading lines from a file. You can do that by either making an
 C<IO> object from a file name or using an open filehandle and then, in
 either case, calling C<.lines> on it. I. e. either C<my @a =
@@ -305,7 +305,7 @@ for 'huge-csv'.IO.lines -> $line {
 =end code
 
 Note the use of C<< -> >> there. That's part of the Block syntax, and in
-Perl 6 is needed for C<if>, C<for>, C<while>, etc.
+Perl 6 is needed for C<if>, C<for>, C<while>, etc.
 
 If you want to slurp the entire file into a scalar, you would - surprise! -
 use the C<.slurp> method. For instance, C<my $x = "filename".IO.slurp;> or

--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -2,34 +2,34 @@
 
 =TITLE 5to6-perlsyn
 
-=SUBTITLE Perl 5 to Perl 6 guide - syntax
+=SUBTITLE Perl 5 to Perl 6 guide - syntax
 
 perlsyn - Perl syntax
 
 =head1 DESCRIPTION
 
 A (hopefully) comprehensive description of the differences between Perl
-5 and Perl 6 with regards to the syntax elements described in the
+5 and Perl 6 with regards to the syntax elements described in the
 perlsyn document.
 
 =head1 NOTE
 
-I will I<not> be explaining Perl 6 syntax in detail. This document is an
-attempt to guide you from how things work in Perl 5 to the equivalents
-in Perl 6. For full documentation on the Perl 6 syntax, please see the
-Perl 6 documentation.
+I will I<not> be explaining Perl 6 syntax in detail. This document is an
+attempt to guide you from how things work in Perl 5 to the equivalents
+in Perl 6. For full documentation on the Perl 6 syntax, please see the
+Perl 6 documentation.
 
 =head1 Free Form
 
-Perl 6 is still I<largely> free form. However, there are a few instances
+Perl 6 is still I<largely> free form. However, there are a few instances
 where the presence or lack of whitespace is now significant. For
-instance, in Perl 5, you can omit a space following a keyword (e. g.
-C<<while($x < 5)>> or C<my($x, $y)>). In Perl 6, that space is required,
-thus C<<while ($x < 5)>> or C<my ($x, $y)>. In Perl 6, however, you can
+instance, in Perl 5, you can omit a space following a keyword (e. g.
+C<<while($x < 5)>> or C<my($x, $y)>). In Perl 6, that space is required,
+thus C<<while ($x < 5)>> or C<my ($x, $y)>. In Perl 6, however, you can
 omit the parentheses altogether: C<< while $x < 5 >>. This holds for
 C<if>, C<for>, etc.
 
-Oddly, in Perl 5, you can leave spaces between an array or hash and its
+Oddly, in Perl 5, you can leave spaces between an array or hash and its
 subscript, and before a postfix operator. So C<$seen {$_} ++> is valid.
 No more. That would now have to be C<%seen{$_}++>.
 
@@ -40,13 +40,13 @@ See L<Whitespace|/language/5to6-nutshell#Whitespace> for details.
 
 =head2 Declarations
 
-As noted in L<5to6-perlfunc.pod|/language/5to6-perlfunc>, there is no C<undef> in Perl 6. A declared, but
+As noted in L<5to6-perlfunc.pod|/language/5to6-perlfunc>, there is no C<undef> in Perl 6. A declared, but
 uninitialized scalar variable will evaluate to its type. In other words, C<my
 $x;say $x;> will give you "(Any)". C<my Int $y;say $y;> will give you "(Int)".
 
 =head2 Comments
 
-C<#> starts a comment that runs to the end of the line as in Perl 5.
+C<#> starts a comment that runs to the end of the line as in Perl 5.
 
 Embedded comments start with a hash character and a backtick (C<#`>), followed by an
 opening bracketing character, and continue to the matching closing bracketing
@@ -60,15 +60,15 @@ if #`( why would I ever write an inline comment here? ) True {
 
 =end code
 
-As in Perl 5, you can use pod directives to create multiline comments, with
+As in Perl 5, you can use pod directives to create multiline comments, with
 C<=begin comment> before and C<=end comment> after the comment.
 
 =head2 Truth and Falsehood
 
-The one difference between Perl 5 truth and Perl 6 truth is that, unlike Perl
-5, Perl 6 treats the string C<"0"> as true. Numeric C<0> is still false, and
+The one difference between Perl 5 truth and Perl 6 truth is that, unlike Perl
+5, Perl 6 treats the string C<"0"> as true. Numeric C<0> is still false, and
 you can use prefix C<+> to coerce string C<"0"> to numeric to get it to be
-false. Perl 6, additionally has an actual Boolean type, so, in many cases,
+false. Perl 6, additionally has an actual Boolean type, so, in many cases,
 True and False may be available to you without having to worry about what
 values count as true and false.
 
@@ -76,31 +76,31 @@ values count as true and false.
 
 Mostly, statement modifiers still work, with a few exceptions.
 
-First, C<for> loops are exclusively what were known in Perl 5 as
+First, C<for> loops are exclusively what were known in Perl 5 as
 C<foreach> loops and C<for> is not used for C-style C<for> loops in Perl
 6. To get that behavior, you want C<loop>. C<loop> cannot be used as a
 statement modifier.
 
-In Perl 6, you cannot use the form C<do {...} while $x>. You will want
+In Perl 6, you cannot use the form C<do {...} while $x>. You will want
 to replace C<do> in that form with C<repeat>. Similarly for C<do {...}
 until $x>.
 
 =head2 Compound Statements
 
-The big change from Perl 5 is that C<given> is not experimental or disabled by
-default in Perl 6. For the details on C<given> see
+The big change from Perl 5 is that C<given> is not experimental or disabled by
+default in Perl 6. For the details on C<given> see
 L<this page|/language/control#given>.
 
 =head2 Loop Control
 
-C<next>, C<last>, and C<redo> have not changed from Perl 5 to Perl 6.
+C<next>, C<last>, and C<redo> have not changed from Perl 5 to Perl 6.
 
-C<continue>, however, does not exist in Perl 6. You would use a C<NEXT>
+C<continue>, however, does not exist in Perl 6. You would use a C<NEXT>
 block in the body of the loop.
 
 =begin code
 
-# Perl 5
+# Perl 5
 my $str = '';
 for (1..5) {
     next if $_ % 2 == 1;
@@ -110,7 +110,7 @@ continue {
     $str .= ':'
 }
 
-# Perl 6
+# Perl 6
 my $str = '';
 for 1..5 {
     next if $_ % 2 == 1;
@@ -131,13 +131,13 @@ spec completely: C<loop {...}>
 
 =head2 Foreach Loops
 
-In Perl 5, C<for>, in addition to being used for C-style C<for> loops, is a
-synonym for C<foreach>. In Perl 6, C<for> is just used for C<foreach> style
+In Perl 5, C<for>, in addition to being used for C-style C<for> loops, is a
+synonym for C<foreach>. In Perl 6, C<for> is just used for C<foreach> style
 loops.
 
 =head2 Switch Statements
 
-Perl 6 has actual switch statements, provided by C<given> with the individual
+Perl 6 has actual switch statements, provided by C<given> with the individual
 cases handled by C<when> and C<default>. The basic syntax is:
 
 =begin code
@@ -155,7 +155,7 @@ L<here|/language/control#given>.
 
 =head2 Goto
 
-C<goto> I<probably> works similarly in Perl 6 to the way it does in Perl 5.
+C<goto> I<probably> works similarly in Perl 6 to the way it does in Perl 5.
 However, as of this writing, it does not seem to be functional. For what is
 planned for C<goto>, see
 L<https://design.perl6.org/S04.html#The_goto_statement>.
@@ -164,24 +164,24 @@ L<https://design.perl6.org/S04.html#The_goto_statement>.
 
 C<...> (along with C<!!!> and C<???>) are used to create stub
 declarations. This is a bit more complicated than the use of C<...> in
-Perl 5, so you'll probably want to look at
+Perl 5, so you'll probably want to look at
 L<https://design.perl6.org/S06.html#Stub_declarations> for the gory
 details. That said, there doesn't seem to be an I<obvious> reason why it
-shouldn't still fulfill the role it did in Perl 5, despite its role
-being expanded in Perl 6.
+shouldn't still fulfill the role it did in Perl 5, despite its role
+being expanded in Perl 6.
 
 =head2 PODs: Embedded Documentation
 
-Pod has changed between Perl 5 and Perl 6. Probably the biggest
+Pod has changed between Perl 5 and Perl 6. Probably the biggest
 difference is that you need to enclose your pod between C<=begin pod>
 and C<=end pod> directives. There are a few tweaks here and there as
 well. For instance, as I have discovered while writing these documents,
 the vertical bar ("|") is significant in C<< X<> >> codes, and it's not
 clear how to get a literal "|" into them. Your best bet may be to use
-the Perl 6 interpreter to check your pod. You can do this by using the
+the Perl 6 interpreter to check your pod. You can do this by using the
 C<--doc> switch. E. g. C<perl6 --doc Whatever.pod>. This will output any
 problems to standard error. (Depending on how/where you've installed
 perl6, you may need to specify the location of C<Pod::To::Text>.)
-Details on Perl 6 style pod is at L<https://design.perl6.org/S26.html>.
+Details on Perl 6 style pod is at L<https://design.perl6.org/S26.html>.
 
 =end pod

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -2,19 +2,19 @@
 
 =TITLE 5to6-perlvar
 
-=SUBTITLE Perl 5 to Perl 6 guide - special variables
+=SUBTITLE Perl 5 to Perl 6 guide - special variables
 
 =head1 DESCRIPTION
 
-A (hopefully) comprehensive list of Perl 5 Special Variables with their Perl 6
+A (hopefully) comprehensive list of Perl 5 Special Variables with their Perl 6
 equivalents with notes on variations between them where necessary.
 
 =head1 NOTE
 
-I will I<not> be explaining the full use of the Perl 6 variables. This
-document is an attempt to guide you from the Special Variables in Perl 5
-to their equivalents in Perl 6. For full documentation on the Perl 6
-special variables, please see the Perl 6 documentation for those
+I will I<not> be explaining the full use of the Perl 6 variables. This
+document is an attempt to guide you from the Special Variables in Perl 5
+to their equivalents in Perl 6. For full documentation on the Perl 6
+special variables, please see the Perl 6 documentation for those
 variables.
 
 =head1 SPECIAL VARIABLES
@@ -26,9 +26,9 @@ variables.
 =item $_
 
 
-Thankfully, C<$_> is the general default variable as in Perl 5. The
-main difference in Perl 6 seems to be that you can now call methods on
-it. For instance, Perl 5's C<say $_> can be rendered in Perl 6 as
+Thankfully, C<$_> is the general default variable as in Perl 5. The
+main difference in Perl 6 seems to be that you can now call methods on
+it. For instance, Perl 5's C<say $_> can be rendered in Perl 6 as
 C<$_.say>. Furthermore, as it is the default variable, you don't even
 need to use the variable name. The previous example can also be
 achieved by using C<.say>.
@@ -37,12 +37,12 @@ achieved by using C<.say>.
 
 =item @_
 
-As Perl 6 now has function signatures, your arguments can go there, rather
+As Perl 6 now has function signatures, your arguments can go there, rather
 than depending on C<@_> for them. In fact, if you use a function signature, use
 of C<@_> will spit at you telling it cannot override an existing signature.
 
 If, however, you do not use a function signature, C<@_> will contain the
-arguments you pass to the function as it did in Perl 5. Again, as with C<$_>,
+arguments you pass to the function as it did in Perl 5. Again, as with C<$_>,
 you can call methods on it. Unlike C<$_> you cannot assume C<@_> as the
 default variable for those methods to operate on. I. e. C<@_.shift> works,
 C<.shift> does not.
@@ -51,7 +51,7 @@ C<.shift> does not.
 
 =item $"
 
-Currently, there is no equivalent of the List Separator variable in Perl 6.
+Currently, there is no equivalent of the List Separator variable in Perl 6.
 Design document S28 says there isn't one, so you probably don't want to hold
 your breath.
 
@@ -61,14 +61,14 @@ your breath.
 
 =item $$
 
-C<$$> is replaced in Perl 6 by C<$*PID>
+C<$$> is replaced in Perl 6 by C<$*PID>
 
 =item $PROGRAM_NAME
 =item $0
 
-You can access the program name in Perl 6 via C<$*PROGRAM-NAME>.
+You can access the program name in Perl 6 via C<$*PROGRAM-NAME>.
 
-Note: $0 in Perl 6 is the variable holding the first captured value from a
+Note: $0 in Perl 6 is the variable holding the first captured value from a
 match (i. e. capture variables now start from $0 rather than $1).
 
 =item $REAL_GROUP_ID
@@ -77,7 +77,7 @@ match (i. e. capture variables now start from $0 rather than $1).
 
 =item $(
 
-The real group id is provided by C<$*GROUP.Numeric> in Perl 6.
+The real group id is provided by C<$*GROUP.Numeric> in Perl 6.
 C<$*GROUP.Str> returns the group name, rather than its number.
 
 =item $EFFECTIVE_GROUP_ID
@@ -86,7 +86,7 @@ C<$*GROUP.Str> returns the group name, rather than its number.
 
 =item $)
 
-The effective group id does not appear to be currently provided by Perl 6.
+The effective group id does not appear to be currently provided by Perl 6.
 
 =item $REAL_USER_ID
 
@@ -94,7 +94,7 @@ The effective group id does not appear to be currently provided by Perl 6.
 
 =item $<
 
-The real user id is provided by C<$*USER.Numeric> in Perl 6.
+The real user id is provided by C<$*USER.Numeric> in Perl 6.
 C<$*USER.Str> returns the user name, rather than its number.
 
 =item $EFFECTIVE_USER_ID
@@ -103,7 +103,7 @@ C<$*USER.Str> returns the user name, rather than its number.
 
 =item $>
 
-The effective user id does not appear to be currently provided by Perl 6.
+The effective user id does not appear to be currently provided by Perl 6.
 
 =item $SUBSCRIPT_SEPARATOR
 
@@ -111,14 +111,14 @@ The effective user id does not appear to be currently provided by Perl 6.
 
 =item $;
 
-The subscript separator variable is not included in Perl 6. Frankly, if your
-Perl 5 code is using this, it's almost certainly really, really old.
+The subscript separator variable is not included in Perl 6. Frankly, if your
+Perl 5 code is using this, it's almost certainly really, really old.
 
 =item $a
 
 =item $b
 
-C<$a> and C<$b> have no special meaning in Perl 6. C<sort()> does not
+C<$a> and C<$b> have no special meaning in Perl 6. C<sort()> does not
 use them for anything special. They're just regular old variables.
 
 This feature has been extended by having blocks with placeholder
@@ -145,16 +145,16 @@ For more on placeholder variables, see
 L<this page|/language/variables#The_%5E_Twigil>
 =item %ENV
 
-%ENV has been replaced by %*ENV in Perl 6. Note that the keys of this hash may
-not be exactly the same between Perl 5 and Perl 6. As of this writing, the
-only difference seems to be that OLDPWD is missing from Perl 6's %ENV.
+%ENV has been replaced by %*ENV in Perl 6. Note that the keys of this hash may
+not be exactly the same between Perl 5 and Perl 6. As of this writing, the
+only difference seems to be that OLDPWD is missing from Perl 6's %ENV.
 
 =item $OLD_PERL_VERSION
 
 =item $]
 
 The version of perl is returned by C<$*PERL.version>. For the beta this was
-"v6.b" with C<$*PERL> containing "Perl 6 (6.b)".
+"v6.b" with C<$*PERL> containing "Perl 6 (6.b)".
 
 =item $SYSTEM_FD_MAX
 
@@ -166,24 +166,24 @@ become C<$*SYS_FD_MAX>, this has not yet been implemented.
 =item @F
 
 [NEEDS FURTHER RESEARCH] A bit confusing at this point. Design doc S28
-indicates that C<@F> in Perl 5 is replaced by C<@_> in Perl 6, but it's
+indicates that C<@F> in Perl 5 is replaced by C<@_> in Perl 6, but it's
 unclear just how that works. On the other hand, it's currently something of a
-moot point, as the Perl 5 to Perl 6 Translation doc indicates that the C<-a>
+moot point, as the Perl 5 to Perl 6 Translation doc indicates that the C<-a>
 and C<-F> command-line switches are not yet implemented in rakudo.
 
 =item @INC
 
-No longer exists in Perl 6.  Please use "use lib" to manipulate the
+No longer exists in Perl 6.  Please use "use lib" to manipulate the
 module repositories to be searched.  The closest thing to @INC is
 really $*REPO.  But that works completely differently from @INC mostly
-because of the precompilation capabilities of Perl 6.
+because of the precompilation capabilities of Perl 6.
 
      # Print out a list of compunit repositories
      .say for $*REPO.repo-chain;
 
 =item %INC
 
-No longer exists in Perl 6.  Because each Repository is responsible for
+No longer exists in Perl 6.  Because each Repository is responsible for
 remembering which modules have been loaded already. You can get a list
 of all loaded modules (compilation units) like so:
 
@@ -223,14 +223,14 @@ relates at all to the operating system.
 =item %SIG
 
 [NEEDS FURTHER RESEARCH] No equivalent variable. S28 indicates that this
-functionality is dealt with in Perl 6 by event filters and exception
+functionality is dealt with in Perl 6 by event filters and exception
 translation.
 
 =item $BASETIME
 
 =item $^T
 
-Replaced in Perl 6 by C<$*INITTIME>. Unlike in Perl 5, this is not in seconds
+Replaced in Perl 6 by C<$*INITTIME>. Unlike in Perl 5, this is not in seconds
 since epoch, but an C<Instant> object, which is measured in atomic seconds,
 with fractions.
 
@@ -242,13 +242,13 @@ As with C<$]> this has been replaced with C<$*PERL.version>.
 
 =item ${^WIN32_SLOPPY_STAT}
 
-There does not seem to be any analog to this in Perl 6.
+There does not seem to be any analog to this in Perl 6.
 
 =item $EXECUTABLE_NAME
 
 =item $^X
 
-This has been replaced by C<$*EXECUTABLE-NAME>. Confusingly, the Perl 6
+This has been replaced by C<$*EXECUTABLE-NAME>. Confusingly, the Perl 6
 Variables doc says "Favor $*EXECUTABLE because it is not guaranteed that
 the perl executable is in PATH." Confusingly because C<$*EXECUTABLE> is
 an C<IO> object, which does not seem to be what you would want here.
@@ -258,13 +258,13 @@ C<$*EXECUTABLE.Str> would give the desired result, though.
 
 =head3 Performance issues
 
-As shown below, C<$`>, C<$&>, and C<$'> are gone from Perl 6, primarily
+As shown below, C<$`>, C<$&>, and C<$'> are gone from Perl 6, primarily
 replaced by variations on C<$/> and, with their elimination, the
-associated performance issues in Perl 5 do not apply.
+associated performance issues in Perl 5 do not apply.
 
 =item $<I<digits>> ($1, $2, ...)
 
-These existing variables do the same thing in Perl 6 as they do in Perl 5,
+These existing variables do the same thing in Perl 6 as they do in Perl 5,
 except that they now start at C<$0> rather than C<$1>. Furthermore, they are
 synonyms for indexed items in the match variable C<$/>. I. e. C<$0> is equivalent
 to C<$/[0]>, C<$1> is equivalent to C<$/[1]>, etc.
@@ -273,14 +273,14 @@ to C<$/[0]>, C<$1> is equivalent to C<$/[1]>, etc.
 
 =item $&
 
-C<$/> now contains the match object, so the Perl 5 behavior of C<$&> can
+C<$/> now contains the match object, so the Perl 5 behavior of C<$&> can
 be obtained by stringifying it, i. e. C<~$/>. C<$/.Str> also should
 work, but C<~$/> seems to be the consensus preference.
 
 =item ${^MATCH}
 
 Since the former performance issues are done away with, this variable is
-not of use in Perl 6.
+not of use in Perl 6.
 
 =item $PREMATCH
 
@@ -291,7 +291,7 @@ Replaced by C<$/.prematch>.
 =item ${^PREMATCH}
 
 Since the former performance issues are done away with, this variable is
-not of use in Perl 6.
+not of use in Perl 6.
 
 =item $POSTMATCH
 
@@ -302,13 +302,13 @@ Replaced by C<$/.postmatch>.
 =item ${^POSTMATCH}
 
 Since the former performance issues are done away with, this variable is
-not of use in Perl 6.
+not of use in Perl 6.
 
 =item $LAST_PAREN_MATCH
 
 =item $+
 
-Does not exist in Perl 6, but you can get the same information using C<$/[*-
+Does not exist in Perl 6, but you can get the same information using C<$/[*-
 1].Str> (C<$/[*-1]> would be the match object, not the actual string).
 
 If you want to I<understand> why that works, you can look at these documents:
@@ -335,10 +335,10 @@ any implemented variable that matches C<$^N>.
 =item @+
 
 As with most regular expression related variables, this functionality
-is, at least in part, moved to the C<$/> variable in Perl 6. Or, in this
+is, at least in part, moved to the C<$/> variable in Perl 6. Or, in this
 case, the numbered variables that alias to the indexes of it. The offset
 is found by using the C<.to> method. I. e. the first offset is
-C<$/[0].to>, which is synonymous with C<$0.to>. The value Perl 5
+C<$/[0].to>, which is synonymous with C<$0.to>. The value Perl 5
 provides as C<$+[0]> is provided by C<$/.to>.
 
 =item %LAST_PAREN_MATCH
@@ -354,7 +354,7 @@ C<$/{$match}>.
 
 Similarly to C<@+> being replaced by using the C<.to> method, C<@-> is
 replaced by using the C<.from> method on C<$/> and its variations. The
-first offset is C<$/[0].from> or the equivalent C<$0.from>. Perl 5's C<$-
+first offset is C<$/[0].from> or the equivalent C<$0.from>. Perl 5's C<$-
 [0]> is C<$/.from>.
 
 
@@ -438,24 +438,24 @@ C<$*OUT.nl-out>.
 
 =item $|
 
-Currently autoflush is not implemented in Perl 6.
+Currently autoflush is not implemented in Perl 6.
 
 =item ${^LAST_FH}
 
-Not implemented in Perl 6.
+Not implemented in Perl 6.
 
 =head3 Variables related to formats
 
-There are no built-in formats in Perl 6.
+There are no built-in formats in Perl 6.
 
 =head2 Error Variables
 
-Because of how error variables have changed in Perl 6, I will not detail the
+Because of how error variables have changed in Perl 6, I will not detail the
 changes individually.
 
-To quote the Perl 6 docs, "$! is the error variable." That's it. All the
+To quote the Perl 6 docs, "$! is the error variable." That's it. All the
 error variables appear to have been eaten by $!. As with the rest of
-Perl 6, it's likely an object that will return various things depending
+Perl 6, it's likely an object that will return various things depending
 on how you use it. Sadly, at the moment, the documentation for it is
 terribly sparse. It will probably do what you intend, but I'm not guaranteeing
 anything. Hopefully there will be more information in the near future.
@@ -472,12 +472,12 @@ Currently no equivalents for either of these variables.
 
 =item ${^ENCODING}
 
-Although deprecated in Perl 5, this may have some sort of equivalent in
+Although deprecated in Perl 5, this may have some sort of equivalent in
 C<$?ENC>, but this is far from clear.
 
 =item ${^GLOBAL_PHASE}
 
-No Perl 6 equivalent.
+No Perl 6 equivalent.
 
 =item $^H
 
@@ -485,21 +485,21 @@ No Perl 6 equivalent.
 
 =item ${^OPEN}
 
-There may or may not be equivalents of these in Perl 6, but they're internal
+There may or may not be equivalents of these in Perl 6, but they're internal
 and you shouldn't be messing with them in the first place - certainly not if
-your understanding of Perl 6 requires you to read this document...
+your understanding of Perl 6 requires you to read this document...
 
 =item $PERLDB
 
 =item $^P
 
-The chance of the Perl 6 debugger resembling the Perl 5 debugger is slim
+The chance of the Perl 6 debugger resembling the Perl 5 debugger is slim
 at best, and at this point there does not seem to be an equivalent of
 this variable.
 
 =item ${^TAINT}
 
-S28 claims this variable is "pending". Not currently in Perl 6.
+S28 claims this variable is "pending". Not currently in Perl 6.
 
 =item ${^UNICODE}
 
@@ -507,13 +507,13 @@ S28 claims this variable is "pending". Not currently in Perl 6.
 
 =item ${^UTF8LOCALE}
 
-These Unicode-related variables do not appear to exist in Perl 6, but -
+These Unicode-related variables do not appear to exist in Perl 6, but -
 maybe? - could have analogs in C<$?ENC> somewhere. This, however, is
 totally unconfirmed.
 
 =head2 Deprecated and removed variables
 
-It should go without saying that, as these have been removed from Perl 5
-already, there should be no need to tell you how to use them in Perl 6.
+It should go without saying that, as these have been removed from Perl 5
+already, there should be no need to tell you how to use them in Perl 6.
 
 =end pod

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -478,7 +478,7 @@ defined in the Employee class as though they were from the Programmer class.
     =begin code
     my $programmer = Programmer.new(
         salary => 100_000,
-        known_languages => <Perl5 Perl 6 Erlang C++>,
+        known_languages => <Perl5 Perl6 Erlang C++>,
         favorite_editor => 'vim'
     );
 
@@ -556,7 +556,7 @@ significant improvement over Perl 5's default approach
         books           => 'Learning Perl 6',
         utensils        => ('stainless steel pot', 'knife', 'calibrated oven'),
         favorite_editor => 'MacVim',
-        known_languages => <Perl 6>
+        known_languages => <Perl6>
     );
 
     $geek.cook('pizza');

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -2,11 +2,11 @@
 
 =TITLE Classes and Objects
 
-=SUBTITLE A tutorial for creating and using classes in Perl 6
+=SUBTITLE A tutorial for creating and using classes in Perl 6
 
 =comment More descriptive title?
 
-Perl 6 has a rich built in syntax for the definition and use of classes
+Perl 6 has a rich built in syntax for the definition and use of classes
 for object oriented programming, allowing for the definition of state
 (as L<attributes|#State>,) and behaviour (as L<methods|#Methods>,)
 in the objects of a class.
@@ -37,7 +37,7 @@ setting of the attributes of the created object:
 
 You are free, though, to provide your own construction and build
 implementation.  The following, more elaborate, example shows how
-a dependency handler might look in Perl 6.  It showcases custom
+a dependency handler might look in Perl 6.  It showcases custom
 constructors, private and public attributes, methods and various aspects
 of signatures. It's not very much code, and yet the result is interesting
 and, at times, useful.
@@ -94,7 +94,7 @@ X<|classes,has>
 X<|behavior>
 X<|classes,behavior>
 
-Perl 6, like many other languages, uses the C<class> keyword to introduce a
+Perl 6, like many other languages, uses the C<class> keyword to introduce a
 new class.  The block that follows may contain arbitrary code, just as with
 any other block, but classes commonly contain state and behavior
 declarations.  The example code includes attributes (state), introduced
@@ -109,7 +109,7 @@ Declaring a class creates a I<type object> which, by default, is installed
 into the current package (just like a variable declared with C<our> scope).
 This type object is an "empty instance" of the class.  You've already seen
 these in previous chapters. For example, types such as C<Int> and C<Str>
-refer to the type object of one of the Perl 6 built-in classes. The example
+refer to the type object of one of the Perl 6 built-in classes. The example
 above uses the class name C<Task> so that other code can refer to it later,
 such as to create class instances by calling the C<new> method.
 
@@ -173,7 +173,7 @@ X<|accessor methods>
 X<|classes,accessors>
 
 This scalar attribute (with the C<$> sigil) has a type of C<Bool>.  Instead
-of the C<!> twigil, the C<.> twigil is used. While Perl 6 does enforce
+of the C<!> twigil, the C<.> twigil is used. While Perl 6 does enforce
 encapsulation on attributes, it also saves you from writing accessor
 methods.  Replacing the C<!> with a C<.> both declares the attribute
 C<$!done> and an accessor method named C<done>. It's as if you had written:
@@ -339,7 +339,7 @@ namespace, the pseudo package C<GLOBAL> can be used.
 
 X<|constructors>
 
-Perl 6 is rather more liberal than many languages in the area of
+Perl 6 is rather more liberal than many languages in the area of
 constructors.  A constructor is anything that returns an instance of the
 class.  Furthermore, constructors are ordinary methods. You inherit a
 default constructor named C<new> from the base class C<Mu>, but you are
@@ -352,9 +352,9 @@ free to override C<new>, as this example does:
 X<|objects,bless>
 X<|bless>
 
-The biggest difference between constructors in Perl 6 and constructors in
+The biggest difference between constructors in Perl 6 and constructors in
 languages such as C# and Java is that rather than setting up state on a
-somehow already magically created object, Perl 6 constructors actually
+somehow already magically created object, Perl 6 constructors actually
 create the object themselves. The easiest way to do this is by calling the
 L<bless> method, also inherited from L<Mu>. The C<bless> method expects a
 set of named parameters providing the initial values for each attribute.
@@ -445,7 +445,7 @@ on the various other dependencies in order, giving the output:
 X<|is (inheritance)>
 
 Object Oriented Programming provides the concept of inheritance as one of
-the mechanisms to allow for code reuse.  Perl 6 supports the ability for one
+the mechanisms to allow for code reuse.  Perl 6 supports the ability for one
 class to inherit from one or more classes.  When a class inherits from
 another class it informs the method dispatcher to follow the inheritance
 chain to look for a method to dispatch.  This happens both for standard
@@ -478,7 +478,7 @@ defined in the Employee class as though they were from the Programmer class.
     =begin code
     my $programmer = Programmer.new(
         salary => 100_000,
-        known_languages => <Perl5 Perl6 Erlang C++>,
+        known_languages => <Perl5 Perl 6 Erlang C++>,
         favorite_editor => 'vim'
     );
 
@@ -539,9 +539,9 @@ attributes.
 
 As mentioned before, a class can inherit from multiple classes.  When a
 class inherits from multiple classes the dispatcher knows to look at both
-classes when looking up a method to search for.  Perl 6 uses the C3
+classes when looking up a method to search for.  Perl 6 uses the C3
 algorithm to linearize multiple inheritance hierarchies, which is a
-significant improvement over Perl 5's default approach
+significant improvement over Perl 5's default approach
 (depth-first search) to handling multiple inheritance.
 
     =begin code
@@ -553,10 +553,10 @@ significant improvement over Perl 5's default approach
     }
 
     my $geek = GeekCook.new(
-        books           => 'Learning Perl 6',
+        books           => 'Learning Perl 6',
         utensils        => ('stainless steel pot', 'knife', 'calibrated oven'),
         favorite_editor => 'MacVim',
-        known_languages => <Perl6>
+        known_languages => <Perl 6>
     );
 
     $geek.cook('pizza');

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Concurrency and Asynchronous Programming
 
-In common with most modern programming languages, Perl 6 is designed to
+In common with most modern programming languages, Perl 6 is designed to
 L<support concurrency|https://en.wikipedia.org/wiki/Concurrent_computing>
 (allowing more than one thing to happen at the same time) and
 asynchronous programming (sometimes called event driven or reactive

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -2,16 +2,16 @@
 
 =TITLE Containers
 
-=SUBTITLE A low-level explanation of Perl 6 containers
+=SUBTITLE A low-level explanation of Perl 6 containers
 
 This article started as a conversation on IRC explaining the difference
-between the C<Array> and the C<List> type in Perl 6. It explains the levels
+between the C<Array> and the C<List> type in Perl 6. It explains the levels
 of indirection involved in dealing with variables and container elements.
 
 =head1 What is a variable?
 
 Some people like to say "everything is an object", but in fact a variable is
-not a user-exposed object in Perl 6.
+not a user-exposed object in Perl 6.
 
 When the compiler encounters a variable declaration like C<my $x>, it
 registers it in some internal symbol table. This internal symbol table is
@@ -28,7 +28,7 @@ container>.
 
 =head1 Scalar containers
 
-Although objects of type C<Scalar> are everywhere in Perl 6, you rarely
+Although objects of type C<Scalar> are everywhere in Perl 6, you rarely
 see them directly as objects, because most operations
 I<decontainerize>, which means they act on the C<Scalar> container's
 contents instead of the container itself.
@@ -95,7 +95,7 @@ container:
 
 =head1 Binding
 
-Next to assignment, Perl 6 also supports I<binding> with the C<:=> operator.
+Next to assignment, Perl 6 also supports I<binding> with the C<:=> operator.
 When binding a value or a container to a variable, the lexpad entry of the
 variable is modified (and not just the container it points to). If you write
 
@@ -138,7 +138,7 @@ Sigilless variables also bind by default and so do parameters with the trait C<i
 =head1 Scalar containers and listy things
 
 There are a number of positional container types with slightly different
-semantics in Perl 6. The most basic one is L<List|/type/List>
+semantics in Perl 6. The most basic one is L<List|/type/List>
 It is created by the comma operator.
 
     say (1, 2, 3).^name;    # List
@@ -193,7 +193,7 @@ To place a non-C<Array> into an array variable, binding works:
 
 =head1 Binding to array elements
 
-As a curious side note, Perl 6 supports binding to array elements:
+As a curious side note, Perl 6 supports binding to array elements:
 
     my @a = (1, 2, 3);
     @a[0] := my $x;
@@ -227,7 +227,7 @@ a thing happening accidentally.
 
 =head1 Flattening, items and containers
 
-The C<%> and C<@> sigils in Perl 6 generally indicate multiple values
+The C<%> and C<@> sigils in Perl 6 generally indicate multiple values
 to an iteration construct, whereas the C<$> sigil indicates only one value.
 
     my @a = 1, 2, 3;
@@ -235,7 +235,7 @@ to an iteration construct, whereas the C<$> sigil indicates only one value.
     my $a = (1, 2, 3);
     for $a { };         # 1 iteration
 
-Contrary to earlier versions of Perl 6, and to Perl 5, C<@>-sigiled variables
+Contrary to earlier versions of Perl 6, and to Perl 5, C<@>-sigiled variables
 do not flatten in list context:
 
     my @a = 1, 2, 3;
@@ -271,12 +271,12 @@ maps over a list of three elements, not of one.
 
 =head1 Custom containers
 
-To provide custom containers Perl 6 provides the class C<Proxy>. It takes two
+To provide custom containers Perl 6 provides the class C<Proxy>. It takes two
 methods that are called when values are stored or fetched from the container.
 Type checks are not done by the container itself and other restrictions like
 readonlyness can be broken. The returned value must therefore be of the same
 type as the type of the variable it is bound to. We can use type captures to
-work with types in Perl 6.
+work with types in Perl 6.
 
     sub lucky(::T $type) {
         my T $c-value; # closure variable

--- a/doc/Language/contributors.pod6
+++ b/doc/Language/contributors.pod6
@@ -2,10 +2,10 @@
 
 =TITLE Contributors
 
-=SUBTITLE List of contributors to Perl 6 over the years
+=SUBTITLE List of contributors to Perl 6 over the years
 
-The following people contributed to the development of Perl 6, as could be
-determined from the logs of all the various projects that make up Perl 6.
+The following people contributed to the development of Perl 6, as could be
+determined from the logs of all the various projects that make up Perl 6.
 If you think you are missing from this list, or for any reason would not
 like to appear on this list, or need a correction, please submit a
 L<Pull Request|/language/glossary#Pull_Request> with the required change(s).

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -6,7 +6,7 @@
 
 =head1 X<statements|control flow>
 
-Perl 6 programs consists of one or more statements.  Simple statements
+Perl 6 programs consists of one or more statements.  Simple statements
 are separated by semicolons.  The following program will say "Hello"
 and then say "World" on the next line.
 
@@ -23,7 +23,7 @@ also be written as:
 
 =head1 X<blocks|control flow>
 
-Like many languages, Perl 6 uses C<blocks> enclosed by C<{> and C<}> to turn
+Like many languages, Perl 6 uses C<blocks> enclosed by C<{> and C<}> to turn
 multiple statements into a single statement.  It is ok to skip the semicolon
 between the last statement in a block and the closing C<}>.
 
@@ -410,7 +410,7 @@ from within C<gather>:
 
 =head1 X<given|control flow>
 
-The C<given> statement is Perl 6's topicalizing keyword in a similar way that
+The C<given> statement is Perl 6's topicalizing keyword in a similar way that
 C<switch> topicalizes in languages such as C.  In other words, C<given>
 sets C<$_> inside the following block.  The keywords for individual cases
 are C<when> and C<default>.  The usual idiom looks like this:

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -2,9 +2,9 @@
 
 =TITLE Exceptions
 
-=SUBTITLE Using exceptions in Perl 6
+=SUBTITLE Using exceptions in Perl 6
 
-Exceptions in Perl 6 are a special kind of object used to signify when
+Exceptions in Perl 6 are a special kind of object used to signify when
 something has gone wrong, for instance, unexpected data was received, a
 network connection is no longer available, or a file is missing which was
 expected to exist.
@@ -15,7 +15,7 @@ backtrace printer.
 
 =head1 Ad-hoc exceptions
 
-Ad-hoc exceptions work just like in traditional Perl 5, one can simply use
+Ad-hoc exceptions work just like in traditional Perl 5, one can simply use
 C<die> with a message as to what went wrong:
 
     die "oops, something went wrong";

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -36,7 +36,7 @@ Mac users can use the latest Rakudo Star DMG binary installer at
 L<http://rakudo.org/downloads/star>
 
 Windows users can use the Rakudo Star MSI binary installer. You will need
-Windows Git and Strawberry Perl 5 to use panda to install library modules.
+Windows Git and Strawberry Perl 5 to use panda to install library modules.
 
 Linux users probably want to download Rakudo Star and follow the compilation
 instructions at L<http://www.perl6.org/downloads/>
@@ -50,7 +50,7 @@ L<https://hub.docker.com/_/rakudo-star/>
 =head2 As an intermediate to advanced user I want to track Rakudo development.
 
 Install L<rakudobrew|https://github.com/tadzik/rakudobrew> which resembles
-Perl 5's perlbrew and the equivalent Python and Ruby tools.
+Perl 5's perlbrew and the equivalent Python and Ruby tools.
 
 =head2 Where can I find good documentation on Perl 6?
 
@@ -76,7 +76,7 @@ is the measure of how complete a Perl 6 implementation is.
 
 Yes, see L<glossary|/language/glossary>.
 
-=head2 I'm a Perl 5 programmer. Where is a list of differences between Perl 5 and 6?
+=head2 I'm a Perl 5 programmer. Where is a list of differences between Perl 5 and 6?
 
 See the '5to6-nutshell' pod under L<https://docs.perl6.org/language/5to6-nutshell>
 and related pages.
@@ -95,12 +95,12 @@ modules called the "ecosystem" hosted on github, and
 L<panda|https://github.com/tadzik/panda/> can install those that work with
 L<rakudo|http://rakudo.org/>.
 
-Support for installing Perl 6 modules from the Perl 5 CPAN is on its way.
+Support for installing Perl 6 modules from the Perl 5 CPAN is on its way.
 
-=head2 Can I use Perl 5 modules from Perl 6?
+=head2 Can I use Perl 5 modules from Perl 6?
 
 Yes, with L<Inline::Perl5|https://github.com/niner/Inline-Perl5/>, which works
-well with most Perl 5 modules. It can even run Perl 5 Catalyst and DBI.
+well with most Perl 5 modules. It can even run Perl 5 Catalyst and DBI.
 
 =head2 Can I use C and C++ from Perl 6?
 
@@ -133,7 +133,7 @@ compilation unit.
 
 =head1 Language Features
 
-=head2 How can I dump Perl 6 data structures (like Perl 5 Data::Dumper and similar)?
+=head2 How can I dump Perl 6 data structures (like Perl 5 Data::Dumper and similar)?
 
 Examples:
 
@@ -279,7 +279,7 @@ information.
 =head2 What's up with array references and automatic dereferencing? Do I still need the C<@> sigil?
 
 In Perl 6, nearly everything is a reference, so talking about taking
-references doesn't make much sense. Unlike Perl 5, scalar variables
+references doesn't make much sense. Unlike Perl 5, scalar variables
 can also contain arrays directly:
 
     my @a = 1, 2, 3;
@@ -456,7 +456,7 @@ the exception with the C<exception> method.
 
 =head2 Why is C<wantarray> or C<want> gone? Can I return different things in different contexts?
 
-Perl 5 has the L<C<wantarray>|/language/5to6-perlfunc#wantarray> function that
+Perl 5 has the L<C<wantarray>|/language/5to6-perlfunc#wantarray> function that
 tells you whether it is called in void, scalar or list context. Perl 6 has no
 equivalent construct, because context does not flow inwards, i.e. a routine would need
 time travel to know which context it is called in because context is lazy, known
@@ -578,7 +578,7 @@ them offer all.
 
 =item Interfacing to external libraries in C / C++ are trivially simple with NativeCall.
 
-=item Interfacing with Perl 5 (CPAN) / Python modules trivially simple with Inline::Perl5 and Inline::Python.
+=item Interfacing with Perl 5 (CPAN) / Python modules trivially simple with Inline::Perl5 and Inline::Python.
 
 =item Can have multiple versions of a module installed and loaded simultaneously.
 
@@ -630,15 +630,15 @@ things already but needs work on others.  Since the Christmas 2015 release stabi
 the definition of the language, we're spending much of our effort on optimizing in 2016.
 Since Perl 6 provides lots of clues to the JIT that other dynamic languages don't, we think
 we'll have a lot of headroom for performance improvements.  Some things already
-run faster than Perl 5.
+run faster than Perl 5.
 
-Perl 5 programmers should be aware that Perl 6 comes with more built-in
+Perl 5 programmers should be aware that Perl 6 comes with more built-in
 functionality.  Simple benchmarks will be misleading unless you include
-things like Moose, type checking modules etc. in your Perl 5 script.
+things like Moose, type checking modules etc. in your Perl 5 script.
 
 The following crude benchmarks, with all the usual caveats about such things,
-can show Perl 6 can be faster than Perl 5 for some similar common tasks if
-the big weaponry is included, but at the same time Perl 5 can be much faster
+can show Perl 6 can be faster than Perl 5 for some similar common tasks if
+the big weaponry is included, but at the same time Perl 5 can be much faster
 if only the bare bones are included.
 
 Try it on your system you may be pleasantly surprised!
@@ -655,7 +655,7 @@ Examples:
         $obj.i = $i;
     }
 
-    # Perl 5 version
+    # Perl 5 version
     package Foo;
     use Moose;
 
@@ -670,7 +670,7 @@ Examples:
 
     1;
 
-    # Another Perl 5 version that offers bare-bones set of features
+    # Another Perl 5 version that offers bare-bones set of features
     # compared to Moose/Perl 6's version but those are not needed in this
     # specific, simple program anyway.
     package Foo;

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -2,9 +2,9 @@
 
 =TITLE Functions
 
-=SUBTITLE Functions and Functional Programming in Perl 6
+=SUBTITLE Functions and Functional Programming in Perl 6
 
-Routines are the smallest means of code reuse in Perl 6. They come in several
+Routines are the smallest means of code reuse in Perl 6. They come in several
 forms, most notably methods, which belong in classes and roles and are
 associated with an object, and functions, also called I<subroutines> or short
 I<sub>s, which exist independently of objects.
@@ -149,7 +149,7 @@ one to skip commas between named arguments.
 
 =head2 X<Multi-dispatch|declarator,multi>
 
-Perl 6 allows you to write several routines with the same name, but different
+Perl 6 allows you to write several routines with the same name, but different
 signatures. When the routine is called by name, the runtime environment
 decides which is the best match, and calls that I<candidate>. You declare
 each candidate with the C<multi> declarator.
@@ -499,7 +499,7 @@ prefix the operator name with a C<&>-sigil.
 
 =head2 Precedence
 
-Operator precedence in Perl 6 is specified relatively to existing operators.
+Operator precedence in Perl 6 is specified relatively to existing operators.
 With C<is tighter(&other-operator)> you can squeeze in an operator with a
 tighter precedence than the one you specified, but looser than the
 next-tighter precedence level.
@@ -554,7 +554,7 @@ exponentiation/power operator, C<< infix:<**> >>:
     say 2 ** (2 ** 3);      # 256
     say (2 ** 2) ** 3;      # 64
 
-Perl 6 has the following possible associativity configurations:
+Perl 6 has the following possible associativity configurations:
 
 =begin table
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -2,13 +2,13 @@
 
 =TITLE Glossary
 
-=SUBTITLE Glossary of Perl 6 terminology
+=SUBTITLE Glossary of Perl 6 terminology
 
 =head1 Abstract Class
 X<|Abstract Class>
 
 The generic Computer Science term "abstract class" defines the
-L<interface|#Interface> or L<#API> of a class.  In Perl 6, this is
+L<interface|#Interface> or L<#API> of a class.  In Perl 6, this is
 implemented using roles with L<stubbed|#Stub> methods.
 
     role Canine {
@@ -22,7 +22,7 @@ implemented using roles with L<stubbed|#Stub> methods.
 =head1 Advent Calendar
 X<|Advent Calendar>
 
-In the context of Perl 6, a yearly set of blog posts for each day from
+In the context of Perl 6, a yearly set of blog posts for each day from
 the 1st until the 25th of December, to be found at
 L<https://perl6advent.wordpress.com>.
 
@@ -176,7 +176,7 @@ X<|bytecode>
 =head1 Camelia
 X<|Camelia>
 
-A butterfly image intended primarily to represent Perl 6, The Language.
+A butterfly image intended primarily to represent Perl 6, The Language.
 
 =head1 Colon Pair and Colon List
 X<|Color Pair> X<|Colon List>
@@ -275,7 +275,7 @@ An interface is an L<abstract class|#Abstract Class>.
 =head1 IRC
 X<|IRC>
 
-Internet Relay Chat.  Perl 6 developers and users usually hang out on the
+Internet Relay Chat.  Perl 6 developers and users usually hang out on the
 C<#perl6> channel of C<irc.freenode.org>. Currently available bots are:
 
 =head2 camelia
@@ -292,7 +292,7 @@ This is a handy tool for showing people if the output is (un)expected.
 X<|dalek>
 
 The L<#Bot> on the #perl6 L<#IRC> channel that reports changes made to
-various Perl 6 related L<repositories|#Repository>.
+various Perl 6 related L<repositories|#Repository>.
 
   [15:46:40] <+dalek> doc: 2819f25 | lizmat++ | doc/Language/glossary.pod:
   [15:46:40] <+dalek> doc: Add stubs for stuff inside the glossary already
@@ -328,7 +328,7 @@ input methods.
 
 =head1 IRC Lingo
 
-The following terms are often used on the Perl 6 related L<#IRC> channels:
+The following terms are often used on the Perl 6 related L<#IRC> channels:
 
 =head2 ALAP
 X<|ALAP>
@@ -420,7 +420,7 @@ Short for "problem".  As in "that's not the pb".
 X<|PBP>
 
 "Perl Best Practices".  The book by Damian Conway outlining best practices
-when programming Perl 5.
+when programming Perl 5.
 
 =head2 PR
 X<|PR>
@@ -430,12 +430,12 @@ See L<#Pull Request>.
 =head2 P5
 X<|P5>
 
-Perl 5
+Perl 5
 
 =head2 P6
 X<|P6>
 
-Perl 6
+Perl 6
 
 =head2 RSN
 X<|RSN>
@@ -579,7 +579,7 @@ X<|multi-method>
 =head1 Niecza
 X<|Niecza>
 
-An implementation of Perl 6 targeting the .NET platform.  No longer actively
+An implementation of Perl 6 targeting the .NET platform.  No longer actively
 maintained.
 
 =head1 Not Quite Perl
@@ -591,7 +591,7 @@ See L<#NQP>.
 X<|Not Quite Perl>
 
 NQP is a primitive language for writing subroutines and methods using a
-subset of the Perl 6 syntax.  It's not intended to be a full-fledged
+subset of the Perl 6 syntax.  It's not intended to be a full-fledged
 programming language, nor does it provide a runtime environment beyond
 the basic VM primitives.  Compilers (such as L<#Rakudo> typically use
 NQP to compile action methods that convert a parse tree
@@ -615,7 +615,7 @@ syntax, what would be the arguments of the function are named
 operands instead. Operators are classified into
 L<categories|https://design.perl6.org/S02.html#Grammatical_Categories> of
 categories.  A category has a precedence, an arity, and can be L<#fiddly>,
-L<#iffy>, L<#diffy>.  Perl 6 is very creative as to what is an operator, so
+L<#iffy>, L<#diffy>.  Perl 6 is very creative as to what is an operator, so
 there are many categories.  Operators are made of many tokens, possibly with
 a subexpression.  For example, C<@a[0]> belongs to the postcircumfix
 category, is broken into the operand C<@a> and the postcircumfix operator
@@ -648,7 +648,7 @@ subroutine/method/callable block.
 =head1 Parrot
 X<|Parrot>
 
-A L<virtual machine|#Virtual Machine> designed to run Perl 6 and other
+A L<virtual machine|#Virtual Machine> designed to run Perl 6 and other
 dynamic languages.  No longer actively maintained.
 
 =head1 PAST
@@ -659,7 +659,7 @@ L<#Parrot> AST.
 =head1 perl
 X<|perl>
 
-Name of the Perl 5 executor.
+Name of the Perl 5 executor.
 
 =head1 Perl
 X<|Perl>
@@ -698,7 +698,7 @@ Successor to L<#QAST>.
 =head1 Rakudo
 X<|Rakudo>
 
-Rakudo is the name of a Perl 6 implementation that runs on L<#MoarVM> and
+Rakudo is the name of a Perl 6 implementation that runs on L<#MoarVM> and
 the JVM.  It is an abbreviation of "Rakuda-do," which, when translated
 from Japanese, means "The Way of the Camel".  Also, in Japanese, "Rakudo"
 means "Paradise."
@@ -709,9 +709,9 @@ X<|Repository>
 =head1 roast
 X<|roast>
 
-The Perl 6 L<specification tests|#test suite>, which live here:
+The Perl 6 L<specification tests|#test suite>, which live here:
 L<https://github.com/perl6/roast/>.  Originally developed for L<#pugs>, it
-now serves all Perl 6 implementations.  Why roast? It's the B<r>epository
+now serves all Perl 6 implementations.  Why roast? It's the B<r>epository
 B<o>f B<a>ll B<s>pec B<t>ests.
 
 =head1 rule
@@ -750,10 +750,10 @@ bytecode.
 =head1 STD
 X<|STD>
 
-STD.pm is the "standard" Perl 6 grammar definition, see
-L<https://github.com/perl6/std/> that was used to implement Perl 6.
+STD.pm is the "standard" Perl 6 grammar definition, see
+L<https://github.com/perl6/std/> that was used to implement Perl 6.
 STD.pm is no longer really a "specification" in a proscriptive sense:
-it's more of a guideline or model for Perl 6 implementations to follow.
+it's more of a guideline or model for Perl 6 implementations to follow.
 
 =head1 Stub
 X<|Stub>
@@ -762,14 +762,14 @@ X<|Stub>
 X<|Symbol>
 
 Fancy alternative way to denote a name. Generally used in the context of
-L<module|/language/modules>s linking, be it in the L<#OS> level, or at the Perl 6 L<#Virtual Machine> level
+L<module|/language/modules>s linking, be it in the L<#OS> level, or at the Perl 6 L<#Virtual Machine> level
 for modules generated from languages targeting these VMs.  The set of
 imported or exported symbols is called the symbol table.
 
 =head1 Synopsis
 X<|Synopsis>
 
-The current human-readable description of the Perl 6 language.  Still in
+The current human-readable description of the Perl 6 language.  Still in
 development.  Much more a community effort than the L<Apocalypses|#Apocalypse>
 and L<Exegeses|#Exegesis> were. The current state of the language is reflected
 by L<#roast>, its L<#test suite>, not the synopses where speculative material
@@ -782,7 +782,7 @@ X<|Syntax Analysis>
 =head1 test suite
 X<|test suite>
 
-The Perl 6 test suite is L<#roast>
+The Perl 6 test suite is L<#roast>
 
 =head1 Texas operator
 X<|Texas operator>
@@ -828,7 +828,7 @@ X<|Virtual Machine>
 A virtual machine is the Perl compiler entity that executes the
 L<bytecode|#Bytecode>.  It can optimize the bytecode or generate
 machine code Just in Time.  Examples are
-L<#MoarVM>, L<#Parrot> (who are intended to run Perl 6) and more
+L<#MoarVM>, L<#Parrot> (who are intended to run Perl 6) and more
 generic virtual machines such as L<#JVM> and Javascript.
 
 =head1 whitespace

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -7,9 +7,9 @@
 Grammars are a powerful tool used to destructure text and often to return
 data structures that have been created by interpreting that text.
 
-For example, Perl 6 is parsed and executed using a Perl 6-style grammar.
+For example, Perl 6 is parsed and executed using a Perl 6-style grammar.
 
-An example that's more practical to the common Perl 6 user is the
+An example that's more practical to the common Perl 6 user is the
 L<JSON::Tiny module|https://github.com/moritz/json>, which can deserialize
 any valid JSON file, however the deserializing code is written in less than
 100 lines of simple, extensible code.
@@ -21,7 +21,7 @@ methods of regular code.
 =head1 X<Named Regexes|declarator,regex;declarator,token;declarator,rule>
 
 The main ingredient of grammars is named L<regexes|/language/regexes>.
-While the syntax of L<Perl 6 Regexes|/language/regexes> is outside the scope
+While the syntax of L<Perl 6 Regexes|/language/regexes> is outside the scope
 of this document, I<named> regexes have a special syntax, similar to
 subroutine definitions:N<In fact, named regexes can even take extra
 arguments, using the same syntax as subroutine parameter lists>

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -8,7 +8,7 @@ X<|IPC>
 
 =head1 X<running|running programs>
 
-Many programs need to be able to run other programs. Running a program in Perl 6
+Many programs need to be able to run other programs. Running a program in Perl 6
 is as easy as:
 
     run 'git', 'status';

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -6,8 +6,8 @@
 
 Lists have been a central part of computing since before there
 were computers, during which time many devils have taken up residence in
-their details. They were actually one of the hardest parts of Perl 6
-to design, but through persistence and patience, Perl 6 has arrived with
+their details. They were actually one of the hardest parts of Perl 6
+to design, but through persistence and patience, Perl 6 has arrived with
 an elegant system for handling them.
 
 =head1 Literal Lists
@@ -43,7 +43,7 @@ first element of a list is at index number zero:
 
 =head1 The @ sigil
 
-Variables in Perl 6 whose names bear the C<@> sigil are expected to
+Variables in Perl 6 whose names bear the C<@> sigil are expected to
 contain some sort of list-like object. Of course, other variables may
 also contain these objects, but C<@>-sigiled variables always do, and
 are expected to act the part.
@@ -106,9 +106,9 @@ As it so happens, loops return C<Seq>s.
 
     (loop { 42.say })[2] # says 42 three times
 
-So, it is fine to have infinite lists in Perl 6, just so long as you never
+So, it is fine to have infinite lists in Perl 6, just so long as you never
 ask them for all their elements.  In some cases, you may want to avoid
-asking them how long they are too -- Perl 6 will try to return C<Inf> if
+asking them how long they are too -- Perl 6 will try to return C<Inf> if
 it knows a sequence is infinite, but it cannot always know.
 
 =comment TODO link or describe C<...>
@@ -399,7 +399,7 @@ good practice to perform additional type checks, where it matters:
 However, as long as you stick to normal assignment operations inside a trusted
 area of code, this will not be a problem, and typecheck errors will happen
 promptly during assignment to the array, if they cannot be caught at compile
-time.  None of the core functions provided in Perl 6 for operating on lists
+time.  None of the core functions provided in Perl 6 for operating on lists
 should ever produce a wonky typed Array.
 
 Nonexistent elements (when indexed), or elements to which C<Nil> has been assigned,
@@ -441,10 +441,10 @@ Arrays.
 
 For most uses, Arrays consist of a number of slots each containing a C<Scalar> of
 the correct type.  Each such C<Scalar>, in turn, contains a value of that type.
-Perl 6 will automatically type-check values and create Scalars to contain them
+Perl 6 will automatically type-check values and create Scalars to contain them
 when Arrays are initialized, assigned to, or constructed.
 
-This is actually one of the trickiest parts of Perl 6 list handling to get a
+This is actually one of the trickiest parts of Perl 6 list handling to get a
 firm understanding of.
 
 First, be aware that because itemization in Arrays is assumed, it essentially
@@ -481,7 +481,7 @@ by hand to undo the nesting:
 
     say gather [0, [(1, 2), [3, 4]], $(5, 6)].deepmap: *.take; # (1 2 3 4 5 6)
 
-...future versions of Perl 6 might find a way to make this easier.  However,
+...future versions of Perl 6 might find a way to make this easier.  However,
 not returning Arrays or itemized lists from functions, when non-itemized lists
 are sufficient, is something that one should consider as a courtesy to their
 users:

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -4,8 +4,8 @@
 
 =SUBTITLE What can help you write/test/improve your module(s)
 
-Here is a list of modules that you can find in the Perl 6 ecosystem
-which aim to make the experience of developing Perl 6 modules
+Here is a list of modules that you can find in the Perl 6 ecosystem
+which aim to make the experience of developing Perl 6 modules
 more fun.
 
 
@@ -14,8 +14,8 @@ more fun.
 Some modules and tools to help you with generating files that are part
 of a module distribution.
 
-=item L<App::Mi6|https://modules.perl6.org/dist/App::Mi6>     Minimal authoring tool for Perl6
-=item L<META6|https://modules.perl6.org/dist/META6>        Do things with Perl 6 META files
+=item L<App::Mi6|https://modules.perl6.org/dist/App::Mi6>     Minimal authoring tool for Perl 6
+=item L<META6|https://modules.perl6.org/dist/META6>        Do things with Perl 6 META files
 =item L<Module::Skeleton|https://bitbucket.org/rightfold/module-skeleton>        Generate a skeleton module
 =item L<p6doc|https://modules.perl6.org/dist/p6doc>        Generate documentation end-products
 

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Modules
 
-=SUBTITLE How to create, use and distribute Perl 6 modules
+=SUBTITLE How to create, use and distribute Perl 6 modules
 
 =head1 Creating and Using Modules
 
@@ -10,18 +10,18 @@ A module is usually a source file or set of source filesN<Technically
 a module is a set of I<compunits> which are usually files but could
 come from anywhere as long as there is a I<compunit repository> that
 can provide it. See L<S11|https://design.perl6.org/S11.html>.> that
-expose Perl 6 constructs. These are typically packages
+expose Perl 6 constructs. These are typically packages
 (L<classes|/language/objects#Classes>,
 L<roles|/language/objects#Roles>, L<grammars|Grammar>),
 L<subroutines|/language/functions>, and sometimes
-L<variables|/language/variables>. In Perl 6 I<module> can also refer
+L<variables|/language/variables>. In Perl 6 I<module> can also refer
 to a type of package declared with the C<module> keyword (see example
 below) but here we mostly mean "module" as a set of source
 files in a namespace.
 
 =head2 Basic Structure
 
-Module distributions (in the I<set of related source files> sense) in Perl 6
+Module distributions (in the I<set of related source files> sense) in Perl 6
 have the same structure as any distribution in the Perl family of languages:
 there is a main project directory containing a C<README> and a C<LICENSE> file,
 a C<lib> directory for the source filesE<mdash>which may be individually
@@ -32,7 +32,7 @@ directory for executable programs and scripts.
 
 Source files generally use the standard C<.pm> extension, and scripts or
 executables use C<.pl>.  However, if you wish to highlight that the file is
-written in Perl 6 you can use the C<.pm6> extension for modules, and the
+written in Perl 6 you can use the C<.pm6> extension for modules, and the
 C<.p6> extension for scripts.  Test files still use the normal C<.t>
 extension.
 
@@ -164,7 +164,7 @@ tags: C<ALL>, C<DEFAULT> and C<MANDATORY>.
 Beneath the surface, C<is export> is adding the symbols to a C<UNIT>
 scoped package in the C<EXPORT> namespace. For example, C<is
 export(:FOO)> will add the target to the C<UNIT::EXPORT::FOO>
-package. This is what Perl 6 is really using to decide what to import.
+package. This is what Perl 6 is really using to decide what to import.
 
     =begin code
     unit module MyModule;
@@ -328,12 +328,12 @@ locations.  For example:
     export PERL6LIB=/path/to/my-modules,/path/to/more/modules
 
 Note that the comma (',') is used as the directory separator (instead
-of the colon (':') as with Perl 5 for C<PERL5LIB> or C<PERLLIB>).
+of the colon (':') as with Perl 5 for C<PERL5LIB> or C<PERLLIB>).
 
 =head1 Distributing Modules
 
-If you've written a Perl 6 module and would like to share it with the
-community, we'd be delighted to have it listed in the L<Perl 6 modules
+If you've written a Perl 6 module and would like to share it with the
+community, we'd be delighted to have it listed in the L<Perl 6 modules
 directory|https://modules.perl6.org>. C<:)>
 
 For now, the process requires that you use git for your module's version
@@ -387,19 +387,19 @@ To share your module, do the following:
     text file, which will later be automatically rendered as HTML by GitHub.
 
     =item Regarding the C<LICENSE> file, if you have no other preference,
-    you might just use the same one that Rakudo Perl 6 uses. Just
+    you might just use the same one that Rakudo Perl 6 uses. Just
     copy/paste the raw form of L<its license|https://github.com/rakudo/rakudo/blob/nom/LICENSE>
     into your own C<LICENSE> file.
 
     =item If you don't yet have any tests, you can leave out the C<t>
     directory and C<basic.t> file for now. For more info on how to write
     tests (for now), you might have a look at how other modules use
-    C<Test>. It's quite similar to Perl 5's C<Test::More>.
+    C<Test>. It's quite similar to Perl 5's C<Test::More>.
 
-    =item To document your modules, use L<Perl 6 Pod |
+    =item To document your modules, use L<Perl 6 Pod |
     https://design.perl6.org/S26.html> markup inside your modules. Module
     documentation is most appreciated and will be especially important once
-    the Perl 6 module directory (or some other site) begins rendering Pod docs
+    the Perl 6 module directory (or some other site) begins rendering Pod docs
     as HTML for easy browsing.
     N«
         Note, described above is a minimal project directory. If your project
@@ -480,10 +480,10 @@ To share your module, do the following:
     view the log file at L<https://modules.perl6.org/update.log> to see
     if it identifies an error with your module or meta file.
 
-B<That's it! Thanks for contributing to the Perl 6 community!>
+B<That's it! Thanks for contributing to the Perl 6 community!>
 
 If you'd like to try out installing your module, use the X<panda> module
-installer tool which is included with Rakudo Star Perl 6:
+installer tool which is included with Rakudo Star Perl 6:
 
 =code panda install Vortex::TotalPerspective
 
@@ -491,7 +491,7 @@ This will download your module to its own working directory (C<~/.panda>),
 build it there, and install the module into C<~/.perl6>.
 
 To use C<Vortex::TotalPerspective> from your scripts, just write
-C<use Vortex::TotalPerspective>, and your Perl 6 implementation will
+C<use Vortex::TotalPerspective>, and your Perl 6 implementation will
 know where to look for the module file(s).
 
 =head1 Modules and Tools related to module authoring
@@ -502,7 +502,7 @@ writing/test modules at L<Modules Extra|/language/modules-extra>
 =head1 The Future of Ecosystem
 
 L<https://modules.perl6.org> and github-based infrastructure is temporary. The
-plan is to establish something similar to Perl 5's PAUSE/CPAN/MetaCPAN
+plan is to establish something similar to Perl 5's PAUSE/CPAN/MetaCPAN
 infrastructure. B<Volunteers needed!>
 
 The rough plan is:
@@ -514,9 +514,9 @@ The rough plan is:
 
 The repository with jdv's fork can be found at L<https://github.com/jdv/metacpan-web>
 
-You can also already upload your Perl 6 modules to
-L<Perl 5's PAUSE|https://pause.perl.org/>, selecting `Perl6` directory during the
-upload. That will ensure your module is indexed in Perl 6's space and not Perl 5's.
+You can also already upload your Perl 6 modules to
+L<Perl 5's PAUSE|https://pause.perl.org/>, selecting `Perl 6` directory during the
+upload. That will ensure your module is indexed in Perl 6's space and not Perl 5's.
 
 =head2 Contact Information
 

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -515,7 +515,7 @@ The rough plan is:
 The repository with jdv's fork can be found at L<https://github.com/jdv/metacpan-web>
 
 You can also already upload your Perl 6 modules to
-L<Perl 5's PAUSE|https://pause.perl.org/>, selecting `Perl 6` directory during the
+L<Perl 5's PAUSE|https://pause.perl.org/>, selecting `Perl6` directory during the
 upload. That will ensure your module is indexed in Perl 6's space and not Perl 5's.
 
 =head2 Contact Information

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -117,7 +117,7 @@ L<design documents|https://design.perl6.org/> are very light on details.
 For each type declarator keyword, such as C<class>, C<role>, C<enum>,
 C<module>, C<package>, C<grammar> or C<subset>, there is a separate meta
 class in the C<Metamodel::> namespace. (Rakudo implements them in the
-C<Perl 6::Metamodel::> namespace, and then maps C<Perl 6::Metamodel> to
+C<Perl6::Metamodel::> namespace, and then maps C<Perl6::Metamodel> to
 C<Metamodel>).
 
 Many of the these meta classes share common functionality. For example

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -2,16 +2,16 @@
 
 =TITLE Meta-Object Protocol
 
-=SUBTITLE Introspection and the Perl 6 Object System
+=SUBTITLE Introspection and the Perl 6 Object System
 
 X<|MOP>
 
-Perl 6 is built on a meta object layer. That means that there are objects
+Perl 6 is built on a meta object layer. That means that there are objects
 (the I<meta objects>) that control how various object-oriented constructs
 (such as classes, roles, methods, attributes, enums, ...) behave.
 
 To get a feeling for the meta object for C<class>, here is the same example
-twice: once as normal declarations in Perl 6, and once expressed through the
+twice: once as normal declarations in Perl 6, and once expressed through the
 meta model:
 
     class A {
@@ -38,7 +38,7 @@ Here, the calls with C<.^> are calls to the meta object, so C<A.^compose> is
 a shortcut for C<A.HOW.compose(A)>. The invocant is passed in the parameter
 list as well, to make it possible to support prototype-style type systems,
 where there is just one meta object (and not one meta object per type, as
-standard Perl 6 does it).
+standard Perl 6 does it).
 
 As the example above demonstrates, all object oriented features are
 available to the user, not just to the compiler. In fact the compiler just
@@ -111,13 +111,13 @@ The presence of a C<Scalar> object indicates that the object is "itemized".
 =head1 Structure of the meta object system
 
 B<Note:> this documentation largely reflects the meta object system as
-implemented by the L<Rakudo Perl 6 compiler|http://rakudo.org/>, since the
+implemented by the L<Rakudo Perl 6 compiler|http://rakudo.org/>, since the
 L<design documents|https://design.perl6.org/> are very light on details.
 
 For each type declarator keyword, such as C<class>, C<role>, C<enum>,
 C<module>, C<package>, C<grammar> or C<subset>, there is a separate meta
 class in the C<Metamodel::> namespace. (Rakudo implements them in the
-C<Perl6::Metamodel::> namespace, and then maps C<Perl6::Metamodel> to
+C<Perl 6::Metamodel::> namespace, and then maps C<Perl 6::Metamodel> to
 C<Metamodel>).
 
 Many of the these meta classes share common functionality. For example
@@ -141,7 +141,7 @@ responsible for role handling can be roles. The answer is I<by magic>.
 
 Just kidding. Bootstrapping is implementation specific. Rakudo does it by
 using the object system of the language in which itself is implemented,
-which happens to be (nearly) a subset of Perl 6: NQP, Not Quite Perl. NQP
+which happens to be (nearly) a subset of Perl 6: NQP, Not Quite Perl. NQP
 has a primitive, class-like kind called C<knowhow>, which is used to
 bootstrap its own classes and roles implementation. C<knowhow> is built on
 primitives that the virtual machine under NQP provides.
@@ -179,7 +179,7 @@ intentionally limits, such as calling private methods on classes that don't
 trust you, peeking into private attributes, and other things that usually
 simply aren't done.
 
-Regular Perl 6 code has many safety checks in place; not so the meta model. It
+Regular Perl 6 code has many safety checks in place; not so the meta model. It
 is close to the underlying virtual machine, and violating the contracts with
 the VM can lead to all sorts of strange behaviors that, in normal code, would
 obviously be bugs.
@@ -189,19 +189,19 @@ So be extra careful and thoughtful when writing meta types.
 =head2 Power, Convenience and Pitfalls
 
 The meta object protocol is designed to be powerful enough to implement the
-Perl 6 object system. This power occasionally comes at the cost of convenience.
+Perl 6 object system. This power occasionally comes at the cost of convenience.
 
 For example, when you write C<my $x = 42> and then proceed to call methods on
 C<$x>, most of these methods end up acting on the L<integer|/type/Int> 42, not
 on the L<scalar container|/type/Scalar> in which it is stored. This is a piece
-of convenience found in ordinary Perl 6. Many parts of the meta object
+of convenience found in ordinary Perl 6. Many parts of the meta object
 protocol cannot afford to offer the convenience of automatically ignoring
 scalar containers, because they are used to implement those scalar containers
 as well. So if you write C<my $t = MyType; ... ; $t.^compose> you are
 composing the Scalar that the C<$>-sigiled variable implies, not C<MyType>.
 
 The consequence is that you need to have a rather detailed understanding of
-the subtleties of Perl 6 in order to avoid pitfalls when working with the MOP,
+the subtleties of Perl 6 in order to avoid pitfalls when working with the MOP,
 and can't expect the same "do what I mean" convenience that ordinary Perl 6
 code offers.
 

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -15,7 +15,7 @@ The simplest imaginable use of NativeCall would look something like this:
     some_argless_function();
 
 The first line imports various traits and types. The next line looks like
-a relatively ordinary Perl 6 sub declaration - with a twist. We use the
+a relatively ordinary Perl 6 sub declaration - with a twist. We use the
 "native" trait in order to specify that the sub is actually defined in a
 native library. The platform-specific extension (e.g., '.so' or '.dll'),
 as well as any customary prefixes (e.g., 'lib') will be added for you.
@@ -25,7 +25,7 @@ loaded and the "some_argless_function" will be located in it. A call will then
 be made. Subsequent calls will be faster, since the symbol handle is retained.
 
 Of course, most functions take arguments or return values - but everything else
-that you can do is just adding to this simple pattern of declaring a Perl 6
+that you can do is just adding to this simple pattern of declaring a Perl 6
 sub, naming it after the symbol you want to call and marking it with the "native"
 trait.
 
@@ -50,7 +50,7 @@ and call the subroutine whatever we want ("init" in this case).
 
 =head1 Passing and Returning Values
 
-Normal Perl 6 signatures and the C<returns> trait are used in order to convey
+Normal Perl 6 signatures and the C<returns> trait are used in order to convey
 the type of arguments a native function expects and what it returns. Here is
 an example.
 
@@ -78,8 +78,8 @@ likely grow with time).
     bool           (bool from C99)
     size_t         (size_t in C)
 
-Don't use Perl 6 native types like C<int> or C<num>, as they don't have to
-correspond to the local C equivalent (e.g., Perl 6's C<int> can be 8 bytes but
+Don't use Perl 6 native types like C<int> or C<num>, as they don't have to
+correspond to the local C equivalent (e.g., Perl 6's C<int> can be 8 bytes but
 C's C<int> is only 4 bytes).
 
 Note that the lack of a C<returns> trait is used to indicate void return type.
@@ -196,7 +196,7 @@ NativeCall has some support for arrays. It is constrained to work with machine-s
 integers, doubles and strings, sized numeric types, arrays of pointers, arrays of
 structs, and arrays of arrays.
 
-Perl 6 arrays, which support amongst other things laziness, are laid out in memory
+Perl 6 arrays, which support amongst other things laziness, are laid out in memory
 in a radically different way to C arrays. Therefore, the NativeCall library offers
 a much more primitive CArray type, which you must use if working with C arrays.
 
@@ -214,7 +214,7 @@ Here is an example of passing a C array.
     RenderBarChart('Weights (kg)', 3, @titles, @values);
 
 Note that binding was used to C<@titles>, I<not> assignment! If you assign, you
-are putting the values into a Perl 6 array, and it will not work out. If this
+are putting the values into a Perl 6 array, and it will not work out. If this
 all freaks you out, forget you ever knew anything about the C<@> sigil and just
 use C<$> all the way when using NativeCall. :-)
 
@@ -259,7 +259,7 @@ the way the big bad native world works. Scared? Here, have a hug. Good luck! :-)
 =head1 Structs
 
 Thanks to representation polymorphism, it's possible to declare a normal looking
-Perl 6 class that, under the hood, stores its attributes in the same way a C
+Perl 6 class that, under the hood, stores its attributes in the same way a C
 compiler would lay them out in a similar struct definition. All it takes is a
 quick use of the "repr" trait:
 
@@ -292,7 +292,7 @@ struct type.
 
 =head2 CUnions
 
-Likewise, it is possible to declare a Perl 6 class that stores its
+Likewise, it is possible to declare a Perl 6 class that stores its
 attributes the same way a C compiler would lay them out in a similar
 C<union> definition; using the C<CUnion> representation:
 
@@ -362,7 +362,7 @@ as a constraint on the code parameter:
     my sub SetCallback(&callback (Str --> int32)) is native('mylib') { * }
 
 Note: the native code is responsible for memory management of values passed to
-Perl 6 callbacks this way. In other words, NativeCall will not free() strings passed
+Perl 6 callbacks this way. In other words, NativeCall will not free() strings passed
 to callbacks.
 
 =head1 Library Paths and Names
@@ -544,7 +544,7 @@ You can look at the results via a normal mysql connection:
 
 =head2 Microsoft Windows
 
-The win32-api-call.p6 script shows an example Windows API call done from Perl 6.
+The win32-api-call.p6 script shows an example Windows API call done from Perl 6.
 See L<https://github.com/jnthn/zavolaj/tree/master/examples>
 
 =end pod

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -2,12 +2,12 @@
 
 =TITLE Object Orientation
 
-=SUBTITLE Object Orientation in Perl 6
+=SUBTITLE Object Orientation in Perl 6
 
-Perl 6 is an object oriented language at its core, even though it allows you
+Perl 6 is an object oriented language at its core, even though it allows you
 to write programs in other programming styles.
 
-Perl 6 comes with a wealth of predefined types, which can be classified in
+Perl 6 comes with a wealth of predefined types, which can be classified in
 two categories: normal and I<native> types.
 
 Native types are used for low-level types (like C<uint64>). They do not have
@@ -139,7 +139,7 @@ another class.
 X<|Attribute> X<|Property> X<|Member> X<|Slot>
 
 Attributes are variables that exist per instance of a class. They are where
-the state of an object is stored. In Perl 6, all attributes are private.
+the state of an object is stored. In Perl 6, all attributes are private.
 They are typically declared using the C<has> declarator and the C<!> twigil.
 
     class Journey {
@@ -338,7 +338,7 @@ class Child B<L<is> Parent1 is Parent2> { }
 If a method is called on the child class, and the child class does not
 provide that method, the method of that name in one of the parent classes is
 invoked instead, if it exists. The order in which parent classes are
-consulted is called the I<method resolution order> (MRO). Perl 6 uses the
+consulted is called the I<method resolution order> (MRO). Perl 6 uses the
 L<C3 method resolution
 order|https://en.wikipedia.org/wiki/C3_linearization>.  You can ask a type
 for its MRO through a call to its meta class:
@@ -474,7 +474,7 @@ positional arguments, you must write your own C<new> method:
 However this is considered poor practice, because it makes correct
 initialization of objects from subclasses harder.
 
-Another thing to note is that the name C<new> is not special in Perl 6. It
+Another thing to note is that the name C<new> is not special in Perl 6. It
 is merely a common convention. You can call C<bless> from any method at all,
 or use C<CREATE> to fiddle around with low-level workings.
 
@@ -844,7 +844,7 @@ Roles can by anonymous.
 
 =head1 Meta-Object Programming and Introspection
 
-Perl 6 has a meta object system, which means that the behavior of objects,
+Perl 6 has a meta object system, which means that the behavior of objects,
 classes, roles, grammars, enums, etc. are themselves controlled by other
 objects; those objects are called I<meta objects>. Meta objects are, like
 ordinary objects, instances of classes, in this case we call them I<meta
@@ -861,11 +861,11 @@ objects have the same meta class by comparing them for equality:
     say 1.HOW === Int.HOW;      # True
     say 1.HOW === Num.HOW;      # False
 
-Perl 6 uses the word I<HOW>, Higher Order Workings, to refer to the meta
+Perl 6 uses the word I<HOW>, Higher Order Workings, to refer to the meta
 object system. Thus it should be no surprise that in Rakudo, the class name
 of the meta class that controls class behavior is called
-C<Perl6::Metamodel::ClassHOW>. For each class there is one instance of
-C<Perl6::Metamodel::ClassHOW>.
+C<Perl 6::Metamodel::ClassHOW>. For each class there is one instance of
+C<Perl 6::Metamodel::ClassHOW>.
 
 But of course the meta model does much more for you. For example it allows
 you to introspect objects and classes. The calling convention for methods on
@@ -880,7 +880,7 @@ of an object, you could write:
     # or shorter:
     say 1.HOW.name(1);                  # Int
 
-(The motivation is that Perl 6 also wants to allow a more prototype-based
+(The motivation is that Perl 6 also wants to allow a more prototype-based
 object system, where it's not necessary to create a new meta object for
 every type).
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -864,8 +864,8 @@ objects have the same meta class by comparing them for equality:
 Perl 6 uses the word I<HOW>, Higher Order Workings, to refer to the meta
 object system. Thus it should be no surprise that in Rakudo, the class name
 of the meta class that controls class behavior is called
-C<Perl 6::Metamodel::ClassHOW>. For each class there is one instance of
-C<Perl 6::Metamodel::ClassHOW>.
+C<Perl6::Metamodel::ClassHOW>. For each class there is one instance of
+C<Perl6::Metamodel::ClassHOW>.
 
 But of course the meta model does much more for you. For example it allows
 you to introspect objects and classes. The calling convention for methods on

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2,14 +2,14 @@
 
 =TITLE Operators
 
-=SUBTITLE Common Perl 6 infixes, prefixes, postfixes, and more!
+=SUBTITLE Common Perl 6 infixes, prefixes, postfixes, and more!
 
 =head1 Operator Precedence
 
 In an expression like C<1 + 2 * 3>, the C<2 * 3> is evaluated first
 because the infix C<*> has tighter B<precedence> than the C<+>.
 
-The following table summarizes the precedence levels in Perl 6, from
+The following table summarizes the precedence levels in Perl 6, from
 tightest to loosest:
 
 =begin table
@@ -116,7 +116,7 @@ L<Defining Operators functions|/language/functions#Defining_Operators>.
 
 Meta operators can be parameterized with other operators or subroutines in the
 same way as functions can take functions as parameters. To use a subroutine as
-a parameter prefix it's name with a C<&>. Perl 6 will generate the actual
+a parameter prefix it's name with a C<&>. Perl 6 will generate the actual
 combined operator in the background, allowing the mechanism to be applied to
 user defined operators. There are quite a few Meta operators with different
 semantics, as explained in detail as follows.
@@ -1026,7 +1026,7 @@ details.
 
 "temporizes" the variable passed as the argument, which means it is reset
 to its old value on scope exit. (This is similar to the
-L<local|http://perldoc.perl.org/functions/local.html> operator in Perl 5,
+L<local|http://perldoc.perl.org/functions/local.html> operator in Perl 5,
 except that C<temp> does not reset the value).
 
 =head2 prefix C«let»

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE Measuring and improving run-time or compile-time performance
 
 This page is about anything to do with L<computer performance|https://en.wikipedia.org/wiki/Computer_performance>
-in the context of Perl 6.
+in the context of Perl 6.
 
 =head1 First, clarify the problem
 
@@ -15,7 +15,7 @@ L<"critical 3%"|https://en.wikiquote.org/wiki/Donald_Knuth> by "profiling" as ex
 =head2 Time with C<now - INIT now>
 
 Expressions of the form C<now - INIT now>, where C<INIT> is a
-L<phase in the running of a Perl 6 program|/language/phasers>, provide a great idiom for timing code snippets.
+L<phase in the running of a Perl 6 program|/language/phasers>, provide a great idiom for timing code snippets.
 
 Use the C<m: your code goes here> L<#perl6 channel evalbot|/language/glossary#camelia>
 to write lines like:
@@ -29,7 +29,7 @@ because the latter occurs during L<the INIT phase|/language/phasers#INIT>.
 =head2 Profile with C<prof-m: your code goes here>
 
 Enter C<prof-m: your code goes here> in the L<#perl6 channel|/language/glossary#IRC>
-to invoke a Perl 6 compiler with a C<--profile> option.
+to invoke a Perl 6 compiler with a C<--profile> option.
 The evalbot's output includes a link to L<profile info|https://en.wikipedia.org/wiki/Profiling_(computer_programming)>:
 
 =begin code :allow< L >
@@ -60,7 +60,7 @@ The Rakudo compiler's C<--profile-compile> option profiles the time and memory u
 
 Use L<perl6-bench|https://github.com/japhb/perl6-bench>.
 
-If you run perl6-bench for multiple compilers (typically versions of Perl 5, Perl 6, or NQP)
+If you run perl6-bench for multiple compilers (typically versions of Perl 5, Perl 6, or NQP)
 then results for each are visually overlaid on the same graphs to provide for quick and easy comparison.
 
 =head2 Share problems
@@ -75,7 +75,7 @@ C<prof-m: your code or gist URL goes here>.
 =item Think about the minimum speed increase (or ram reduction or whatever) you need/want.
 What if it took a month for folk to help you achieve that? A year?
 
-=item Let folk know if your Perl 6 use-case is in a production setting or just for fun.
+=item Let folk know if your Perl 6 use-case is in a production setting or just for fun.
 
 =head1 Solve problems
 
@@ -126,7 +126,7 @@ positioned character in the large string. For most strings the Boyer-Moore algor
 faster algorithmically, where N is the length of the small string.
 
 The next couple sections discuss two broad categories for algorithmic improvement that are especially
-easy to accomplish in Perl 6. For more on this general topic, read the wikipedia page on
+easy to accomplish in Perl 6. For more on this general topic, read the wikipedia page on
 L<algorithmic efficiency|https://en.wikipedia.org/wiki/Algorithmic_efficiency>,
 especially the See also section near the end.
 
@@ -135,7 +135,7 @@ especially the See also section near the end.
 This is another very important class of algorithmic improvement.
 
 See the slides for
-L<Parallelism, Concurrency, and Asynchrony in Perl 6|http://jnthn.net/papers/2015-yapcasia-concurrency.pdf#page=17>
+L<Parallelism, Concurrency, and Asynchrony in Perl 6|http://jnthn.net/papers/2015-yapcasia-concurrency.pdf#page=17>
 and/or L<the matching video|https://www.youtube.com/watch?v=JpqnNCx7wVY&list=PLRuESFRW2Fa77XObvk7-BYVFwobZHdXdK&index=8>.
 
 =head2 Use existing high performance code
@@ -148,11 +148,11 @@ support for C++ libs too) such as L<Gumbo|https://github.com/Skarsnik/perl6-gumb
 (Data marshalling and call handling is somewhat poorly optimized at the time of writing this but for many
 applications that won't matter.)
 
-Perl 5's compiler can be treated as a C lib. Mix in Perl 6 types, the L<MOP|/language/mop>, and some hairy
+Perl 5's compiler can be treated as a C lib. Mix in Perl 6 types, the L<MOP|/language/mop>, and some hairy
 programming that someone else has done for you, and the upshot is that you can conveniently
-L<use Perl 5 modules in Perl 6|http://stackoverflow.com/a/27206428/1077672>.
+L<use Perl 5 modules in Perl 6|http://stackoverflow.com/a/27206428/1077672>.
 
-More generally, Perl 6 is designed for smooth interop with other languages and there are a number
+More generally, Perl 6 is designed for smooth interop with other languages and there are a number
 of L<modules aimed at providing convenient use of libs from other langs|https://modules.perl6.org/#q=inline>.
 
 =head2 Make the Rakudo compiler generate faster code
@@ -162,13 +162,13 @@ more importantly, how fast or lean the code it generates runs. But that's expect
 year and beyond. You can talk to compiler devs on the freenode IRC channels #perl6 and #moarvm about what
 to expect. Better still you can contribute yourself:
 
-=item Rakudo is largely written in Perl 6. So if you can write Perl 6, then you can hack on the compiler,
+=item Rakudo is largely written in Perl 6. So if you can write Perl 6, then you can hack on the compiler,
 including optimizing any of the large body of existing high-level code that impacts the speed of your code
 (and everyone else's).
 
 =item Most of the rest of the compiler is written in a small language called
-L<NQP|https://github.com/perl6/nqp> that's basically a subset of Perl 6.
-If you can write Perl 6 you can fairly easily learn to use and improve the mid-level NQP code too,
+L<NQP|https://github.com/perl6/nqp> that's basically a subset of Perl 6.
+If you can write Perl 6 you can fairly easily learn to use and improve the mid-level NQP code too,
 at least from a pure language point of view. To dig in to NQP and Rakudo's guts, start with
 L<NQP and internals course|http://edumentab.github.io/rakudo-and-nqp-internals-course/>.
 

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -2,11 +2,11 @@
 
 =TITLE Quoting Constructs
 
-=SUBTITLE Writing strings, word lists, and regexes in Perl 6
+=SUBTITLE Writing strings, word lists, and regexes in Perl 6
 
 =head1 The Q Lang
 
-Strings are usually represented in Perl 6 code using some form of quoting
+Strings are usually represented in Perl 6 code using some form of quoting
 construct. The most minimalistic of these is C<Q>, usable via the shortcut
 C<｢…｣>, or via C<Q> followed by any pair of delimiters surrounding your
 text. Most of the time, though, the most you'll need is C<'…'> or C<"…">,
@@ -86,7 +86,7 @@ say B<">The B<\>$color variable contains the value '$color'B<">;
 
     The $color variable contains the value 'blue'
 
-Another feature of C<qq> is the ability to interpolate Perl 6 code from
+Another feature of C<qq> is the ability to interpolate Perl 6 code from
 within the string, using curly braces:
 
 =for code :allow<B L>
@@ -134,12 +134,12 @@ interpolated as well.
 To enter unicode sequences use C<\x> or C<\x[]> with the hex-code of the
 character or a list of characters.
 
-    my $s = "I \x[2665] Perl 6!";
+    my $s = "I \x[2665] Perl 6!";
     dd $s;
-    OUTPUT«Str $s = "I ♥ Perl 6!"␤»
-    my $s = "I really \x[2661,2665,2764,1f495] Perl 6!";
+    OUTPUT«Str $s = "I ♥ Perl 6!"␤»
+    my $s = "I really \x[2661,2665,2764,1f495] Perl 6!";
     dd $s;
-    OUTPUT«Str $s = "I really ♡♥❤💕 Perl 6!"␤»
+    OUTPUT«Str $s = "I really ♡♥❤💕 Perl 6!"␤»
 
 You can also use unicode names with C<\c[]>.
 
@@ -241,9 +241,9 @@ so quotes coming from inside interpolated variables are just literal quote chara
 
 To run a string as an external program, not only is it possible to pass the
 string to the C<shell> or C<run> functions but one can also perform shell
-quoting in a similar manner to the backticks a.k.a. C<qx> in Perl 5.  There
+quoting in a similar manner to the backticks a.k.a. C<qx> in Perl 5.  There
 are some subtleties to consider, however.  The backticks are no longer used
-for shell quoting in Perl 6 and the C<qx> quotes I<don't> interpolate Perl
+for shell quoting in Perl 6 and the C<qx> quotes I<don't> interpolate Perl
 variables.  Thus
 
     my $world = "there";
@@ -271,7 +271,7 @@ other ways to execute external commands.
 
 If one wishes to use the content of a Perl variable within an external
 command, then the C<qqx> shell quoting construct should be used (this
-corresponds to Perl 5's C<qx>):
+corresponds to Perl 5's C<qx>):
 
     my $world = "there";
     say qqx{echo "hello $world"};  # hello there

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -1,16 +1,16 @@
 =begin pod
 
-=TITLE Perl 6 from Ruby - Nutshell
+=TITLE Perl 6 from Ruby - Nutshell
 
-=SUBTITLE Learning Perl 6 from Ruby, in a nutshell: What do I already know?
+=SUBTITLE Learning Perl 6 from Ruby, in a nutshell: What do I already know?
 
 This page attempts to index the high-level differences in syntax and semantics
-between Ruby and Perl 6. Whatever works in Ruby and must be written differently
-in Perl 6 should be listed here (whereas many Perl 6 features and idioms won't
+between Ruby and Perl 6. Whatever works in Ruby and must be written differently
+in Perl 6 should be listed here (whereas many Perl 6 features and idioms won't
 be).
 
 Hence this should not be mistaken for a beginner tutorial or overview of Perl
-6; it is intended as a technical reference for Perl 6 learners with a strong
+6; it is intended as a technical reference for Perl 6 learners with a strong
 Ruby background.
 
 
@@ -27,7 +27,7 @@ will continue:
       bar +
       baz
 
-In Perl 6 you must explicitly terminate statements with a C<;>, which allows
+In Perl 6 you must explicitly terminate statements with a C<;>, which allows
 for better feedback and more flexibility in breaking up long lines. Two
 exceptions not needing an explicit C<;> are the last statement in a block, and
 after the closing curley brace of the block itself (if there is nothing else on
@@ -50,16 +50,16 @@ even with strict mode and warnings turned on:
         . name
         ) . upcase+"!"if$greeted[i]<1
 
-Perl 6 also endorses programmer freedom and creativity, but balanced syntactic
+Perl 6 also endorses programmer freedom and creativity, but balanced syntactic
 flexibility against its design goal of having a consistent, deterministic,
 extensible grammar that supports single-pass parsing and helpful error
 messages, integrates features like custom operators cleanly, and doesn't lead
 programmers to accidentally misstate their intent. Also, the practice of "code
-golf" is slightly de-emphasized; Perl 6 is designed to be more concise in
+golf" is slightly de-emphasized; Perl 6 is designed to be more concise in
 concepts than in keystrokes.
 
 As a result, there are various places in the syntax where whitespace is
-optional in Ruby, but is either mandatory or forbidden in Perl 6. Many of those
+optional in Ruby, but is either mandatory or forbidden in Perl 6. Many of those
 restrictions are unlikely to concern much real-life Perl code (e.g. whitespace
 being disallowed between an array variable and its square braces), but there
 are a few that will unfortunately conflict with some Ruby hackers' habitual
@@ -68,10 +68,10 @@ coding styles:
 =begin item
 I<No space allowed before the opening parenthesis of an argument list.>
 
-    foo (3, 4, 1); # Not right in Ruby or Perl 6 (in Perl 6 this would
+    foo (3, 4, 1); # Not right in Ruby or Perl 6 (in Perl 6 this would
                    # try to pass a single argument of type List to foo)
-    foo(3, 4, 1);  # Ruby and Perl 6
-    foo 3, 4, 1;   # Ruby and Perl 6 - alternative parentheses-less style
+    foo(3, 4, 1);  # Ruby and Perl 6
+    foo 3, 4, 1;   # Ruby and Perl 6 - alternative parentheses-less style
 
 =end item
 
@@ -79,12 +79,12 @@ I<No space allowed before the opening parenthesis of an argument list.>
 I<Space is B<required> immediately after keywords>
 
     if(a < 0); ...; end         # OK in Ruby
-    if ($a < 0) { ... }         # Perl 6
-    if $a < 0 { ... }           # Perl 6, more idiomatic
+    if ($a < 0) { ... }         # Perl 6
+    if $a < 0 { ... }           # Perl 6, more idiomatic
 
     while(x > 5); ...; end      # OK in Ruby
-    while ($x > 5) { ... }      # Perl 6
-    while $x > 5 { ... }        # Perl 6, more idiomatic
+    while ($x > 5) { ... }      # Perl 6
+    while $x > 5 { ... }        # Perl 6, more idiomatic
 
 =end item
 
@@ -93,15 +93,15 @@ I<No space allowed before a postfix/postcircumfix operator (including
 array/hash subscripts).>
 
     seen [ :fish ] = 1    # Ruby, not idiomatic but allowed
-    %seen< fish > = 1;    # Perl 6, no space allowed after 'seen'
+    %seen< fish > = 1;    # Perl 6, no space allowed after 'seen'
 =end item
 
 =begin item
 I<Space required before an infix operator if it would
 conflict with an existing postfix/postcircumfix operator.>
 
-    n<1     # Ruby (in Perl 6 this would conflict with postcircumfix < >)
-    $n < 1; # Perl 6
+    n<1     # Ruby (in Perl 6 this would conflict with postcircumfix < >)
+    $n < 1; # Perl 6
 
 =end item
 
@@ -110,14 +110,14 @@ conflict with an existing postfix/postcircumfix operator.>
 Method call syntax uses a dot just like Ruby:
 
     person.name    # Ruby
-    $person.name   # Perl 6
+    $person.name   # Perl 6
 
 To call a method whose name is not known until runtime:
 
     object.send(methodname, args);  # Ruby
-    $object."$methodname"(@args);   # Perl 6
+    $object."$methodname"(@args);   # Perl 6
 
-If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
+If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
 a C<Method> object, rather than the simple string name of the method.
 
 =head2 Variables, Sigils, Scope, and Common Types
@@ -128,7 +128,7 @@ variables (including parameters). The C<&> sigil is also used to indicate
 method references. Symbols are prefixed with C<:>, but they are not variable
 and so not really sigils.
 
-In Perl 6 sigils are primarily used to indicate a role that the contained value
+In Perl 6 sigils are primarily used to indicate a role that the contained value
 implements, indicating the type (or at least the interface) of the value. The
 sigils are invariant, no matter how the variable is being used - you can think
 of them as part of the variable's name.
@@ -142,16 +142,16 @@ For local variables, Ruby uses implicit variable declaration upon assignment
 and limited to the current block. In Ruby the content of an C<if> or C<while>
 built-in construct is not a block or scope.
 
-Perl 6 uses explicit scope indicators, and never creates variables implicitly.
+Perl 6 uses explicit scope indicators, and never creates variables implicitly.
 Every place you see C<{ ... }> is a scope, including the body of a conditional
 or loop. The commonly used scope declarations:
 
     foo = 7        # Ruby, variable scope is defined by first assignment and
                    # extends to the end of the current block
 
-    my  $foo = 7   # Perl 6, lexical scoped to the current block
-    our $foo = 7   # Perl 6, package scoped
-    has $!foo = 7  # Perl 6, instance scoped (attribute)
+    my  $foo = 7   # Perl 6, lexical scoped to the current block
+    our $foo = 7   # Perl 6, package scoped
+    has $!foo = 7  # Perl 6, instance scoped (attribute)
 
 =head3 C<$> Scalar
 
@@ -173,14 +173,14 @@ positional indexing and slicing capabilities.
 I<Indexing>
 
     puts months[2]; # Ruby
-    say @months[2]; # Perl 6
+    say @months[2]; # Perl 6
 =end item
 
 =begin item
 I<Value-slicing>
 
     puts months[8..11].join(',') # Ruby
-    say @months[8..11].join(',') # Perl 6
+    say @months[8..11].join(',') # Perl 6
 =end item
 
 
@@ -190,7 +190,7 @@ The C<%> sigil is always used with "hash" variables (e.g. C<%calories>,
 C<%calories<apple>>, C<%calories<pear plum>>). Variables using the C<%> sigil
 can only contain things that do the C<Associative> role.
 
-Ruby uses square brackets to access values for both Arrays and Hashes. Perl 6
+Ruby uses square brackets to access values for both Arrays and Hashes. Perl 6
 uses curley braces for hashes instead. The angle-brackets version is available
 which always autoquotes its contents (strings without quotes):
 
@@ -200,12 +200,12 @@ Adverbs can be used to control the type of slice.
 I<Indexing>
 
     puts calories["apple"]  # Ruby
-    say %calories{"apple"}; # Perl 6
+    say %calories{"apple"}; # Perl 6
 
     puts calories["apple"]  # Ruby
     puts calories[:apple]   # Ruby, symbols for keys are common
-    say %calories<apple>;   # Perl 6 - angle brackets instead of single-quotes
-    say %calories«$key»;    # Perl 6 - double angles interpolate as double-quotes
+    say %calories<apple>;   # Perl 6 - angle brackets instead of single-quotes
+    say %calories«$key»;    # Perl 6 - double angles interpolate as double-quotes
 =end item
 
 =begin item
@@ -213,18 +213,18 @@ I<Value-slicing>
 
     puts calories.values_at('pear', 'plum').join(',') # Ruby
     puts calories.values_at(%w(pear plum)).join(',')  # Ruby, pretty?
-    say %calories{'pear', 'plum'}.join(',');          # Perl 6
-    say %calories<pear plum>.join(',');               # Perl 6 (prettier)
+    say %calories{'pear', 'plum'}.join(',');          # Perl 6
+    say %calories<pear plum>.join(',');               # Perl 6 (prettier)
     my $keys = 'pear plum';
-    say %calories«$keys».join(','); # Perl 6, interpolated split
+    say %calories«$keys».join(','); # Perl 6, interpolated split
 =end item
 
 =begin item
 I<Key/value-slicing>
 
     say calories.slice('pear', 'plum').join(','); # Ruby, with ActiveRecord
-    say %calories{'pear', 'plum'}:kv.join(',');   # Perl 6 - use :kv adverb
-    say %calories<pear plum>:kv.join(',');        # Perl 6 (prettier version)
+    say %calories{'pear', 'plum'}:kv.join(',');   # Perl 6 - use :kv adverb
+    say %calories<pear plum>:kv.join(',');        # Perl 6 (prettier version)
 =end item
 
 =head3 C<&> Sub
@@ -238,19 +238,19 @@ contain things that do the C<Callable> role.
     add.(2, 3)              # => 5, Ruby invocation of a lambda
     add.call(2, 3)          # => 5, Ruby invocation of a lambda
 
-    my &add = -> $n, $m { $n + $m } # Perl 6 addition function
+    my &add = -> $n, $m { $n + $m } # Perl 6 addition function
     &add(2, 3)                      # => 5, you can keep the sigil
     add(2, 3)                       # => 5, and it works without it
 
     foo_method = &foo;     # Ruby
-    my &foo_method = &foo; # Perl 6
+    my &foo_method = &foo; # Perl 6
 
     some_func(&say) # Ruby pass a function reference
-    some_func(&say) # Perl 6 passes function references the same way
+    some_func(&say) # Perl 6 passes function references the same way
 
 Often in Ruby we pass a block as the last parameter, which is especially used
 for DSLs. This can be an implicit parameter called by C<yield>, or an explicit
-block prefixed with C<&>. In Perl 6 a C<Callable> parameter is always listed
+block prefixed with C<&>. In Perl 6 a C<Callable> parameter is always listed
 and called by the variable name (instead of yield), and there are a variety of
 ways of invoking the function.
 
@@ -264,12 +264,12 @@ ways of invoking the function.
       puts "Hi #{n}"
     end
 
-    # Perl 6, declare a method with an explicit block argument
+    # Perl 6, declare a method with an explicit block argument
     sub f(&g:($)) {
       g(2)
     }
 
-    # Perl 6, invoke f, pass it a block with 1 argument
+    # Perl 6, invoke f, pass it a block with 1 argument
     # There are several other ways to do this
     f(-> $n { say "Hi {$n}" }) # Explicit argument
     f -> $n { say "Hi {$n}" }  # Explicit argument, no parenthesis
@@ -284,27 +284,27 @@ ways of invoking the function.
 =head3 C<*> Slurpy params / argument expansion
 
 In Ruby you can declare an argument to slurp the remainder of the passed
-parameters into an array using a C<*> prefix. It works the same way in Perl 6:
+parameters into an array using a C<*> prefix. It works the same way in Perl 6:
 
     def foo(*args); puts "I got #{args.length} args!"; end # Ruby
-    sub foo(*@args) { say "I got #{@args.elems} args!" }   # Perl 6
+    sub foo(*@args) { say "I got #{@args.elems} args!" }   # Perl 6
 
-You might want to expand an array into a set of arguments. In Perl 6 this is
+You might want to expand an array into a set of arguments. In Perl 6 this is
 also done using the C<*> prefix:
 
     args = %w(a b c)         # Ruby
     foo(*args)
 
-    my @args = <a b c>       # Perl 6
+    my @args = <a b c>       # Perl 6
     foo(*@args)
 
-Perl 6 has many more advanced ways of passing parameters and receiving
+Perl 6 has many more advanced ways of passing parameters and receiving
 arguments, see L<Signatures|/language/functions#Signatures> and
 L<Captures|/type/Capture>.
 
 =head2 Twigils
 
-Perl 6 additionally uses "twigils", which are further indicators about the
+Perl 6 additionally uses "twigils", which are further indicators about the
 variable and go between the sigil and the rest of the variable name. Examples:
 
     $foo     # Scalar with no twigil
@@ -322,29 +322,29 @@ Though each of these examples use the C<$> sigil, most could use C<@>
 
 =head2 C<:> Symbols
 
-Perl 6 generally uses strings in the places where Ruby uses symbols. A primary
+Perl 6 generally uses strings in the places where Ruby uses symbols. A primary
 example of this is in hash keys.
 
     address[:joe][:street] # Typical Ruby nested hash with symbol keys
-    %address<joe><street>  # Typical Perl 6 nested hash with string keys
+    %address<joe><street>  # Typical Perl 6 nested hash with string keys
 
-Perl 6 has I<colon-pair> syntax, which can sometimes look like Ruby symbols.
+Perl 6 has I<colon-pair> syntax, which can sometimes look like Ruby symbols.
 
     :age            # Ruby symbol
 
-    # All of these are equivalent for Perl 6
-    :age            # Perl 6 pair with implicit True value
-    :age(True)      # Perl 6 pair with explicit True value
-    age => True     # Perl 6 pair using arrow notation
-    "age" => True   # Perl 6 pair using arrow notation and explicit quotes
+    # All of these are equivalent for Perl 6
+    :age            # Perl 6 pair with implicit True value
+    :age(True)      # Perl 6 pair with explicit True value
+    age => True     # Perl 6 pair using arrow notation
+    "age" => True   # Perl 6 pair using arrow notation and explicit quotes
 
 You could probably get away with using a colon-pair without an explicit value
 and pretend that it is a Ruby symbol a lot of the time, but it isn't idomatic
-Perl 6.
+Perl 6.
 
 =head1 Operators
 
-Many operators have a similar usage in both Ruby and Perl 6:
+Many operators have a similar usage in both Ruby and Perl 6:
 
 =item C<,> List Separator
 =item C<+> Numeric Addition
@@ -366,7 +366,7 @@ value) or post-decrement C<$x--> (decrement, return old value).
 
 =head2 C«== != < > <= >=» Comparisons
 
-Comparisons in Perl 6 are separated between numeric and string to avoid common
+Comparisons in Perl 6 are separated between numeric and string to avoid common
 errors.
 
 =item C«== != < > <= >=» Comparisons
@@ -378,7 +378,7 @@ tries to convert the values to strings.
 =head2 C«<=>» Three-way comparisons
 
 In Ruby, the C«<=>» operator returns -1, 0, or 1.
-In Perl 6, they return C<Order::Less>, C<Order::Same>, or C<Order::More>.
+In Perl 6, they return C<Order::Less>, C<Order::Same>, or C<Order::More>.
 
 C«<=>» forces numeric context for the comparison.
 
@@ -401,7 +401,7 @@ See L<S03/Smart matching|https://design.perl6.org/S03.html#Smart_matching>
 =head2 C<& | ^> Numeric Bitwise ops
 =head2 C<& | ^> Boolean ops
 
-In Perl 6, these single-character ops have been removed, and replaced by
+In Perl 6, these single-character ops have been removed, and replaced by
 two-character ops which coerce their arguments to the needed context.
 
     # Infix ops (two arguments; one on each side of the op)
@@ -417,17 +417,17 @@ two-character ops which coerce their arguments to the needed context.
 =head2 C<&.> Conditional chaining operator
 
 Ruby uses the C<&.> operator to chain methods without raising an error if one
-invocation returns nil. In Perl 6 use C<.?> for the same purpose.
+invocation returns nil. In Perl 6 use C<.?> for the same purpose.
 
 =head2 C«<< >>» Numeric shift left, right ops, shovel operator
 
 Replaced by C«+<» and C«+>» .
 
     puts 42 << 3  # Ruby
-    say  42 +< 3; # Perl 6
+    say  42 +< 3; # Perl 6
 
 Note that Ruby often uses the C«<<» operator as the "shovel operator", which is
-similar to C<.push>. This usage isn't common in Perl 6.
+similar to C<.push>. This usage isn't common in Perl 6.
 
 =head2 C«=>» and C<:> Key-Value Separators
 
@@ -435,35 +435,35 @@ In Ruby, C«=>» is used in the context of key/value pairs for Hash literal
 declaration and parameter passing. C<:> is used as a shorthand when the left
 side is a symbol.
 
-In Perl 6, C«=>» is the Pair operator, which is quite different in
+In Perl 6, C«=>» is the Pair operator, which is quite different in
 principle, but works the same in many situations.
 
 If you are using C«=>» in a hash literal, then the usage is very similar:
 
     hash = { "AAA" => 1, "BBB" => 2 }  # Ruby, though symbol keys are more common
-    my %hash = ( AAA => 1, BBB => 2 ); # Perl 6, uses ()'s though {} usually work
+    my %hash = ( AAA => 1, BBB => 2 ); # Perl 6, uses ()'s though {} usually work
 
 =head2 C<? :> Ternary operator
 
-In Perl 6, this is spelled with two question marks instead of one question
+In Perl 6, this is spelled with two question marks instead of one question
 mark, and two exclamation points instead of one colon. This deviation from the
 common ternary operators disambiguates several situations and makes the
 false-case stand out more.
 
     result     = (  score > 60 )  ? 'Pass'  : 'Fail'; # Ruby
-    my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
+    my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
 
 =head2 C<+> String Concatenation
 
 Replaced by the tilde. Mnemonic: think of "stitching" together the two strings with needle and thread.
 
     $food = 'grape' + 'fruit'  # Ruby
-    $food = 'grape' ~ 'fruit'; # Perl 6
+    $food = 'grape' ~ 'fruit'; # Perl 6
 
 =head2 String interpolation
 
 In Ruby, C<"#{foo}s"> deliminates a block embedded in a double-quoted string.
-In Perl 6 drop the C<#> prefix: C<"{$foo}s">. As in Ruby, you can place
+In Perl 6 drop the C<#> prefix: C<"{$foo}s">. As in Ruby, you can place
 arbitrary code into the embedded block and it will be rendered in string
 context.
 
@@ -473,12 +473,12 @@ Simple variables can be interpolated into a double-quoted string without using t
     name = "Bob"
     puts "Hello! My name is #{name}!"
 
-    # Perl 6
+    # Perl 6
     my $name = "Bob"
     say "Hello! My name is $name!"
 
 The result of an embedded block in Ruby uses C<.to_s> to get string context.
-Perl 6 uses C<.Str>, or C<.gist> for the same affect.
+Perl 6 uses C<.Str>, or C<.gist> for the same affect.
 
 =head1 Compound Statements
 
@@ -486,7 +486,7 @@ Perl 6 uses C<.Str>, or C<.gist> for the same affect.
 
 =head3 C<if> C<elsif> C<else> C<unless>
 
-This work very similarly between Ruby and Perl 6, but Perl 6 uses C<{ }> to
+This work very similarly between Ruby and Perl 6, but Perl 6 uses C<{ }> to
 clearly deliniate the blocks.
 
     # Ruby
@@ -498,7 +498,7 @@ clearly deliniate the blocks.
         puts "Smaller!"
     end
 
-    # Perl 6
+    # Perl 6
     if x > 5 {
         say "Bigger!"
     } elsif x == 5 {
@@ -510,16 +510,16 @@ clearly deliniate the blocks.
 Binding the conditional expression to a variable is a little different:
 
     if x = dostuff(); ...; end   # Ruby
-    if dostuff() -> $x {...}     # Perl 6, block-assignment uses arrow
+    if dostuff() -> $x {...}     # Perl 6, block-assignment uses arrow
 
-The C<unless> conditional only allows for a single block in Perl 6;
+The C<unless> conditional only allows for a single block in Perl 6;
 it does not allow for an C<elsif> or C<else> clause.
 
 =head3 C<case>-C<when>
 
-The Perl 6 C<given>-C<when> construct is like a chain of C<if>-C<elsif>-C<else>
+The Perl 6 C<given>-C<when> construct is like a chain of C<if>-C<elsif>-C<else>
 statements or like the C<case>-C<when> construct in Ruby. A big difference is
-that Ruby uses the C<==> comparison for each condition, but Perl 6 uses the
+that Ruby uses the C<==> comparison for each condition, but Perl 6 uses the
 more general smart-match C<~~> operator.
 
 It has the
@@ -560,12 +560,12 @@ instead. Binding the conditional expression to a variable is also a little
 different:
 
     while x = dostuff(); ...; end    # Ruby
-    while dostuff() -> $x {...}      # Perl 6
+    while dostuff() -> $x {...}      # Perl 6
 
 =head3 C<for> C<.each>
 
 C<for> loops are rare in Ruby, instead we typically use C<.each> on an
-enumerable. The most direct translation to Perl 6 would be to use C<.map> for
+enumerable. The most direct translation to Perl 6 would be to use C<.map> for
 both C<.each> and C<.map>, but we typically use a C<for> loop directly.
 
     # Ruby for loop
@@ -578,12 +578,12 @@ both C<.each> and C<.map>, but we typically use a C<for> loop directly.
         puts "n: #{n}"
     end
 
-    # Perl 6
+    # Perl 6
     for 0..5 -> $n {
         say "n: $n";
     }
 
-    # Perl 6, mis-using .map
+    # Perl 6, mis-using .map
     (0..5).map: -> $n {
         say "n: $n";
     }
@@ -592,12 +592,12 @@ In Ruby, the iteration variable for C<.each> is a copy of the list element, and
 modifying it does nothing to the original list. Note that it is a copy of the
 REFERENCE, so you can still change the values to which it refers.
 
-In Perl 6, that alias is read-only (for safety) and thus behaves exactly like
+In Perl 6, that alias is read-only (for safety) and thus behaves exactly like
 Ruby, unless you change C«->» to C«<->».
 
     cars.each { |car| ... }    # Ruby; read-only referenc
-    for @cars  -> $car   {...} # Perl 6; read-only
-    for @cars <-> $car   {...} # Perl 6; read-write
+    for @cars  -> $car   {...} # Perl 6; read-only
+    for @cars <-> $car   {...} # Perl 6; read-write
 
 =head2 Flow Interruption statements
 
@@ -608,33 +608,33 @@ Same as Ruby:
 
 =item2 C<break>
 
-This is C<last> in Perl 6.
+This is C<last> in Perl 6.
 
 =head1 Regular Expressions ( Regex / Regexp )
 
-Regular expressions in Perl 6 are significantly different, and more powerful,
+Regular expressions in Perl 6 are significantly different, and more powerful,
 than in Ruby. By default whitespace is ignored and all characters must be
 escaped, for example. Regexes can be easily combined and declared in ways to
 build efficient grammars.
 
-There are many powerful features of Perl 6 regexes, especially defining entire
+There are many powerful features of Perl 6 regexes, especially defining entire
 grammars using the same syntax. See L<Regexes|/language/regexes> and
 L<Grammars|/language/grammars>.
 
 =head2 C<.match> method and C<=~> operator
 
 In Ruby, regex matches can be done against a variable using the C<=~> regexp
-match operator or the C<.match> method. In Perl 6, the C<~~> smartmatch op is
+match operator or the C<.match> method. In Perl 6, the C<~~> smartmatch op is
 used instead, or the C<.match> method.
 
     next if line   =~ /static/   # Ruby
-    next if $line  ~~ /static/;  # Perl 6
+    next if $line  ~~ /static/;  # Perl 6
 
     next if line  !~  /dynamic/ ; # Ruby
-    next if $line !~~ /dynamic/ ; # Perl 6
+    next if $line !~~ /dynamic/ ; # Perl 6
 
     next if line.match(/static/)    # Ruby
-    next if $line.match(/static/);  # Perl 6
+    next if $line.match(/static/);  # Perl 6
 
 Alternately, the C<.match> and C<.subst> methods can be used. Note that
 C<.subst> is non-mutating. See
@@ -642,13 +642,13 @@ L<S05/Substitution|https://design.perl6.org/S05.html#Substitution>.
 
 =head2 C<.sub> and C<.sub!>
 
-In Perl 6 you typically use the C<s///> operator to do regex substitution.
+In Perl 6 you typically use the C<s///> operator to do regex substitution.
 
     fixed = line.sub(/foo/, 'bar')        # Ruby, non-mutating
-    my $fixed = $line.subst(/foo/, 'bar') # Perl 6, non-mutating
+    my $fixed = $line.subst(/foo/, 'bar') # Perl 6, non-mutating
 
     line.sub!(/foo/, 'bar')   # Ruby, mutating
-    $line ~~ s/foo/bar/;      # Perl 6, mutating
+    $line ~~ s/foo/bar/;      # Perl 6, mutating
 
 =head2 Regex options
 
@@ -656,23 +656,23 @@ Move any options from the end of the regex to the beginning. This may
 require you to add the optional C<m> on a plain match like C«/abc/».
 
     next if $line =~    /static/i # Ruby
-    next if $line ~~ m:i/static/; # Perl 6
+    next if $line ~~ m:i/static/; # Perl 6
 
 =head2 Whitespace is ignored, most things must be quoted
 
 In order to aid in readability and reusability, whitespace is not significant
-in Perl 6 regexes.
+in Perl 6 regexes.
 
     /this is a test/ # Ruby, boring string
     /this.*/         # Ruby, possibly interesting string
 
-    / this " " is " " a " " test / # Perl 6, each space is quoted
-    / "this is a test" / # Perl 6, quoting the whole string
-    / this .* /          # Perl 6, possibly interesting string
+    / this " " is " " a " " test / # Perl 6, each space is quoted
+    / "this is a test" / # Perl 6, quoting the whole string
+    / this .* /          # Perl 6, possibly interesting string
 
 =head2 Special matchers generally fall under the <> syntax
 
-There are many cases of special matching syntax that Perl 6 regexes support.
+There are many cases of special matching syntax that Perl 6 regexes support.
 They won't all be listed here, but often instead of being surrounded by C<()>,
 the assertions will be surrounded by C«<>».
 
@@ -709,7 +709,7 @@ For look-around assertions:
 
 =head2 Longest token matching (LTM) displaces alternation
 
-In Perl 6 regexen, C<|> does Longest Token Match (LTM), which decides which
+In Perl 6 regexen, C<|> does Longest Token Match (LTM), which decides which
 alternation wins an ambiguous match based off of a set of rules, rather than
 about which was written first in the regex.
 
@@ -719,16 +719,16 @@ To avoid the new logic, change any C<|> in your Ruby regex to a C<||>.
 
 =head2 Reading the lines of a text file into an array
 
-Both Ruby and Perl 6 make it easy to read all of the lines in a file into a
+Both Ruby and Perl 6 make it easy to read all of the lines in a file into a
 single variable, and in both cases each line has the newline removed.
 
     lines = File.readlines("file")   # Ruby
-    my @lines = "file".IO.lines;     # Perl 6, create an IO object from a string
+    my @lines = "file".IO.lines;     # Perl 6, create an IO object from a string
 
 =head2 Iterating over the lines of a text file
 
 Reading the entire file into memory isn't recommended. The C<.lines> method in
-Perl 6 returns a lazy sequence, but assigning to an array forces the file to be
+Perl 6 returns a lazy sequence, but assigning to an array forces the file to be
 read. It is better to iterate over the results:
 
     # Ruby
@@ -736,7 +736,7 @@ read. It is better to iterate over the results:
         puts line
     end
 
-    # Perl 6
+    # Perl 6
     for "file".IO.lines -> $line {
         say $line
     }
@@ -745,8 +745,8 @@ read. It is better to iterate over the results:
 
 =head2 Basic classes, methods, attributes
 
-Classes are defined similarly between Ruby and Perl 6, using the C<class>
-keyword. Ruby uses C<def> for methods, whereas Perl 6 uses C<method>.
+Classes are defined similarly between Ruby and Perl 6, using the C<class>
+keyword. Ruby uses C<def> for methods, whereas Perl 6 uses C<method>.
 
     # Ruby
     class Foo
@@ -755,7 +755,7 @@ keyword. Ruby uses C<def> for methods, whereas Perl 6 uses C<method>.
         end
     end
 
-    # Perl 6
+    # Perl 6
     class Foo {
         method greet($name) {
             say "Hi $name!"
@@ -764,7 +764,7 @@ keyword. Ruby uses C<def> for methods, whereas Perl 6 uses C<method>.
 
 In Ruby you can use an attribute without declaring it beforehand, and you can
 tell it is an attribute because of the C<@> sigil. You can also easily create
-accessors using C<attr_accessor> and it's variants. In Perl 6 you use a C<has>
+accessors using C<attr_accessor> and it's variants. In Perl 6 you use a C<has>
 declaration and a variety of sigils. You can use the C<!> twigil for private
 attributes or C<.> to create an accessor.
 
@@ -776,14 +776,14 @@ attributes or C<.> to create an accessor.
         end
     end
 
-    # Perl 6
+    # Perl 6
     class Person
         has $.age;              # Declare $!age and accessor methods
         has $!name = 'default'; # Assign default value to private instance var
     end
 
 Creating a new instance of the class uses the C<.new> method. In Ruby you must
-manually assign instance variables as needed inside C<initialize>. In Perl 6
+manually assign instance variables as needed inside C<initialize>. In Perl 6
 you get a default constructor that accepts key/value pairs of accessor
 attributes, and can do further setup in the C<BUILD> method. Like with Ruby,
 you can override C<new> itself for more advanced functionality, but this is
@@ -800,7 +800,7 @@ rare.
     end
     p = Person.new( name: 'Jack', age: 23 )
 
-    # Perl 6
+    # Perl 6
     class Person
         has $.name = 'Jill';
         has $.age  = 42;
@@ -813,7 +813,7 @@ rare.
 
 =head2 Private Methods
 
-Private methods in Perl 6 are declared with a C<!> prefixed in their name, and
+Private methods in Perl 6 are declared with a C<!> prefixed in their name, and
 are invoked with a C<!> instead of a C<.>.
 
     # Ruby
@@ -829,7 +829,7 @@ are invoked with a C<!> instead of a C<.>.
         end
     end
 
-    # Perl 6
+    # Perl 6
     class Foo {
         method visible {
             say "I can be seen!"
@@ -842,35 +842,35 @@ are invoked with a C<!> instead of a C<.>.
     }
 
 An important note is that in Ruby child objects can see parent private methods
-(so they are more like "protected" methods in other languages). In Perl 6 child
+(so they are more like "protected" methods in other languages). In Perl 6 child
 objects cannot call parent private methods.
 
 =head2 Going Meta
 
-Here are a few examples of meta-programming. Note that Perl 6 separates the
+Here are a few examples of meta-programming. Note that Perl 6 separates the
 meta-methods from the regular methods.
 
     person = Person.new       # Ruby, create a new person
-    my $person = Person.new   # Perl 6, create a new person
+    my $person = Person.new   # Perl 6, create a new person
 
     person.class              # Ruby, returns Person (class)
-    $person.WHAT              # Perl 6, returns Person (class)
+    $person.WHAT              # Perl 6, returns Person (class)
 
     person.methods            # Ruby
-    $person.^methods          # Perl 6, using .^ syntax to access meta-methods
+    $person.^methods          # Perl 6, using .^ syntax to access meta-methods
 
     person.instance_variables # Ruby
-    $person.^attributes       # Perl 6
+    $person.^attributes       # Perl 6
 
-Like Ruby, in Perl 6, everything is an object, but not all operations are
+Like Ruby, in Perl 6, everything is an object, but not all operations are
 equivalent to C<.send>. Many operators are global functions that use typed
 multi-dispatch (function signatures with types) to decide which implementation
 to use.
 
     5.send(:+, 3)    # => 8, Ruby
-    &[+](5, 3)       # => 8, Perl 6, reference to infix additon operator
+    &[+](5, 3)       # => 8, Perl 6, reference to infix additon operator
 
-    &[+].^candidates # Perl 6, lists all signatures for the + operator
+    &[+].^candidates # Perl 6, lists all signatures for the + operator
 
 See L<Meta-Object Protocol|/language/mop> for lots of further details.
 
@@ -883,7 +883,7 @@ modules is C<RUBYLIB>.
 
     $ RUBYLIB="/some/module/lib" ruby program.rb
 
-In Perl 6 this is similar, you merely needs to change the name. As you probably
+In Perl 6 this is similar, you merely needs to change the name. As you probably
 guessed, you just need to use C<PERL6LIB>:
 
     $ PERL6LIB="/some/module/lib" perl6 program.p6
@@ -891,7 +891,7 @@ guessed, you just need to use C<PERL6LIB>:
 As with Ruby, if you don't specify C<PERL6LIB>, you need to specify the
 library path within the program via the C<use lib> pragma:
 
-    # Ruby and Perl 6
+    # Ruby and Perl 6
     use lib '/some/module/lib';
 
 =head1 Misc.
@@ -901,7 +901,7 @@ library path within the program via the C<use lib> pragma:
 In Ruby there is no built-in way to selectively import/export methods from a
 module.
 
-In Perl 6 you specifies the functions which are to be exported by using the
+In Perl 6 you specifies the functions which are to be exported by using the
 C<is export> role on the relevant subs and I<all> subs with this role are
 then exported. Hence, the following module C<Bar> exports the subs C<foo>
 and C<bar> but not C<baz>:
@@ -929,7 +929,7 @@ Some modules allow for selectively importing funcitons, which would look like:
 
 =head2 C<OptionParser>, parsing command-line flags
 
-Command line argument switch parsing in Perl 6 is done by the parameter list of
+Command line argument switch parsing in Perl 6 is done by the parameter list of
 the C<MAIN> subroutine.
 
     # Ruby
@@ -961,7 +961,7 @@ the C<MAIN> subroutine.
     ruby example.rb --length=abc
         Length must be > 0
 
-    # Perl 6
+    # Perl 6
     sub MAIN ( Int :$length where * > 0, :filename = 'file.dat', Bool :$verbose ) {
         say $length;
         say $data;
@@ -976,21 +976,21 @@ the C<MAIN> subroutine.
         Usage:
           c.p6 [--length=<Int>] [--file=<Any>] [--verbose]
 
-Note that Perl 6 auto-generates a full usage message on error in
+Note that Perl 6 auto-generates a full usage message on error in
 command-line parsing.
 
 =head1 RubyGems, External Libraries
 
-See L<https://modules.perl6.org/>, where a growing number of Perl 6 libraries
+See L<https://modules.perl6.org/>, where a growing number of Perl 6 libraries
 are available along with the tools to manage them.
 
-If the module that you were using has not been converted to Perl 6, and no
-alternative is listed in this document, then its use under Perl 6 may not
+If the module that you were using has not been converted to Perl 6, and no
+alternative is listed in this document, then its use under Perl 6 may not
 have been addressed yet.
 
 You can experiment with L<Inline::Ruby|https://github.com/awwaiid/Inline-Ruby/>
-to call existing Ruby code from your Perl 6 programs. This uses an embedded
-instance of the C<ruby> interpreter to run Ruby code called from your Perl 6
+to call existing Ruby code from your Perl 6 programs. This uses an embedded
+instance of the C<ruby> interpreter to run Ruby code called from your Perl 6
 script. Note that this is an EXPERIMENTAL library. You can similarly call other
 language's libraries with Inline::Perl5, Inline::Python, and others.
 
@@ -1013,7 +1013,7 @@ have at all, instead referring to other documents.
 Example code and links to other documents should be favored over long
 explanations of details better found elsewhere.
 
-Finally, if a real user asks a Ruby to Perl 6 question that is not being
+Finally, if a real user asks a Ruby to Perl 6 question that is not being
 answered here, please add it to the document. Even if we do not have a good
 answer yet, that will be better than losing the information about a real need.
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -13,12 +13,12 @@ regular expressions due to the influence of languages such as Perl, but the
 short-hand term I<regex> has stuck and continues to mean I<regular
 expression-like pattern matching>.
 
-In Perl 6, although they are capable of much more than regular languages, we
+In Perl 6, although they are capable of much more than regular languages, we
 continue to call them I<regexes>.
 
 =head1 X<Lexical conventions|quote,/ /;quote,rx;quote,m>
 
-Perl 6 has special syntax for writing regexes:
+Perl 6 has special syntax for writing regexes:
 
     m/abc/;         # a regex that is immediately matched against $_
     rx/abc/;        # a Regex object
@@ -37,7 +37,7 @@ instead.
 Whitespace in regexes is generally ignored (except with the C<:s> or
 C<:sigspace> adverb).
 
-As in the rest of Perl 6, comments in regexes start with a hash character
+As in the rest of Perl 6, comments in regexes start with a hash character
 C<#> and go to the end of the current line.
 
 =head1 Literals
@@ -187,7 +187,7 @@ approach is the use of Unicode properties. They are called in the form C<<
 <:property> >>, where C<property> can be a short or long Unicode property
 name.
 
-The following list is stolen from the Perl 5
+The following list is stolen from the Perl 5
 L<perlunicode|http://perldoc.perl.org/perlunicode.html> documentation:
 
 =begin table
@@ -536,7 +536,7 @@ the end of the string).
 
 =head1 X«Grouping and Capturing|regex,( );regex,[ ];regex,$<capture> =»
 
-In regular (non-regex) Perl 6, you can use parentheses to group things
+In regular (non-regex) Perl 6, you can use parentheses to group things
 together, usually to override operator precedence:
 
     say 1 + 4 * 2;      # 9, because it is parsed as 1 + (4 * 2)
@@ -710,7 +710,7 @@ C<()> can be delimiters.  Colons clash with adverbs such as C<s:i/Foo/bar/>
 and the other delimiters are used for other purposes.
 
 Like the C<m//> operator, whitespace is ignored in general.  Comments, as in
-Perl 6 in general, start with the hash character C<#> and go to the end of
+Perl 6 in general, start with the hash character C<#> and go to the end of
 the current line.
 
 =head2 Replacing literals
@@ -776,7 +776,7 @@ reformat them into C<MM-DD-YYYY> order:
     s/ (\d+)\-(\d+)\-(\d+) /$1-$2-$0/; # Transform YYYY-MM-DD to MM-DD-YYYY
     .say;                              # 01-23-2016 18:09:00
 
-Since the right-hand side is effectively a regular Perl 6 interpolated string,
+Since the right-hand side is effectively a regular Perl 6 interpolated string,
 you can reformat the time from C<HH:MM> to C<h:MM {AM,PM}> like so:
 
     $_ = '18:38';
@@ -927,7 +927,7 @@ like C<:overlap> are appended to the match call:
 =head2 X<Regex Adverbs|regex adverb,:ignorecase;regex adverb,:i>
 
 Adverbs that appear at the time of a regex declaration are part of the
-actual regex and influence how the Perl 6 compiler translates the regex into
+actual regex and influence how the Perl 6 compiler translates the regex into
 binary code.
 
 For example, the C<:ignorecase> (C<:i>) adverb tells the compiler to ignore
@@ -1243,7 +1243,7 @@ writing unreadable code.
 
 =head2 Code layout
 
-Without the C<:sigspace> adverb, whitespace is not significant in Perl 6
+Without the C<:sigspace> adverb, whitespace is not significant in Perl 6
 regexes. Use that to your own advantage and insert whitespace where it
 increases readability. Also insert comments where necessary.
 

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -2,10 +2,10 @@
 
 =TITLE Sets, Bags, and Mixes
 
-=SUBTITLE Unordered collections of unique and weighted objects in Perl 6
+=SUBTITLE Unordered collections of unique and weighted objects in Perl 6
 
 Often you want to collect objects in a container but you do not care
-about the order of these objects. For such cases, Perl 6 provides the
+about the order of these objects. For such cases, Perl 6 provides the
 I<unordered> collection types L<B<C<Set>>|Set>,
 L<B<C<SetHash>>|SetHash>, L<B<C<Bag>>|Bag>, L<B<C<BagHash>>|BagHash>,
 L<B<C<Mix>>|Mix>, and L<B<C<MixHash>>|MixHash>. Being unordered, these

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -7,11 +7,11 @@
 Often one needs to refer to a specific element (or specific slice of elements)
 of a collection or data structure. Borrowing from mathematical notation where
 the components of a vector I<v> would be referred to as I<v₁, v₂, v₃>, this
-concept is called "subscripting" (or "indexing") in Perl 6.
+concept is called "subscripting" (or "indexing") in Perl 6.
 
 =head1 Basics
 
-Perl 6 provides two universal subscripting interfaces:
+Perl 6 provides two universal subscripting interfaces:
 
 =begin table
          elements are           interface      supported by
@@ -152,7 +152,7 @@ on.
 
 Note: The asterisk is important. Passing a bare negative integer (e.g.
 C<@alphabet[-1]>) like you would do in many other programming languages, throws
-an error in Perl 6.
+an error in Perl 6.
 
 What actually happens here, is that an expression like C<*-1> declares a code
 object via L<Whatever>-currying - and the C<[ ]> subscript reacts to being
@@ -560,7 +560,7 @@ See also the L<values> routine.
 =head1 Custom types
 
 The subscripting interfaces described on this page are not meant to be
-exclusive to Perl 6's built-in collection types - you can (and should)
+exclusive to Perl 6's built-in collection types - you can (and should)
 reuse them for any custom type that wants to provide access to data by
 index or key.
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -106,7 +106,7 @@ whitespace disambiguates possible parses.
 
 =head3 Single-line comments
 
-The most common form of comments in Perl 6 starts with a single hash character
+The most common form of comments in Perl 6 starts with a single hash character
 C<#> and goes until the end of the line.
 
 =begin code
@@ -197,7 +197,7 @@ name of the identifier.
 
 =head1 Statements and Expressions
 
-Perl 6 programs are made of lists of statements. A special case of a statement
+Perl 6 programs are made of lists of statements. A special case of a statement
 is an I<expression>, which returns a value. For example C<if True { say 42 }>
 is syntactically a statement, but not an expression, whereas C<1 + 2> is an
 expression (and thus also a statement).
@@ -279,7 +279,7 @@ See the L<documentation on packages|/language/packages> for more details.
 =head2 Literals
 
 A L<literal|https://en.wikipedia.org/wiki/Literal_%28computer_programming%29>
-is a representation of a constant value in source code. Perl 6 has literals
+is a representation of a constant value in source code. Perl 6 has literals
 for several built-in types, like L<strings|/type/Str>, several numeric types,
 L<pairs|/type/Pair> and more.
 

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE The Good, the Bad, and the Ugly
 
-The official specification for Perl 6 POD tables is located in the
+The official specification for Perl 6 POD tables is located in the
 Documentation specification here:
 L<Tables|https://raw.githubusercontent.com/perl6/specs/master/S26-documentation.pod>.
 Although Pod 6 specifications are not completely handled properly yet,

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -2,9 +2,9 @@
 
 =TITLE Terms
 
-=SUBTITLE Perl 6 Terms
+=SUBTITLE Perl 6 Terms
 
-Most syntactic constructs in Perl 6 can be categorized in I<terms> and
+Most syntactic constructs in Perl 6 can be categorized in I<terms> and
 L<operators|/language/operators>.
 
 Here you can find an overview of different kinds of terms.
@@ -51,7 +51,7 @@ constructs a L<Num> with value C<3 * 10**8>.
     q|Other delimiters can be used too!|
 
 String literals are most often created with C<'> or C<">, however strings
-are actually a powerful sub-language of Perl 6. See L<Quoting Constructs|/language/quoting>.
+are actually a powerful sub-language of Perl 6. See L<Quoting Constructs|/language/quoting>.
 
 =head2 Regex
 
@@ -108,7 +108,7 @@ more details.
 
 =head1 Identifier terms
 
-There are built-in identifier terms in Perl 6, which are listed below.  In
+There are built-in identifier terms in Perl 6, which are listed below.  In
 addition one can add new identifier terms with the syntax:
 
     sub term:<forty-two> { 42 };

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Testing
 
-=SUBTITLE Writing and running tests in Perl 6
+=SUBTITLE Writing and running tests in Perl 6
 
 
 Testing code is an integral part of software development.  For instance, how
@@ -10,10 +10,10 @@ can one be sure the code works if there isn't some way to verify it behaves
 as desired?  This is the role of tests: to provide automated, repeatable
 verifications of code behaviour.
 
-In Perl 6, the L<Test|https://github.com/rakudo/rakudo/blob/nom/lib/Test.pm6> module provides a testing framework similar to the
-traditional Perl 5 L<Test::More|http://perldoc.perl.org/Test/More.html>
+In Perl 6, the L<Test|https://github.com/rakudo/rakudo/blob/nom/lib/Test.pm6> module provides a testing framework similar to the
+traditional Perl 5 L<Test::More|http://perldoc.perl.org/Test/More.html>
 module.  Thus, anyone familiar with C<Test::More> (and friends) should be
-comfortable with Perl 6's C<Test> module.  The C<Test> module is the testing
+comfortable with Perl 6's C<Test> module.  The C<Test> module is the testing
 module used by the official spectest suite.
 
 The testing functions emit output conforming to the L<Test Anything
@@ -34,7 +34,7 @@ A typical test file looks something like this:
 
     # .... tests
 
-We ensure that we're using Perl 6, via the C<use v6> pragma, then we load
+We ensure that we're using Perl 6, via the C<use v6> pragma, then we load
 the C<Test> module and specify where our libraries are.  We then specify how
 many tests we I<plan> to run (such that the testing framework can tell us if
 more or fewer tests were run than we expected) and when finished with the
@@ -47,7 +47,7 @@ command line:
 
     $ perl6 t/test-filename.t
 
-Or via the L<prove|http://perldoc.perl.org/prove.html> command from Perl 5,
+Or via the L<prove|http://perldoc.perl.org/prove.html> command from Perl 5,
 where one specifies C<perl6> as the executable to run the tests:
 
     $ prove --exec perl6 -r t

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Traps to avoid
 
-=SUBTITLE Traps to avoid when getting started with Perl 6
+=SUBTITLE Traps to avoid when getting started with Perl 6
 
 When learning a programming language, possibly with the background of being
 familiar with another programming language, there are always some things
@@ -11,10 +11,10 @@ discovery.
 
 This document aims to show common misconceptions.
 
-During the making of Perl 6 great pains were taken to get rid of warts in
+During the making of Perl 6 great pains were taken to get rid of warts in
 the syntax.  When you whack one wart, though, sometimes another pops up.  So
 a lot of time was spent finding the minimum number of warts or trying to put
-them where they would rarely be seen.  Because of this, Perl 6's warts are
+them where they would rarely be seen.  Because of this, Perl 6's warts are
 in different places than you may expect them to be when coming from another
 language.
 
@@ -123,7 +123,7 @@ C<nextsame> inside C<BUILDALL>, but not inside C<BUILD>).
     False
 
 Whitespace in regexes is, by default, considered an optional filler without
-semantics, just like in the rest of the Perl 6 language.
+semantics, just like in the rest of the Perl 6 language.
 
 Ways to match whitespace:
 
@@ -160,13 +160,13 @@ Instead, use an expression that produces a value when you want a value.
 
 =head2 Referencing the last element of an array
 
-In Perl 5 one could reference the last element of an array by asking for the
+In Perl 5 one could reference the last element of an array by asking for the
 "-1th" element of the array, e.g.:
 
     my @array = qw{victor alice bob charlie eve};
     say @array[-1];    #->  eve
 
-In Perl 6 it is not possible to use negative subscripts, however the same is
+In Perl 6 it is not possible to use negative subscripts, however the same is
 achieved by actually using a function, namely C<*-1>.  Thus accessing the
 last element of an array becomes:
 
@@ -206,11 +206,11 @@ than requiring every element to be checked on every call.
 
 =head2 Capitalizing a string
 
-In Perl 5 one could capitalize a string by using the C<ucfirst> function
+In Perl 5 one could capitalize a string by using the C<ucfirst> function
 
     say ucfirst "alice"; #-> Alice
 
-The C<ucfirst> function does not exist in Perl 6; one needs to use the
+The C<ucfirst> function does not exist in Perl 6; one needs to use the
 C<tc> method:
 
     say "alice".tc;      #-> Alice
@@ -225,10 +225,10 @@ Here, C<tc> means "title case".
 
 Interpolation in string literals can be too clever for your good.
 
-    "$foo<html></html>" # Perl 6 understands that as:
+    "$foo<html></html>" # Perl 6 understands that as:
     $foo<html> ~ '</html>'
 
-    "$foo(" ~ @args ~ ")" # Perl 6 understands that as:
+    "$foo(" ~ @args ~ ")" # Perl 6 understands that as:
     $foo( ~ @args ~ ")"   # and will produce very confusing error messages
 
 You can avoid those problems by surrounding all variables with C<{}>, with or
@@ -247,22 +247,22 @@ There are methods that Str inherits from Any that work on iterables like lists. 
 
 =head1 Operators
 
-Some operators commonly shared among other languages were repurposed in Perl 6 for other, more common, things:
+Some operators commonly shared among other languages were repurposed in Perl 6 for other, more common, things:
 
 =head2 Junctions
 
 The C<^>, C<|>, and C<&> are I<not> bitwise operators, they create L<Junctions|/type/Junction>. The corresponding
-bitwise operators in Perl 6 are: C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for booleans.
+bitwise operators in Perl 6 are: C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for booleans.
 
 =head2 String Ranges/Sequences
 
 In some languages, using strings as range end points, considers the entire string when figuring out what the next string
-should be; loosely treating the strings as numbers in a large base. Here's Perl 5 version:
+should be; loosely treating the strings as numbers in a large base. Here's Perl 5 version:
 
     say join ", ", "az".."bc"
     az, ba, bb, bc
 
-Such a range in Perl 6 will produce a different result, where I<each letter> will be ranged to a corresponding letter in the
+Such a range in Perl 6 will produce a different result, where I<each letter> will be ranged to a corresponding letter in the
 end point, producing more complex sequences:
 
     say join ", ", "az".."bc"'
@@ -273,7 +273,7 @@ end point, producing more complex sequences:
     say join ", ", "r2".."t3"
     r2, r3, s2, s3, t2, t3
 
-To achieve simpler behaviour, similar to the Perl 5 example above, use a sequence operator that calls C<.succ> method on the
+To achieve simpler behaviour, similar to the Perl 5 example above, use a sequence operator that calls C<.succ> method on the
 starting string:
 
     say join ", ", ("az", *.succ ... "bc")
@@ -283,7 +283,7 @@ starting string:
 
 =head2 Adverbs and Precedence
 
-Adverbs do have a precedence that may not follow the order of operators that is displayed on your screen. If two operators of equal precedence are followed by an adverb it will pick the first operator it finds in the abstract syntax tree. Use parentheses to help Perl 6 understand what you mean or use operators with looser precedence.
+Adverbs do have a precedence that may not follow the order of operators that is displayed on your screen. If two operators of equal precedence are followed by an adverb it will pick the first operator it finds in the abstract syntax tree. Use parentheses to help Perl 6 understand what you mean or use operators with looser precedence.
 
     my %x = a => 42;
     say !%x<b>:exists;            # dies with X::AdHoc

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -2,9 +2,9 @@
 
 =TITLE Typesystem
 
-=SUBTITLE Introduction to the type system of Perl 6
+=SUBTITLE Introduction to the type system of Perl 6
 
-=head1 Definition of a Perl 6 Type
+=head1 Definition of a Perl 6 Type
 
 =head2 Type objects
 
@@ -55,7 +55,7 @@ shares the name with the attribute:
     my $a = B.new.m;
     say $a.i; # OUTPUT«answer␤»
 
-Since C<$.i> method call is named C<i> and the attribute is named C<i>, Perl 6
+Since C<$.i> method call is named C<i> and the attribute is named C<i>, Perl 6
 lets us shortcut. The same applies to C<:$var>, C<:$!private-attribute>,
 C<:&attr-with-code-in-it>, and so on.
 
@@ -118,7 +118,7 @@ will import their methods into the target class. If the same method name occurs
 in multiple parents, the first added parent will win.
 
 If no C<is> trait is provided the default of L<C<Any>|/type/Any> will be used
-as a parent class. This forces all Perl 6 objects to have the same set of basic
+as a parent class. This forces all Perl 6 objects to have the same set of basic
 methods to provide an interface for introspection and coercion to basic types.
 
     class A {

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -4,11 +4,11 @@
 
 =SUBTITLE Input methods for unicode characters in editors and the shell
 
-Perl 6 allows the use of unicode characters as variable names.  Many
+Perl 6 allows the use of unicode characters as variable names.  Many
 operators are defined with unicode symbols (in particular the L<set/bag
 operators|/language/setbagmix#Set%2FBag_Operators>) as well as some quoting
 constructs.  Hence it is good to know how to enter these symbols into editors,
-the Perl 6 shell and the command line, especially if the symbols aren't
+the Perl 6 shell and the command line, especially if the symbols aren't
 available as actual characters on a keyboard.
 
 General information about entering unicode under various operating systems
@@ -113,7 +113,7 @@ following key combination (whitespace has been added for clarity):
 This also the method one would use to enter unicode characters into the
 C<perl6> REPL, if one has started the REPL inside a Unix shell.
 
-=head1 Unicode characters useful in Perl 6
+=head1 Unicode characters useful in Perl 6
 
 =head2 L<Guillemets|https://en.wikipedia.org/wiki/Guillemet>
 

--- a/doc/Language/unicode_texas.pod6
+++ b/doc/Language/unicode_texas.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Unicode symbols and their Texas (ASCII) counterparts
 
-The following unicode symbols can be used in Perl 6 without needing to
+The following unicode symbols can be used in Perl 6 without needing to
 load any additional modules.  Please note that the Since column
 applies to the version of Perl the symbol was known to be available.
 It is only mentioned if it is different from C<6.c>.
@@ -54,7 +54,7 @@ line), or C<Zp> (Separator, paragraph) property.
 =head1 Other acceptable single codepoints
 
 This list contains the single codepoints [and their Texas (ASCII)
-equivalents] that have a special meaning in Perl 6.
+equivalents] that have a special meaning in Perl 6.
 
 =table
   Symbol | Codepoint | Texas      | Since | Remarks

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Variables
 
-=SUBTITLE Variables in Perl 6
+=SUBTITLE Variables in Perl 6
 
 Variable names start with a special character called a I<sigil>, followed
 optionally by a second special character named I<twigil> and then an
@@ -128,7 +128,7 @@ See L<operators|/language/operators> for more details on precedence.
 =head2 Sigilless variables
 X<|\ (sigilless variables)>
 
-It is possible to create "variables" in Perl 6 that do not have sigils:
+It is possible to create "variables" in Perl 6 that do not have sigils:
 
     my \degrees = pi / 180;
     my \θ       = 15 * degrees;
@@ -253,9 +253,9 @@ directly accessed from within the class via C<!>:
     =end code
 
 Note how the attributes are declared as C<$.x> and C<$.y> but are still
-accessed via C<$!x> and C<$!y>. This is because in Perl 6 all attributes are
+accessed via C<$!x> and C<$!y>. This is because in Perl 6 all attributes are
 private and can be directly accessed within the class by using
-C<$!attribute-name>. Perl 6 may automatically generate accessor methods for
+C<$!attribute-name>. Perl 6 may automatically generate accessor methods for
 you though. For more details on objects, classes and their attributes see
 L<object orientation|/language/objects>.
 
@@ -360,7 +360,7 @@ not have an explicit parameter list. This is true for normal blocks too.
 Placeholder variables syntactically cannot have any type constraints. Be
 also aware that one cannot have placeholder variables with a single
 upper-case letter. This is disallowed in favor of being to able to catch
-some Perl 5-isms.
+some Perl 5-isms.
 
 =head2 The C<:> Twigil
 X<|$:>
@@ -415,7 +415,7 @@ X<|$~MAIN>X<|$~Quote>X<|$~Quasi>X<|$~Regex>X<|$~Trans>X<|$~P5Regex>
     $~Quasi      the current root of quasiquoting language
     $~Regex      the current root of regex language
     $~Trans      the current root of transliteration language
-    $~P5Regex    the current root of the Perl 5 regex language
+    $~P5Regex    the current root of the Perl 5 regex language
 
 You may C<supersede> or C<augment> these languages in your current lexical
 scope by using
@@ -940,7 +940,7 @@ L<Signature|/type/Signature>s. or subsequent assignments to a variable.
 
 =head1 Special Variables
 
-Perl 5 is infamous for its many obscure special variables. Perl 6 also has
+Perl 5 is infamous for its many obscure special variables. Perl 6 also has
 special variables but only has three that are extra short due to how often
 they're used. Other special variables have longer, more descriptive names.
 

--- a/doc/Programs/00-running.pod6
+++ b/doc/Programs/00-running.pod6
@@ -67,7 +67,7 @@ attempts to document all those currently in use.
 
   Appends a comma-delimited list of paths to C<@INC>. C<RAKUDOLIB> is evaluated first.
 
-=defn C<RAKUDO_MODULE_DEBUG> (I<Bool>; C<src/Perl 6/ModuleLoader.pm>)
+=defn C<RAKUDO_MODULE_DEBUG> (I<Bool>; C<src/Perl6/ModuleLoader.pm>)
 Causes the module loader to print debugging information to standard error.
 
 

--- a/doc/Programs/00-running.pod6
+++ b/doc/Programs/00-running.pod6
@@ -1,8 +1,8 @@
 =begin pod
 
-=TITLE Perl 6
+=TITLE Perl 6
 
-=SUBTITLE perl6 - the Rakudo Perl 6 Compiler
+=SUBTITLE perl6 - the Rakudo Perl 6 Compiler
 
 =head1 SYNOPSIS
 
@@ -67,7 +67,7 @@ attempts to document all those currently in use.
 
   Appends a comma-delimited list of paths to C<@INC>. C<RAKUDOLIB> is evaluated first.
 
-=defn C<RAKUDO_MODULE_DEBUG> (I<Bool>; C<src/Perl6/ModuleLoader.pm>)
+=defn C<RAKUDO_MODULE_DEBUG> (I<Bool>; C<src/Perl 6/ModuleLoader.pm>)
 Causes the module loader to print debugging information to standard error.
 
 

--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Debugging
 
-=SUBTITLE Debug Perl 6 programs
+=SUBTITLE Debug Perl 6 programs
 
 There are at least two useful debuggers available for Rakudo:
 
@@ -12,11 +12,11 @@ There are at least two useful debuggers available for Rakudo:
 
 =item L<Grammar::Debugger|https://modules.perl6.org/repo/Grammar::Debugger> (and C<Grammar::Tracer> in the same distribution)
 
- Simple tracing and debugging support for Perl 6 grammars
+ Simple tracing and debugging support for Perl 6 grammars
 
 Please see the documentation for these programs for further information.
 
 Historically others have existed and others are likely to be written in future,
-check the L<Perl 6 Modules|https://modules.perl6.org/> website.
+check the L<Perl 6 Modules|https://modules.perl6.org/> website.
 
 =end pod

--- a/doc/Programs/README.md
+++ b/doc/Programs/README.md
@@ -20,8 +20,8 @@ on:
 
   2016-05-06
 
-It was then modified to Perl 6 pod syntax.  At the moment, there
-is an error in the Perl 6 pod converter which throws an exception
+It was then modified to Perl 6 pod syntax.  At the moment, there
+is an error in the Perl 6 pod converter which throws an exception
 on leading hyphens in column one of a table row.  The error
 can be partially mitigated by escaping the '-', but the
 backslash will show in the rendered pod.  Rakudo bug #128221 has

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -6,7 +6,7 @@
 
     class Any is Mu { ... }
 
-While L<Mu|/type/Mu> is the root of the Perl 6 class hierarchy, C<Any> is the class
+While L<Mu|/type/Mu> is the root of the Perl 6 class hierarchy, C<Any> is the class
 that serves as a default base class for new classes, and as the base class for
 most built-in classes.
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -6,7 +6,7 @@
 
     class Attribute { }
 
-In Perl 6 lingo, an I<attribute> refers to a per-instance/object storage slot.
+In Perl 6 lingo, an I<attribute> refers to a per-instance/object storage slot.
 An C<Attribute> is used to talk about classes' and roles' attributes on the
 meta level.
 

--- a/doc/Type/Cancellation.pod6
+++ b/doc/Type/Cancellation.pod6
@@ -6,7 +6,7 @@
 
     my class Cancellation { ... }
 
-A low level part of the Perl 6 L<concurrency|/language/concurrency#Schedulers>
+A low level part of the Perl 6 L<concurrency|/language/concurrency#Schedulers>
 system. Some L<Scheduler> objects return a C<Cancellation> with the
 L<.cue|/type/Scheduler#method_cue> method which can be used to cancel the
 scheduled execution before normal completion.  C<Cancellation.cancelled> is a

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -6,7 +6,7 @@
 
     class Code is Any does Callable { ... }
 
-C<Code> is the ultimate base class of all code objects in Perl 6. It
+C<Code> is the ultimate base class of all code objects in Perl 6. It
 exposes functionality that all code objects have. While thunks are
 directly of type C<Code>, most code objects (such as those resulting
 from blocks, subroutines or methods) will be of some subclass of C<Code>.

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -215,7 +215,7 @@ returns its L<sine|https://en.wikipedia.org/wiki/Sine>.
     say sin(pi/4);          # 0.707106781186547
     say sin(pi/2);          # 1
 
-Note that Perl 6 is no computer algebra system, so C<sin(pi)> typically does
+Note that Perl 6 is no computer algebra system, so C<sin(pi)> typically does
 not produce an exact 0, but rather a very small L<floating-point
 number|/type/Num>.
 
@@ -1013,7 +1013,7 @@ smart-matches against C<$where> through the C<&filter>. With the default
 filter (first character to upper case, rest to lower) and matcher (which
 accepts everything), this title-cases each word:
 
-    say "perl 6 programming".wordcase;      # Perl 6 Programming
+    say "perl 6 programming".wordcase;      # Perl 6 Programming
 
 With a matcher:
 
@@ -1045,8 +1045,8 @@ character in the result.)
 If C<$string> is longer than C<$pattern>, the case information from the last character of
 C<$pattern> is applied to the remaining characters of C<$string>.
 
-    say "perL 6".samecase("A__a__"); # Perl 6
-    say "pERL 6".samecase("Ab");     # Perl 6
+    say "perL 6".samecase("A__a__"); # Perl 6
+    say "pERL 6".samecase("Ab");     # Perl 6
 
 =head2 routine uniname
 
@@ -1166,7 +1166,7 @@ Usage:
 Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and returns a list of Unicode codepoints for each character.
 
-    say "Perl 6".ords;              # 80 101 114 108 32 54
+    say "Perl 6".ords;              # 80 101 114 108 32 54
     say ords 10;                    # 49 48
 
 This is the list-returning version of L<ord>. The inverse operation in
@@ -1188,7 +1188,7 @@ Coerces the invocant (or in the sub form, the argument list) to a list of
 integers, and returns the string created by interpreting each integer as a
 Unicode codepoint, and joining the characters.
 
-    say <80 101 114 108 32 54>.chrs;    # Perl 6
+    say <80 101 114 108 32 54>.chrs;    # Perl 6
 
 This is the list-input version of L<chr>. The inverse operation is L<ords>.
 
@@ -1244,7 +1244,7 @@ and C<:p> adds them as L<Pairs|/type/Pair>:
 
     say 'abc'.split(/b/, :p)                # (a 0 => ｢b｣ c)
 
-Note that unlike in Perl 5, empty chunks are not removed from the result list.
+Note that unlike in Perl 5, empty chunks are not removed from the result list.
 For that behavior, use the `:skip-empty` named argument:
 
     say ("f,,b,c,d".split: /","/             ).perl  # ("f", "", "b", "c", "d")

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1166,7 +1166,7 @@ Usage:
 Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and returns a list of Unicode codepoints for each character.
 
-    say "Perl 6".ords;              # 80 101 114 108 32 54
+    say "Perl 6".ords;              # 80 101 114 108 160 54
     say ords 10;                    # 49 48
 
 This is the list-returning version of L<ord>. The inverse operation in
@@ -1188,7 +1188,7 @@ Coerces the invocant (or in the sub form, the argument list) to a list of
 integers, and returns the string created by interpreting each integer as a
 Unicode codepoint, and joining the characters.
 
-    say <80 101 114 108 32 54>.chrs;    # Perl 6
+    say <80 101 114 108 160 54>.chrs;   # Perl 6
 
 This is the list-input version of L<chr>. The inverse operation is L<ords>.
 

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -108,7 +108,7 @@ prints
 
 to the standard error stream.
 
-This is in spirit similar to Perl 5's L<Data::Dumper
+This is in spirit similar to Perl 5's L<Data::Dumper
 module|http://perldoc.perl.org/Data/Dumper.html>.
 
 Please note that C<dd> will ignore named parameters. You can use a capture to

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -26,7 +26,7 @@ unless when stated otherwise.
 
 =comment TODO: Investigate if the $SPEC = $*SPEC, :$CWD = $*CWD params that
          a bunch of these routines have in their signature in Rakudo, are
-         "official" Perl 6 API, and if so, document them here in a central
+         "official" Perl 6 API, and if so, document them here in a central
          place so all the routine documentations can link to it without
          having to repeat it.
 
@@ -410,12 +410,12 @@ creation time.
 
 X<-e> X<-f>
 
-The C<-e> and C<-f> file test operators do not exist in Perl 6. Use instead
+The C<-e> and C<-f> file test operators do not exist in Perl 6. Use instead
 C<:e> and C<:f>.
 
 X<-M> X<-A> X<-C>
 
-The C<-M>, C<-A> and C<-C> file test operators do not exist in Perl 6, use
+The C<-M>, C<-A> and C<-C> file test operators do not exist in Perl 6, use
 instead the L<modified|/type/IO::Path#method_modified>,
 L<accessed|/type/IO::Path#method_accessed> and
 L<changed|/type/IO::Path#method_changed> methods instead.

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -32,7 +32,7 @@ use v6;
 await IO::Socket::Async.connect('localhost', 3333).then( -> $p {
     if $p.status {
         given $p.result {
-            .print('Hello, Perl 6');
+            .print('Hello, Perl 6');
             react {
                 whenever .Supply() -> $v {
                     $v.say;
@@ -65,7 +65,7 @@ And an associated client might be:
 =begin code
 
 my $socket = IO::Socket::Async.udp();
-await $socket.print-to('localhost', 3333, "Hello, Perl 6!");
+await $socket.print-to('localhost', 3333, "Hello, Perl 6!");
 
 =end code
 

--- a/doc/Type/IO/Socket/INET.pod6
+++ b/doc/Type/IO/Socket/INET.pod6
@@ -30,7 +30,7 @@ And a client that connects to it, and prints out what the server answers:
 use v6;
 
 my $conn = IO::Socket::INET.new(:host<localhost>, :port(3333));
-$conn.print: 'Hello, Perl 6';
+$conn.print: 'Hello, Perl 6';
 say $conn.recv;
 $conn.close;
 =end code

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -20,7 +20,7 @@ other operations with Instants are undefined.
 
 =head1 Future Leap Seconds
 
-Perl 6's methods that involve knowledge of leap seconds do not
+Perl 6's methods that involve knowledge of leap seconds do not
 make any guesses for leap seconds in the future and only use the already-known
 leap seconds. This means you can get different results, depending on the
 compiler version you're using. For example, the December 31, 2016 leap second

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -119,7 +119,7 @@ this code that implements it:
     say @pieces; # [5 4 3 2]
 
 For a more detailed discussion, see
-L<this blog post|http://perl6.party/post/Perl6-.polymod-break-up-a-number-into-denominations>
+L<this blog post|http://perl6.party/post/Perl 6-.polymod-break-up-a-number-into-denominations>
 
 =head2 routine is-prime
 

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -119,7 +119,7 @@ this code that implements it:
     say @pieces; # [5 4 3 2]
 
 For a more detailed discussion, see
-L<this blog post|http://perl6.party/post/Perl 6-.polymod-break-up-a-number-into-denominations>
+L<this blog post|http://perl6.party/post/Perl6-.polymod-break-up-a-number-into-denominations>
 
 =head2 routine is-prime
 

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -6,7 +6,7 @@
 
     class Label { ... }
 
-In Perl 6, you can give for example loops a label, and use it to control that
+In Perl 6, you can give for example loops a label, and use it to control that
 loop (instead of the inner-most loop).
 
     USERS:          # the label

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -15,7 +15,7 @@ Arrays to have every value of the list stored in a container.
 
 =head1 Items, Flattening and Sigils
 
-In Perl 6, assigning a C<List> to a scalar variable does not lose
+In Perl 6, assigning a C<List> to a scalar variable does not lose
 information. The difference is that iteration generally treats a
 list (or any other list-like object, like a L<Seq> or an L<Array>)
 inside a scalar as a single element, as long as it's part of another .

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -22,7 +22,7 @@ I<critical section>).
 Locks are reentrant, that is, a thread that holds the lock can lock it again
 without blocking.
 
-High-level Perl 6 code should avoid the direct usage of locks, because they
+High-level Perl 6 code should avoid the direct usage of locks, because they
 are not composable. Instead, high-level constructs such as
 L<Promise|/type/Promise>, L<Channel|/type/Channel> and Supply should be used
 whenever possible.

--- a/doc/Type/Metamodel/AttributeContainer.pod6
+++ b/doc/Type/Metamodel/AttributeContainer.pod6
@@ -23,7 +23,7 @@ It can for example be of L<type Attribute|/type/Attribute>.
 
     method attributes(Metamodel::AttributeContainer: $obj)
 
-Returns a list of attributes. For most Perl 6 types, these will be objects of
+Returns a list of attributes. For most Perl 6 types, these will be objects of
 L<type Attribute|/type/Attribute>.
 
 =head2 method set_rw

--- a/doc/Type/Metamodel/C3MRO.pod6
+++ b/doc/Type/Metamodel/C3MRO.pod6
@@ -29,7 +29,7 @@ say Weird.^mro;
     # (Weird) (Child1) (GrandChild2) (Child2) (CommonAncestor) (Any) (Mu)
 =end code
 
-C3 is the default resolution order for classes and grammars in Perl 6.
+C3 is the default resolution order for classes and grammars in Perl 6.
 Note that roles generally do not appear in the method resolution order (unless
 they are punned into a class, from which another type inherits), because
 methods are copied into classes at role application time.

--- a/doc/Type/Metamodel/ClassHOW.pod6
+++ b/doc/Type/Metamodel/ClassHOW.pod6
@@ -2,7 +2,7 @@
 
 =TITLE class Metamodel::ClassHOW
 
-=SUBTITLE Metaobject representing a Perl 6 class.
+=SUBTITLE Metaobject representing a Perl 6 class.
 
     class Metamodel::ClassHOW
         does Metamodel::Naming

--- a/doc/Type/Metamodel/MethodContainer.pod6
+++ b/doc/Type/Metamodel/MethodContainer.pod6
@@ -45,7 +45,7 @@ The returned list contains objects of type L<Method>, which you can
 use to introspect their signatures and call them.
 
 Some introspection method-look-alikes like L<C<WHAT>|/language/mop#WHAT> will
-not show up, although they are present in any Perl 6 object. They are handled
+not show up, although they are present in any Perl 6 object. They are handled
 at the grammar level and will likely remain so for bootstrap reasons.
 
 =head2 method method_table

--- a/doc/Type/Metamodel/PrivateMethodContainer.pod6
+++ b/doc/Type/Metamodel/PrivateMethodContainer.pod6
@@ -6,7 +6,7 @@
 
     role Metamodel::PrivateMethodContainer { ... }
 
-In Perl 6, classes, roles and grammars can have private methods, that is,
+In Perl 6, classes, roles and grammars can have private methods, that is,
 methods that are only callable from within the class, and are not inherited to
 types derived by inheritance.
 
@@ -42,7 +42,7 @@ Returns a hash of C«name => &method_object»
 =begin comment
 
 TODO: document find_private_method, once we've figured out how to represent
-or catch nqp::null in Perl 6 land
+or catch nqp::null in Perl 6 land
 
 =end comment
 

--- a/doc/Type/Metamodel/Trusting.pod6
+++ b/doc/Type/Metamodel/Trusting.pod6
@@ -9,7 +9,7 @@
 Normally, code in a class or role can only access its own private methods. If
 another type declares that it trusts that first class, then access to private
 methods of that second type is possible. C<Metamodel::Trusting> implements
-that aspect of the Perl 6 object system.
+that aspect of the Perl 6 object system.
 
     class A {
         my class B {

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -2,7 +2,7 @@
 
 =TITLE class Mu
 
-=SUBTITLE The root of the Perl 6 type hierarchy.
+=SUBTITLE The root of the Perl 6 type hierarchy.
 
     class Mu { ... }
 

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -52,7 +52,7 @@ C<Nil>.
 
 When assigned to a container, the C<Nil> value (but not any subclass of
 C<Nil>) will attempt to revert the container to its default value; if no
-such default is declared, Perl 6 assumes C<Any>. However, if the container's
+such default is declared, Perl 6 assumes C<Any>. However, if the container's
 type is constrained with C<:D>, assigning C<Nil> to it will immediately throw
 an exception.  (In contrast, an instantiated C<Failure> matches C<:D>
 because it's a definite value, but will fail to match the actual nominal

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -29,6 +29,6 @@ Returns a pseudo random number between 0 and the invocant.
 
 Seeds the pseudo random number generator used by L<Num.rand|/type/Num#rand> with
 the provided value. Note that C<srand> is called with a platform dependent
-value when a Perl 6 program is started.
+value when a Perl 6 program is started.
 
 =end pod

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -19,7 +19,7 @@ Binary numeric operations return an object of the "wider" type:
 So for example the product of a L<Rat> and an L<Int> is a L<Rat>.
 
 Unary operations that in pure math usually return an irrational number
-generally return L<Num> in Perl 6.
+generally return L<Num> in Perl 6.
 
 =head1 Methods
 

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -15,7 +15,7 @@ the exit code. It is typically created through the C<run> subroutine:
     say "Output was $captured-output.perl()";       # Output was "Hallo world\n"
 
 Piping several commands is easy too. To achieve the equivalent of the pipe
-C<echo "Hello, world" | cat -n> in Perl 6, and capture the output from the
+C<echo "Hello, world" | cat -n> in Perl 6, and capture the output from the
 second command, you can do
 
     my $p1 = run 'echo', 'Hello, world', :out;

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -10,7 +10,7 @@ C<Rational> is the common role for numbers that are stored as pairs of
 numerator and denominator. It is parameterized by the types of the numerator
 and denominator.
 
-Built into Perl 6 are L<Rat> and L<FatRat>, which both do the C<Rational> role.
+Built into Perl 6 are L<Rat> and L<FatRat>, which both do the C<Rational> role.
 
 =head1 Methods
 

--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -7,7 +7,7 @@
     class Scalar { ... }
 
 A C<Scalar> is an internal indirection which is for most purposes
-invisible during ordinary use of Perl 6.  It is the default container
+invisible during ordinary use of Perl 6.  It is the default container
 type associated with the C<$> sigil.  A literal C<Scalar> may be
 placed around a literal value by enclosing the value in C<$(…)>.
 This notation will appear in the output of a C<.perl> method in
@@ -23,7 +23,7 @@ In addition C<Scalar>s delegate all method calls to the value which
 they contain.  As such, C<Scalar>s are for the most part invisible.
 There is, however, one important place where C<Scalar>s have a visible
 impact: a C<Scalar> will shield its contents from flattening by most
-Perl 6 core list operations.
+Perl 6 core list operations.
 
 A C<$>-sigiled variable may be bound directly to a value with no
 intermediate C<Scalar> using the binding operator C<:=>.  You can

--- a/doc/Type/Stash.pod6
+++ b/doc/Type/Stash.pod6
@@ -7,7 +7,7 @@
     class Stash is Hash { }
 
 A C<Stash> is a hash that is used for symbol tables at the package scoping level
-in Perl 6.
+in Perl 6.
 
 To get a Stash, you can call the C<.WHO> pseudo-method on a package (because it
 answers the question I<who lives here?>), or if you write the package name as

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -103,11 +103,11 @@ every word is capitalized, and all the other letters lowercased.
 
 =head2 method lcfirst
 
-Perl 6 does not have a C<lcfirst> function.
+Perl 6 does not have a C<lcfirst> function.
 
 =head2 method ucfirst
 
-Perl 6 does not have a C<ucfirst> function.  See L<tc>.
+Perl 6 does not have a C<ucfirst> function.  See L<tc>.
 
 =head2 method unival
 
@@ -131,7 +131,7 @@ string, and C<NaN> for non-numeric characters.
 
 =head2 method length
 
-Perl 6 does not have a C<length> function.  See L<chars>, L<elems>,
+Perl 6 does not have a C<length> function.  See L<chars>, L<elems>,
  or L<codes>.
 
 =head2 routine chars
@@ -401,7 +401,7 @@ Compatibility:
 
 =end table
 
-Perl 5 (non-)compatibility:
+Perl 5 (non-)compatibility:
 
 =begin table
 
@@ -431,11 +431,11 @@ Examples:
  printf('%2$d %1$d', 12, 34);       # 34 12
  printf("%x", 255);                 # ff
 
-Special case:  printf("<b>%s</b>\n", "Perl 6")  will not work use either of the following:
+Special case:  printf("<b>%s</b>\n", "Perl 6")  will not work use either of the following:
 
- printf Q:b "<b>%s</b>\n",  "Perl 6";
- printf     "<b>\%s</b>\n", "Perl 6";
- printf     "<b>%s\</b>\n", "Perl 6";
+ printf Q:b "<b>%s</b>\n",  "Perl 6";
+ printf     "<b>\%s</b>\n", "Perl 6";
+ printf     "<b>%s\</b>\n", "Perl 6";
 
 =head2 sub sprintf
 
@@ -494,7 +494,7 @@ Compatibility:
 
 =end table
 
-Perl 5 (non-)compatibility:
+Perl 5 (non-)compatibility:
 
 =begin table
 
@@ -520,11 +520,11 @@ Examples:
 
  sprintf "%ld a big number, %lld a bigger number\n", 4294967295, 4294967296;
 
-Special case:  sprintf("<b>%s</b>\n", "Perl 6")  will not work use either of the following:
+Special case:  sprintf("<b>%s</b>\n", "Perl 6")  will not work use either of the following:
 
- sprintf Q:b "<b>%s</b>\n",  "Perl 6";
- sprintf     "<b>\%s</b>\n", "Perl 6";
- sprintf     "<b>%s\</b>\n", "Perl 6";
+ sprintf Q:b "<b>%s</b>\n",  "Perl 6";
+ sprintf     "<b>\%s</b>\n", "Perl 6";
+ sprintf     "<b>%s\</b>\n", "Perl 6";
 
 =head2 method starts-with
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -12,7 +12,7 @@ L<Channel|/type/Channel>, but it can have multiple subscribers
 
 It is a thread-safe implementation of the
 L<Observer Pattern|https://en.wikipedia.org/wiki/Observer_pattern>,
-and central to supporting reactive programming in Perl 6.
+and central to supporting reactive programming in Perl 6.
 
 
 There are two types of Supplies: C<live> and C<on demand>. When tapping into a

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -7,7 +7,7 @@
     class Version { }
 
 Version objects identify version of software components (and potentially other
-entities). Perl 6 uses them internally for versioning modules.
+entities). Perl 6 uses them internally for versioning modules.
 
 A version consists of several parts, which are visually represented by joining
 them with a dot. A version part is usually an integer, a string like C<alpha>,

--- a/doc/Type/X/Bind/NativeType.pod6
+++ b/doc/Type/X/Bind/NativeType.pod6
@@ -10,7 +10,7 @@ Compile-time error thrown when trying to bind to a natively typed variable.
 
 Since native variables explicitly don't have the concept of a container at
 run time. Thus it does not make sense to support both binding and assignment,
-and Perl 6 supports only assignment (which makes more sense, because native
+and Perl 6 supports only assignment (which makes more sense, because native
 types are value types). So use assignment for natively typed variables.
 
 For example the code

--- a/doc/Type/X/NYI.pod6
+++ b/doc/Type/X/NYI.pod6
@@ -9,11 +9,11 @@
 Error class for unimplemented features. I<NYI> stands for I<Not Yet
 Implemented>.
 
-If a Perl 6 compiler is not yet feature complete, it may throw an C<X::NYI>
+If a Perl 6 compiler is not yet feature complete, it may throw an C<X::NYI>
 exception when a program uses a feature that it can detect is not yet
 implemented.
 
-A full-featured Perl 6 compiler must not throw such exceptions, but
+A full-featured Perl 6 compiler must not throw such exceptions, but
 still provide the C<X::NYI> class for compatibility reasons.
 
 A typical error message is

--- a/doc/Type/X/Obsolete.pod6
+++ b/doc/Type/X/Obsolete.pod6
@@ -6,7 +6,7 @@
 
     class X::Obsolete does X::Comp { }
 
-Syntax error thrown when obsolete (mostly Perl 5) syntax is detected.
+Syntax error thrown when obsolete (mostly Perl 5) syntax is detected.
 
 For example
 
@@ -15,7 +15,7 @@ For example
 dies with
 
     ===SORRY!===
-    Unsupported use of /i; in Perl 6 please use :i
+    Unsupported use of /i; in Perl 6 please use :i
 
 =head1 Methods
 
@@ -36,6 +36,6 @@ Describes what to use instead of the obsolete syntax.
     method when() returns Str:D
 
 Returns a string describing the state of the language (usually
-C<" in Perl 6">).
+C<" in Perl 6">).
 
 =end pod

--- a/doc/Type/X/Parameter/MultipleTypeConstraints.pod6
+++ b/doc/Type/X/Parameter/MultipleTypeConstraints.pod6
@@ -7,7 +7,7 @@
     class X::Parameter::MultipleTypeConstraints does X::Comp { }
 
 Compile time error thrown when a parameter has multiple type constraints.
-This is not allowed in Perl 6.0.
+This is not allowed in Perl 6.0.
 
 Example:
 

--- a/doc/Type/X/Syntax/Malformed.pod6
+++ b/doc/Type/X/Syntax/Malformed.pod6
@@ -6,7 +6,7 @@
 
     class X::Syntax::Malformed does X::Syntax { ... }
 
-The Perl 6 compiler throws errors of type C<X::Syntax::Malformed> when it
+The Perl 6 compiler throws errors of type C<X::Syntax::Malformed> when it
 knows what kind of declaration it is parsing, and encounters a syntax error,
 but can't give a more specific error message.
 

--- a/doc/Type/X/Syntax/P5.pod6
+++ b/doc/Type/X/Syntax/P5.pod6
@@ -2,11 +2,11 @@
 
 =TITLE class X::Syntax::P5
 
-=SUBTITLE Compilation error due to use of Perl 5-only syntax
+=SUBTITLE Compilation error due to use of Perl 5-only syntax
 
     class X::Syntax::P5 does X::Syntax { }
 
-Syntax error thrown when some piece of code is clearly Perl 5, not Perl 6.
+Syntax error thrown when some piece of code is clearly Perl 5, not Perl 6.
 
 For example
 
@@ -15,7 +15,7 @@ For example
 dies with
 
     ===SORRY!===
-    This appears to be Perl 5 code
+    This appears to be Perl 5 code
 
 
 =end pod


### PR DESCRIPTION
For https://github.com/perl6/doc/issues/746