### PR TITLE
New pod config option: 'signature'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,16 @@ To export examples from all .pod6-files use `make extract-examples`. To run
 individual tests pick the right .p6-file from `examples/` as a parameter to
 `perl6`.
 
+### Signatures
+
+Signatures are part of actual code and need to be tested too. But without the body every
+signature will cause an error during the test. Use the pod-config option `signature` to
+automatically add an empty body.
+
+    =begin code :signature
+        method new(*@codes)
+    =end code
+
 ### Skipping tests
 
 Some examples fail with compile time exceptions and would interrupt the test

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -20,7 +20,9 @@ List or a list-like type.
 
 Defined as:
 
-    multi method ACCEPTS(Any:D: Mu $other) {}
+=begin code :signature
+    multi method ACCEPTS(Any:D: Mu $other)
+=end code
 
 Usage:
 
@@ -36,7 +38,9 @@ Many built-in types override this for more specific comparisons
 
 Defined as:
 
-    method any() returns Junction:D {}
+=begin code :signature
+    method any() returns Junction:D
+=end code
 
 Usage:
 
@@ -54,7 +58,9 @@ C<any>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method all() returns Junction:D {}
+=begin code :signature
+    method all() returns Junction:D
+=end code
 
 Usage:
 
@@ -72,7 +78,9 @@ C<all>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method one() returns Junction:D {}
+=begin code :signature
+    method one() returns Junction:D
+=end code
 
 Usage:
 
@@ -90,7 +98,9 @@ C<one>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-    method none() returns Junction:D {}
+=begin code :signature
+    method none() returns Junction:D
+=end code
 
 Usage:
 
@@ -127,8 +137,10 @@ into the newly created Array.
 
 Defined as:
 
-    multi sub    reverse(*@list ) returns List:D {}
-    multi method reverse(List:D:) returns List:D {}
+=begin code :signature
+    multi sub    reverse(*@list ) returns List:D
+    multi method reverse(List:D:) returns List:D
+=end code
 
 Usage:
 
@@ -163,8 +175,10 @@ Examples:
 Defined as:
 
     proto method map(|) is nodal { * }
-    multi method map(\SELF: &block;; :$label, :$item) {}
-    multi method map(HyperIterable:D: &block;; :$label) {}
+=begin code :signature
+    multi method map(\SELF: &block;; :$label, :$item)
+    multi method map(HyperIterable:D: &block;; :$label)
+=end code
 
 C<map> will iterate over the invocant and apply the number of positional
 parameters of the code object from the invocant per call.  The returned values
@@ -174,7 +188,9 @@ of the code object will become elements of the returned C<Seq>.
 
 Defined as:
 
-    method deepmap(&block -->List) is nodal {}
+=begin code :signature
+    method deepmap(&block -->List) is nodal
+=end code
 
 C<deepmap> will apply C<&block> to each element and return a new C<List> with
 the return values of C<&block>, unless the element does the C<Iterable> role.
@@ -187,7 +203,9 @@ For those elements C<deepmap> will descend recursively into the sublist.
 
 Defined as:
 
-    method duckmap(&block) is rw is nodal {}
+=begin code :signature
+    method duckmap(&block) is rw is nodal
+=end code
 
 C<duckmap> will apply C<&block> on each element and return a new list with
 defined return values of the block. For undefined return values, C<duckmap>
@@ -246,7 +264,9 @@ Interprets the invocant as a list, and returns the last index of that list.
 
 =head2 method pairup
 
-    method pairup() returns List {}
+=begin code :signature
+    method pairup() returns List
+=end code
 
 Interprets the invocant as a list, and constructs a list of
 L<pairs|/type/Pair> from it, in the same way that assignment to a
@@ -259,7 +279,9 @@ list item, if any, is considered to be a key again).
 
 =head2 sub exit
 
-    sub exit(Int() $status = 0) {}
+=begin code :signature
+    sub exit(Int() $status = 0)
+=end code
 
 Exits the current process with return code C<$status>.
 

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -15,8 +15,10 @@ scalar containers, which means you can assign to array elements.
 
 Defined as:
 
-    multi sub    pop(Array:D ) {}
-    multi method pop(Array:D:) {}
+=begin code :signature
+    multi sub    pop(Array:D )
+    multi method pop(Array:D:)
+=end code
 
 Usage:
 
@@ -40,8 +42,10 @@ Example:
 
 Defined as:
 
-    multi sub    push(Array:D, **@values) returns Array:D {}
-    multi method push(Array:D: **@values) returns Array:D {}
+=begin code :signature
+    multi sub    push(Array:D, **@values) returns Array:D
+    multi method push(Array:D: **@values) returns Array:D
+=end code
 
 Usage:
 
@@ -88,8 +92,11 @@ Defined as
 =begin code :skip-test
     sub append(\array, elems)
 =end code
