### PR TITLE
Change 'mayor' to 'major' in my_version pointers example

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -121,9 +121,9 @@ call, the argument must be manually encoded and passed as C<CArray[uint8]>:
 When the signature of your native function needs a pointer to some native type
 (C<int32>, C<uint32>, etc.) all you need to do is declare the argument C<is rw> :
 
-    # C prototype is void my_version(int *mayor, int *minor)
+    # C prototype is void my_version(int *major, int *minor)
     sub my_version(int32 is rw, int32 is rw) is native('foo') { * }
-    my_version(my int32 $mayor, my int32 $minor); # Pass a pointer to
+    my_version(my int32 $major, my int32 $minor); # Pass a pointer to
 
 Sometimes you need to get a pointer (for example, a library handle) back from a
 C library. You don't care about what it points to - you just need to keep hold


### PR DESCRIPTION
The ['Basic use of Pointers' section of the Native Calling documentation](https://docs.perl6.org/language/nativecall#Basic_use_of_Pointers) previously read:

```
# C prototype is void my_version(int *mayor, int *minor)
sub my_version(int32 is rw, int32 is rw) is native('foo') { * }
my_version(my int32 $mayor, my int32 $minor); # Pass a pointer to
```

I changed both instances of 'mayor' to 'major'.