### PR TITLE
The TOC animation was removed

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -53,12 +53,12 @@ function setup_collapsible_TOC() {
                 var el = $(this);
                 if (el.text() == '[hide]') {
                     Cookies.set('toc_state', 'hidden');
-                    el.parents('nav').find('tbody').slideUp();
+                    el.parents('nav').find('tbody').hide();
                     el.text('[show]');
                 }
                 else {
                     Cookies.set('toc_state', 'shown');
-                    el.parents('nav').find('tbody').slideDown();
+                    el.parents('nav').find('tbody').show();
                     el.text('[hide]');
                 }
 


### PR DESCRIPTION
We already decided at https://github.com/perl6/doc/issues/686 that the delay should be removed anyway, since it has no sense. Now someone have to just remove it's remainder. After this original issue can be closed.