-    multi method append(Array:D: \values) {}
-    multi method append(Array:D: **@values is raw) {}
+=begin code :signature
+    multi method append(Array:D: \values)
+    multi method append(Array:D: **@values is raw)
+=end code
+
 
 Usage:
 
@@ -117,8 +124,10 @@ Example:
 
 Defined as:
 
-    multi sub    shift(Array:D ) {}
-    multi method shift(Array:D:) {}
+=begin code :signature
+    multi sub    shift(Array:D )
+    multi method shift(Array:D:)
+=end code
 
 Usage:
 
@@ -142,8 +151,11 @@ Example:
 
 Defined as:
 
-    multi sub    unshift(Array:D, **@values) returns Array:D {}
-    multi method unshift(Array:D: **@values) returns Array:D {}
+=begin code :signature
+    multi sub    unshift(Array:D, **@values) returns Array:D
+    multi method unshift(Array:D: **@values) returns Array:D
+=end code
+
 
 Usage:
 
@@ -175,8 +187,11 @@ Defined as
 =begin code :skip-test
     sub prepend(\array, elems)
 =end code
-    multi method prepend(Array:D: \values) {}
-    multi method prepend(Array:D: **@values is raw) {}
+=begin code :signature
+    multi method prepend(Array:D: \values)
+    multi method prepend(Array:D: **@values is raw)
+=end code
+
 
 Usage:
 
@@ -198,8 +213,11 @@ Example:
 
 Defined as:
 
-    multi sub    splice(@list,  $start, $elems?, *@replacement) returns Array {}
-    multi method splice(Array:D $start, $elems?, *@replacement) returns Array {}
+=begin code :signature
+    multi sub    splice(@list,  $start, $elems?, *@replacement) returns Array
+    multi method splice(Array:D $start, $elems?, *@replacement) returns Array
+=end code
+
 
 Usage:
 
@@ -243,7 +261,9 @@ Example:
 
 Defined as:
 
-    method default {}
+=begin code :signature
+    method default
+=end code
 
 Usage:
 
@@ -272,7 +292,9 @@ the type object C<(Any)>.
 
 Defined as:
 
-    method of {}
+=begin code :signature
+    method of
+=end code
 
 Usage:
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -36,7 +36,9 @@ The usual way to obtain an object of type C<Attribute> is by introspection:
 
 Defined as:
 
-    method name(Attribute:D:) returns Str:D {}
+=begin code :signature
+    method name(Attribute:D:) returns Str:D
+=end code
 
 Usage:
 
@@ -51,7 +53,9 @@ so if an attribute is declared as C<has $.a>, the name returned is C<$!a>.
 
 Defined as:
 
-    method package(Attribute:D:) returns Mu:U {}
+=begin code :signature
+    method package(Attribute:D:) returns Mu:U
+=end code
 
 Usage:
 
@@ -65,7 +69,9 @@ Returns the package (class/grammar/role) to which this attribute belongs.
 
 Defined as:
 
-    method has_accessor(Attribute:D:) returns Bool:D {}
+=begin code :signature
+    method has_accessor(Attribute:D:) returns Bool:D
+=end code
 
 Usage:
 
@@ -79,7 +85,9 @@ Returns C<True> if the attribute has a public accessor method.
 
 Defined as:
 
-    method readonly(Attribute:D:) returns Bool:D {}
+=begin code :signature
+    method readonly(Attribute:D:) returns Bool:D
+=end code
 
 Usage:
 
@@ -94,7 +102,9 @@ Returns C<False> for attributes marked as C<is rw>.
 
 Defined as:
 
-    method type(Attribute:D:) returns Mu {}
+=begin code :signature
+    method type(Attribute:D:) returns Mu
+=end code
 
 Usage:
 
@@ -108,7 +118,9 @@ Returns the type constraint of the attribute.
 
 Defined as:
 
-    method get_value(Attribute:D: Mu $instance) {}
+=begin code :signature
+    method get_value(Attribute:D: Mu $instance)
+=end code
 
 Usage:
 
@@ -125,7 +137,9 @@ used with care.  Here be dragons.
 
 Defined as:
 
-    method set_value(Attribute:D: Mu $instance, Mu \new_val) {}
+=begin code :signature
+    method set_value(Attribute:D: Mu $instance, Mu \new_val)
+=end code
 
 Usage:
 
@@ -140,7 +154,9 @@ used with care.  Here be dragons.
 
 =head2 trait is required
 
-    multi sub trait_mod:<is> (Attribute $attr, :$required!) {}
+=begin code :signature
+    multi sub trait_mod:<is> (Attribute $attr, :$required!)
+=end code
 
 Marks an attribute as being required.  If a value is not provided
 during object construction, an exception is thrown.
@@ -162,7 +178,9 @@ constructors written using L<bless>.
 
 =head2 trait is rw
 
-    multi sub trait_mod:<is> (Attribute:D $attr, :$rw!) {}
+=begin code :signature
+    multi sub trait_mod:<is> (Attribute:D $attr, :$rw!)
+=end code
 
 Marks an attribute as read/write as opposed to the default
 C<readonly>.  The default accessor for the attribute will return a

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -12,7 +12,9 @@ An enum for boolean true/false decisions.
 
 =head2 routine succ
 
-    method succ() returns Bool:D {}
+=begin code :signature
+    method succ() returns Bool:D
+=end code
 
 Returns C<True>.
 
@@ -23,7 +25,9 @@ C<succ> is short for "successor"; it returns the next enum value. Bool is a spec
 
 =head2 routine pred
 
-    method pred() returns Bool:D {}
+=begin code :signature
+    method pred() returns Bool:D
+=end code
 
 Returns C<False>.
 
@@ -34,7 +38,9 @@ C<pred> is short for "predecessor"; it returns the previous enum value. Bool is 
 
 =head2 routine enums
 
-    method enums() returns Hash:D {}
+=begin code :signature
+    method enums() returns Hash:D
+=end code
 
 Returns a L<Hash|/type/Hash> of enum-pairs. Works on both the C<Bool> type
 and any key.
@@ -46,13 +52,17 @@ and any key.
 
 =head2 prefix ?
 
-    multi sub prefix:<?>(Mu) returns Bool:D {}
+=begin code :signature
+    multi sub prefix:<?>(Mu) returns Bool:D
+=end code
 
 Coerces its argument to C<Bool>.
 
 =head2 prefix so
 
-    multi sub prefix:<so>(Mu) returns Bool:D {}
+=begin code :signature
+    multi sub prefix:<so>(Mu) returns Bool:D
+=end code
 
 Coerces its argument to C<Bool>, has looser precedence than C<< prefix:<?> >>.
 

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -77,14 +77,18 @@ data,) should be used to create a client or a server respectively.
 
 =head2 method connect
 
-    method connect(Str $host, Int $port) returns Promise {}
+=begin code :signature
+    method connect(Str $host, Int $port) returns Promise
+=end code
 
 Attempts to connect to the TCP server specified by C<$host> and C<$port>,
 returning a L<Promise> that will either be kept with a connected L<IO::Socket::Async> or broken if the connection cannot be made.
 
 =head2 method listen
 
-    method listen(Str $host, Int $port) returns Supply {}
+=begin code :signature
+    method listen(Str $host, Int $port) returns Supply
+=end code
 
 Creates a listening socket on the specified C<$host> and C<$port>, returning
 a L<Supply> to which the accepted client L<IO::Socket::Async>s will be C<emit>ted. This L<Supply> should be tapped to
@@ -95,7 +99,9 @@ should be C<close>d.
 
 =head2 method udp
 
-    method udp(IO::Socket::Async:U: :$broadcast ) returns IO::Socket::Async {}
+=begin code :signature
+    method udp(IO::Socket::Async:U: :$broadcast ) returns IO::Socket::Async
+=end code
 
 Returns an initialised C<IO::Socket::Async> client object that is
 configured to send UDP messages using C<print-to> or C<write-to>.  The
@@ -104,7 +110,9 @@ the socket to send packets to a broadcast address.
 
 =head2 method bind-udp
 
-    method bind-udp(IO::Socket::Async:U: Str() $host, Int() $port, :$broadcast) returns IO::Socket::Async {}
+=begin code :signature
+    method bind-udp(IO::Socket::Async:U: Str() $host, Int() $port, :$broadcast) returns IO::Socket::Async
+=end code
 
 This returns an initialised C<IO::Socket::Async> server object that is
 configured to receive UDP messages sent to the specified C<$host> and C<$port>
@@ -114,7 +122,9 @@ address.
 
 =head2 method print
 
-    method print(Str $str) returns Promise {}
+=begin code :signature
+    method print(Str $str) returns Promise
+=end code
 
 Attempt to send C<$str> on the L<IO::Socket::Async> that will
 have been obtained indirectly via C<connect> or C<listen>, returning a
@@ -123,7 +133,9 @@ sent or broken if there was an error sending.
 
 =head2 method print-to
 
-    method print-to(IO::Socket::Async:D: Str() $host, Int() $port, Str() $str) returns Promise {}
+=begin code :signature
+    method print-to(IO::Socket::Async:D: Str() $host, Int() $port, Str() $str) returns Promise
+=end code
 
 This is the equivalent of C<print> for UDP sockets that have been created with
 the C<udp> method, it will try send a UDP message of C<$str> to the specified
@@ -134,7 +146,9 @@ have been specified when the socket was created.
 
 =head2 method write
 
-    method write(Blob $b) returns Promise {}
+=begin code :signature
+    method write(Blob $b) returns Promise
+=end code
 
 Attempt to send the bytes in C<$b> on the L<IO::Socket::Async> that will
 have been obtained indirectly via C<connect> or C<listen>, returning a
@@ -143,7 +157,9 @@ sent or broken if there was an error sending.
 
 =head2 method write-to
 
-    method write-to(IO::Socket::Async:D: Str() $host, Int() $port, Blob $b) returns Promise {}
+=begin code :signature
+    method write-to(IO::Socket::Async:D: Str() $host, Int() $port, Blob $b) returns Promise
+=end code
 
 This is the equivalent of C<write> for UDP sockets that have been created
 with the C<udp> method, it will try send a UDP message comprised of
@@ -155,7 +171,9 @@ flag must have been specified when the socket was created.
 
 =head2 method Supply
 
-    method Supply(:$bin, :$buf = buf8.new) returns Supply {}
+=begin code :signature
+    method Supply(:$bin, :$buf = buf8.new) returns Supply
+=end code
 
 Returns a L<Supply> which can be tapped to obtain the data read from
 the connected L<IO::Socket::Async> as it arrives.  By default the data
@@ -165,7 +183,9 @@ case you can provide your own C<Buf> with the C<:buf> named parameter.
 
 =head2 method close
 
-    method close() {}
+=begin code :signature
+    method close()
+=end code
 
 Close the connected client L<IO::Socket::Async> which will have been
 obtained from the C<listen> L<Supply> or the C<connect>

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -29,7 +29,9 @@ Those label are objects of type C<Label>.
 
 Defined as:
 
-    method next(Label:) {}
+=begin code :signature
+    method next(Label:)
+=end code
 
 Usage:
 
@@ -43,7 +45,9 @@ Begin the next iteration of the loop associated with the label.
 
 Defined as:
 
-    method last(Label:) {}
+=begin code :signature
+    method last(Label:)
+=end code
 
 Usage:
 

--- a/doc/Type/Metamodel/AttributeContainer.pod6
+++ b/doc/Type/Metamodel/AttributeContainer.pod6
@@ -13,7 +13,9 @@ attributes is implemented by this role.
 
 =head2 method add_attribute
 
-    method add_attribute(Metamodel::AttributeContainer: $obj, $name, $attribute) {}
+=begin code :signature
+    method add_attribute(Metamodel::AttributeContainer: $obj, $name, $attribute)
+=end code
 
 Adds an attribute. C<$attribute> must be an object that supports the
 methods C<name>,  C<type> and C<package>, which are called without arguments.
@@ -21,14 +23,18 @@ It can for example be of L<type Attribute|/type/Attribute>.
 
 =head2 method attributes
 
-    method attributes(Metamodel::AttributeContainer: $obj) {}
+=begin code :signature
+    method attributes(Metamodel::AttributeContainer: $obj)
+=end code
 
 Returns a list of attributes. For most Perl 6 types, these will be objects of
 L<type Attribute|/type/Attribute>.
 
 =head2 method set_rw
 
-    method set_rw(Metamodel::AttributeContainer: $obj) {}
+=begin code :signature
+    method set_rw(Metamodel::AttributeContainer: $obj)
+=end code
 
 Marks a type whose attributes default to having a write accessor. For example
 in
@@ -48,7 +54,9 @@ making all the attributes implicitly writable, so that you can write;
 
 =head2 method rw
 
-    method rw(Metamodel::AttributeContainer: $obj) {}
+=begin code :signature
+    method rw(Metamodel::AttributeContainer: $obj)
+=end code
 
 Returns a true value if L<method set_rw|#method set_rw> has been called on
 this object, that is, if new public attributes are writable by default.

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -27,14 +27,18 @@ generally return L<Num> in Perl 6.
 
 =head2 method Real
 
-    method Real(Numeric:D:) returns Real:D {}
+=begin code :signature
+    method Real(Numeric:D:) returns Real:D
+=end code
 
 If this C<Numeric> is equivalent to a C<Real>, return that C<Real>.
 Fail with C<X::Numeric::Real> otherwise.
 
 =head2 method Int
 
-    method Int(Numeric:D:) returns Int:D {}
+=begin code :signature
+    method Int(Numeric:D:) returns Int:D
+=end code
 
 If this C<Numeric> is equivalent to a C<Real>, return the equivalent of
 calling C<truncate> on that C<Real> to get an C<Int>. Fail with
@@ -42,7 +46,9 @@ C<X::Numeric::Real> otherwise.
 
 =head2 method Rat
 
-    method Rat(Numeric:D: Real $epsilon = 1.0e-6) returns Rat:D {}
+=begin code :signature
+    method Rat(Numeric:D: Real $epsilon = 1.0e-6) returns Rat:D
+=end code
 
 If this C<Numeric> is equivalent to a C<Real>, return a C<Rat> which is
 within C<$epsilon> of that C<Real>'s value. Fail with C<X::Numeric::Real>
@@ -50,14 +56,18 @@ otherwise.
 
 =head2 method Num
 
-    method Num(Numeric:D:) returns Num:D {}
+=begin code :signature
+    method Num(Numeric:D:) returns Num:D
+=end code
 
 If this C<Numeric> is equivalent to a C<Real>, return that C<Real> as a C<Num>
 as accurately as is possible. Fail with C<X::Numeric::Real> otherwise.
 
 =head2 method narrow
 
-    method narrow(Numeric:D) returns Numeric:D {}
+=begin code :signature
+    method narrow(Numeric:D) returns Numeric:D
+=end code
 
 Returns the number converted to the narrowest type that can hold it without
 loss of precision.
@@ -67,50 +77,64 @@ loss of precision.
 
 =head2 method ACCEPTS
 
-    multi method ACCEPTS(Numeric:D: $other) {}
+=begin code :signature
+    multi method ACCEPTS(Numeric:D: $other)
+=end code
 
 Returns True if C<$other> is numerically the same as the invocant.
 
 =head2 routine log
 
-    multi sub    log(Numeric:D, Numeric $base = e) returns Numeric:D {}
-    multi method log(Numeric:D: Numeric $base = e) returns Numeric:D {}
+=begin code :signature
+    multi sub    log(Numeric:D, Numeric $base = e) returns Numeric:D
+    multi method log(Numeric:D: Numeric $base = e) returns Numeric:D
+=end code
 
 Calculates the logarithm to base C<$base>. Defaults to the natural logarithm.
 
 =head2 routine log10
 
-    multi sub    log10(Numeric:D ) returns Numeric:D {}
-    multi method log10(Numeric:D:) returns Numeric:D {}
+=begin code :signature
+    multi sub    log10(Numeric:D ) returns Numeric:D
+    multi method log10(Numeric:D:) returns Numeric:D
+=end code
 
 Calculates the logarithm to base 10.
 
 =head2 routine exp
 
-    multi sub    exp(Numeric:D, Numeric:D $base = e) returns Numeric:D {}
-    multi method exp(Numeric:D: Numeric:D $base = e) returns Numeric:D {}
+=begin code :signature
+    multi sub    exp(Numeric:D, Numeric:D $base = e) returns Numeric:D
+    multi method exp(Numeric:D: Numeric:D $base = e) returns Numeric:D
+=end code
 
 Returns C<$base> to the power of the number, or C<e> to the power of the
 number if called without a second argument.
 
 =head2 method roots
 
-    multi method roots(Numeric:D: Int:D $n) returns Positional {}
+=begin code :signature
+    multi method roots(Numeric:D: Int:D $n) returns Positional
+=end code
 
 Returns a list of the C<$n> complex roots, which evaluate to the original
 number when raised to the C<$n>th power.
 
 =head2 routine abs
 
-    multi sub    abs(Numeric:D ) returns Real:D {}
-    multi method abs(Numeric:D:) returns Real:D {}
+=begin code :signature
+    multi sub    abs(Numeric:D ) returns Real:D
+    multi method abs(Numeric:D:) returns Real:D
+=end code
 
 Returns the absolute value of the number.
 
 =head2 routine sqrt
 
-    multi sub    sqrt(Numeric:D) returns Numeric:D {}
-    multi method sqrt(Numeric:D) returns Numeric:D {}
+=begin code :signature
+    multi sub    sqrt(Numeric:D) returns Numeric:D
+    multi method sqrt(Numeric:D) returns Numeric:D
+=end code
 
 Returns a square root of the number. For real numbers the positive square
 root is returned.
@@ -122,26 +146,34 @@ use the C<roots> method.
 
 =head2 method conj
 
-    multi method conj(Numeric:D) returns Numeric:D {}
+=begin code :signature
+    multi method conj(Numeric:D) returns Numeric:D
+=end code
 
 Returns the complex conjugate of the number. Returns the number itself for
 real numbers.
 
 =head2 method Bool
 
-    multi method Bool(Numeric:D:) {}
+=begin code :signature
+    multi method Bool(Numeric:D:)
+=end code
 
 Returns C<False> if the number is equivalent to zero, and C<True> otherwise.
 
 =head2 method succ
 
-    method succ(Numeric:D:) {}
+=begin code :signature
+    method succ(Numeric:D:)
+=end code
 
 Returns the number incremented by one (successor).
 
 =head2 method pred
 
-    method pred(Numeric:D:) {}
+=begin code :signature
+    method pred(Numeric:D:)
+=end code
 
 Returns the number decremented by one (predecessor).
 

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -51,7 +51,9 @@ An example that opens an external program for writing:
 
 =head2 method new
 
-    method new(:$path, *@args, :$w) returns Proc::Async:D {}
+=begin code :signature
+    method new(:$path, *@args, :$w) returns Proc::Async:D
+=end code
 
 Creates a new C<Proc::Async> object with external program name or path C<$path>
 and the command line arguments C<@args>.
@@ -62,7 +64,9 @@ C<say>.
 
 =head2 method stdout
 
-    method stdout(Proc::Async:D: :$bin) returns Supply:D {}
+=begin code :signature
+    method stdout(Proc::Async:D: :$bin) returns Supply:D
+=end code
 
 Returns the L<Supply|/type/Supply> for the external program's standard output
 stream. If C<:bin> is passed, the standard output is passed along in  binary as
@@ -87,7 +91,9 @@ you try.
 
 =head2 method stderr
 
-    method stderr(Proc::Async:D: :$bin) returns Supply:D {}
+=begin code :signature
+    method stderr(Proc::Async:D: :$bin) returns Supply:D
+=end code
 
 Returns the L<Supply|/type/Supply> for the external program's standard error
 stream. If C<:bin> is passed, the standard error is passed along in  binary as
@@ -112,7 +118,9 @@ you try.
 
 =head2 method w
 
-    method w(Proc::Async:D:) {}
+=begin code :signature
+    method w(Proc::Async:D:)
+=end code
 
 Returns a true value if C<:w> was passed to the constructor, that is, if the
 external program is started with its input stream made available to output to
@@ -120,7 +128,9 @@ the program through the C<.print>, C<.say> and C<.write> methods.
 
 =head2 method start
 
-    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$cwd = $*CWD) returns Promise:D {}
+=begin code :signature
+    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$cwd = $*CWD) returns Promise:D
+=end code
 
 Initiates spawning of the external program. Returns a promise that will be
 kept with a L<Proc|/type/Proc> object once the external
@@ -148,27 +158,35 @@ C<try>:
 
 =head2 method started
 
-    method started(Proc::Async:D:) returns Bool:D {}
+=begin code :signature
+    method started(Proc::Async:D:) returns Bool:D
+=end code
 
 Returns C<False> before C<.start> has been called, and C<True> afterwards.
 
 =head2 method path
 
-    method path(Proc::Async:D:) {}
+=begin code :signature
+    method path(Proc::Async:D:)
+=end code
 
 Returns the name and/or path of the external program that was passed to the
 C<new> method as first argument.
 
 =head2 method args
 
-    method args(Proc::Async:D:) returns Positional:D {}
+=begin code :signature
+    method args(Proc::Async:D:) returns Positional:D
+=end code
 
 Returns the command line arguments for the external programs, as passed to the
 C<new> method.
 
 =head2 method write
 
-    method write(Proc::Async:D: Blob:D $b, :$scheduler = $*SCHEDULER) {}
+=begin code :signature
+    method write(Proc::Async:D: Blob:D $b, :$scheduler = $*SCHEDULER)
+=end code
 
 Write the binary data in C<$b> to the standard input stream of the external
 program.
@@ -185,7 +203,9 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method print
 
-    method print(Proc::Async:D: Str(Any) $str, :$scheduler = $*SCHEDULER) {}
+=begin code :signature
+    method print(Proc::Async:D: Str(Any) $str, :$scheduler = $*SCHEDULER)
+=end code
 
 Write the text data in C<$str> to the standard input stream of the external
 program, encoding it as UTF-8.
@@ -202,7 +222,9 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method say
 
-    method say(Proc::Async:D: $output, :$scheduler = $*SCHEDULER) {}
+=begin code :signature
+    method say(Proc::Async:D: $output, :$scheduler = $*SCHEDULER)
+=end code
 
 Calls method C<gist> on the C<$output>, adds a newline, encodes it as UTF-8,
 and sends it to the standard input stream of the external
@@ -220,7 +242,9 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method close-stdin
 
-    method close-stdin(Proc::Async:D:) {}
+=begin code :signature
+    method close-stdin(Proc::Async:D:)
+=end code
 
 Closes the standard input stream of the external program. Programs that read
 from STDIN often only terminate when their input stream is closed. So if
@@ -236,7 +260,9 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method kill
 
-    method kill(Proc::Async:D: $signal = "HUP") {}
+=begin code :signature
+    method kill(Proc::Async:D: $signal = "HUP")
+=end code
 
 Sends a signal to the running program. The signal can be a signal name
 ("KILL" or "SIGKILL"), an integer (9) or an element of the C<Signal> enum

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -6,6 +6,7 @@
 
     class RatStr is Rat is Str {}
 
+
 The dual value types (often referred to as L<allomorphs|/language/glossary#Allomorph>)
 allow for the representation of a value as both a string and a numeric type, typically
 they will be created for you when the context is "stringy" but they can be determined
@@ -24,7 +25,9 @@ L<Rat|/type/Rat> :
 
 =head2 method new
 
-    method new(Rat $i, Str $s) {}
+=begin code :signature
+    method new(Rat $i, Str $s)
+=end code
 
 The constructor requires both the C<Rat> and the C<Str> value, when constructing one
 directly the values can be whatever is required:
@@ -35,7 +38,9 @@ directly the values can be whatever is required:
 
 =head2 method Numeric
 
-    method Numeric {}
+=begin code :signature
+    method Numeric
+=end code
 
 The numeric coercion is applied when the C<RatStr> is used in a numeric context,
 such as a numeric comparison or smart match against a numeric value. It will return
@@ -43,7 +48,9 @@ the C<Rat> value.
 
 =head2 method Rat
 
-    method Rat {}
+=begin code :signature
+    method Rat
+=end code
 
 Returns the C<Rat> value of the C<RatStr>.
 
@@ -55,7 +62,9 @@ Returns the string value of the C<RatStr>.
 
 =head2 infix cmp
 
-    multi sub infix:<cmp>(RatStr:D $a, RatStr:D $b) {}
+=begin code :signature
+    multi sub infix:<cmp>(RatStr:D $a, RatStr:D $b)
+=end code
 
 Compare two C<RatStr> objects.  The comparison is done on the C<Rat> value first and
 then on the C<Str> value. If you want to compare in a different order then you would

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -13,7 +13,9 @@ See L<Set> and L<SetHash>.
 
 =head2 method grab
 
-    method grab($count = 1) {}
+=begin code :signature
+    method grab($count = 1)
+=end code
 
 Removes and returns C<$count> elements chosen at random (without repetition)
 from the set.
@@ -26,7 +28,9 @@ exception.
 
 =head2 method grabpairs
 
-    method grabpairs($count = 1) {}
+=begin code :signature
+    method grabpairs($count = 1)
+=end code
 
 Removes C<$count> elements chosen at random (without repetition) from the set,
 and returns a list of C<Pair> objects whose keys are the grabbed elements and
@@ -41,7 +45,9 @@ exception.
 
 =head2 method pick
 
-    multi method pick($count = 1) {}
+=begin code :signature
+    multi method pick($count = 1)
+=end code
 
 Returns C<$count> elements chosen at random (without repetition) from the set.
 
@@ -50,7 +56,9 @@ size of the set, then all its elements are returned in random order.
 
 =head2 method roll
 
-    multi method roll($count = 1) {}
+=begin code :signature
+    multi method roll($count = 1)
+=end code
 
 Returns a lazy list of C<$count> elements, each randomly selected from the set.
 Each random choice is made independently, like a separate die roll where each
@@ -62,7 +70,9 @@ If C<*> is passed as C<$count>, the list is infinite.
 
 Defined as:
 
-    multi method keys(Setty:D:) returns Seq:D {}
+=begin code :signature
+    multi method keys(Setty:D:) returns Seq:D
+=end code
 
 Returns a L<Seq|/type/Seq> of all elements of the set.
 
@@ -73,7 +83,9 @@ Returns a L<Seq|/type/Seq> of all elements of the set.
 
 Defined as:
 
-    multi method values(Setty:D:) returns Seq:D {}
+=begin code :signature
+    multi method values(Setty:D:) returns Seq:D
+=end code
 
 Returns a L<Seq|/type/Seq> containing as many C<True> values as the set has elements.
 
@@ -84,7 +96,9 @@ Returns a L<Seq|/type/Seq> containing as many C<True> values as the set has elem
 
 Defined as:
 
-    multi method kv(Setty:D:) returns Seq:D {}
+=begin code :signature
+    multi method kv(Setty:D:) returns Seq:D
+=end code
 
 Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
@@ -93,20 +107,26 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-    method elems(--> Int) {}
+=begin code :signature
+    method elems(--> Int)
+=end code
 
 The number of elements of the set.
 
 =head2 method total
 
-    method total(--> Int) {}
+=begin code :signature
+    method total(--> Int)
+=end code
 
 The total of all the values of the C<QuantHash> object. For a C<Setty>
 object, this is just the number of elements.
 
 =head2 method ACCEPTS
 
-    method ACCEPTS($other) {}
+=begin code :signature
+    method ACCEPTS($other)
+=end code
 
 Returns C<True> if C<$other> and C<self> contain all the same elements,
 and no others.
@@ -115,7 +135,9 @@ and no others.
 
 Defined as:
 
+=begin code :signature
     method Bag(Setty:D:) returns Bag:D
+=end code
 
 Returns a L<Bag|/type/Bag> containing the elements of the invocant.
 
@@ -126,7 +148,9 @@ Returns a L<Bag|/type/Bag> containing the elements of the invocant.
 
 Defined as:
 
+=begin code :signature
     method BagHash(Setty:D:) returns BagHash:D
+=end code
 
 Returns a L<BagHash|/type/BagHash> containing the elements of the invocant.
 
@@ -137,7 +161,9 @@ Returns a L<BagHash|/type/BagHash> containing the elements of the invocant.
 
 Defined as:
 
-    multi method Bool(Setty:D:) returns Bool:D {}
+=begin code :signature
+    multi method Bool(Setty:D:) returns Bool:D
+=end code
 
 Returns C<True> if the invocant contains at least one element.
 

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -501,20 +501,26 @@ directly as raw parameter.
 
 =head2 method params
 
-    method params(Signature:D:) returns Positional {}
+=begin code :signature
+    method params(Signature:D:) returns Positional
+=end code
 
 Returns the list of L<C<Parameter>> objects that make up the signature.
 
 =head2 method arity
 
-    method arity(Signature:D:) returns Int:D {}
+=begin code :signature
+    method arity(Signature:D:) returns Int:D
+=end code
 
 Returns the I<minimal> number of positional arguments required to satisfy
 the signature.
 
 =head2 method count
 
-    method count(Signature:D:) returns Real:D {}
+=begin code :signature
+    method count(Signature:D:) returns Real:D
+=end code
 
 Returns the I<maximal> number of positional arguments which can be bound
 to the signature. Returns C<Inf> if there is a slurpy positional parameter.
@@ -527,10 +533,12 @@ Whatever the Signature's return constraint is:
 
 =head2 method ACCEPTS
 
-    multi method ACCEPTS(Signature:D: Capture $topic) {}
-    multi method ACCEPTS(Signature:D: @topic) {}
-    multi method ACCEPTS(Signature:D: %topic) {}
-    multi method ACCEPTS(Signature:D: Signature $topic) {}
+=begin code :signature
+    multi method ACCEPTS(Signature:D: Capture $topic)
+    multi method ACCEPTS(Signature:D: @topic)
+    multi method ACCEPTS(Signature:D: %topic)
+    multi method ACCEPTS(Signature:D: Signature $topic)
+=end code
 
 The first three see if the argument could be bound to the capture,
 i.e., if a function with that C<Signature> would be able to be called

--- a/doc/Type/X/AdHoc.pod6
+++ b/doc/Type/X/AdHoc.pod6
@@ -33,7 +33,9 @@ C<.message> method, which all C<Exception>s must have, is preferable.
 
 =head2 method payload
 
-    method payload(X::AdHoc:D) {}
+=begin code :signature
+    method payload(X::AdHoc:D)
+=end code
 
 Returns the original object which was passed to C<die>.
 

--- a/doc/Type/X/Anon/Augment.pod6
+++ b/doc/Type/X/Anon/Augment.pod6
@@ -26,7 +26,9 @@ Dies with
 
 =head2 method package-kind
 
-    method package-kind returns Str:D {}
+=begin code :signature
+    method package-kind returns Str:D
+=end code
 
 Returns the kind of package (module, class, grammar, ...) that the code
 tried to augment.

--- a/doc/Type/X/Proc/Async.pod6
+++ b/doc/Type/X/Proc/Async.pod6
@@ -12,7 +12,9 @@ All exceptions thrown by L<Proc::Async> do this common role.
 
 =head2 method proc
 
-    method fproc(X::Proc::Async:D) returns Proc::Async {}
+=begin code :signature
+    method fproc(X::Proc::Async:D) returns Proc::Async
+=end code
 
 Returns the object that threw the exception.
 

--- a/doc/Type/X/Syntax/Regex/Adverb.pod6
+++ b/doc/Type/X/Syntax/Regex/Adverb.pod6
@@ -22,13 +22,17 @@ because C<:g> belongs to a match operation, not a regex itself.
 
 =head2 method adverb
 
-    method adverb() returns Str:D {}
+=begin code :signature
+    method adverb() returns Str:D
+=end code
 
 Returns the illegally used adverb
 
 =head2 method construct
 
-    method construct() returns Str:D {}
+=begin code :signature
+    method construct() returns Str:D
+=end code
 
 Returns the name of the construct that adverb was used on (C<m>, C<ms>,
 C<rx>, C<s>, C<ss>).

--- a/util/extract-examples.p6
+++ b/util/extract-examples.p6
@@ -17,9 +17,10 @@ multi sub walk(Pod::Block::Code $_, @context is copy) {
 
     if .config<skip-test> {
         return ''
-    }else{
+    } else {
         my $content = .contents».&walk(@context).trim;
-        return '# ', '=' x 78, NL, '{', NL, $content, NL, '}'
+        $content = $content.subst("\n", "\{\} \n", :g) if .config<signature>;
+        return '# ', '=' x 78, NL, '{', NL, (.config<signature> ?? $content ~ ' {' ~ '}' !! $content ), NL, '}';
     }
 }
 


### PR DESCRIPTION
See https://github.com/perl6/doc/issues/794#issuecomment-237981574

Firstly, cast @gfldex, since he is the main inventor of our doc-compiling project.

Since we need to compile signatures(errors occur there too) we need some method/routine/sub body to compile it without error. The thing is, we don't want reader to see this ugly `{}` empty method body.
Because of that, using @coke advice, I've implemented this option. If you write it like this:
```
=begin code :signature
    method some(Bar)
=end code
```
or even like that
```
=begin code :signature
    method some1(Bar)
    method some2(Bar)
=end code
```
empty brackets will be added automatically(in second case, for every string respectively).

My English is less than awesome(I guess, it really is), so I'll be really grateful if someone will fix up my bad-written description at the `CONTRIBUTION.md` page.

It can be merged if @gfldex approves.