### PR TITLE
Revert "New pod config option: 'signature'"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,16 +97,6 @@ To export examples from all .pod6-files use `make extract-examples`. To run
 individual tests pick the right .p6-file from `examples/` as a parameter to
 `perl6`.
 
-### Signatures
-
-Signatures are part of actual code and need to be tested too. But without the body every
-signature will cause an error during the test. Use the pod-config option `signature` to
-automatically add an empty body.
-
-    =begin code :signature
-        method new(*@codes)
-    =end code
-
 ### Skipping tests
 
 Some examples fail with compile time exceptions and would interrupt the test

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -20,9 +20,7 @@ List or a list-like type.
 
 Defined as:
 
-=begin code :signature
-    multi method ACCEPTS(Any:D: Mu $other)
-=end code
+    multi method ACCEPTS(Any:D: Mu $other) {}
 
 Usage:
 
@@ -38,9 +36,7 @@ Many built-in types override this for more specific comparisons
 
 Defined as:
 
-=begin code :signature
-    method any() returns Junction:D
-=end code
+    method any() returns Junction:D {}
 
 Usage:
 
@@ -58,9 +54,7 @@ C<any>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-=begin code :signature
-    method all() returns Junction:D
-=end code
+    method all() returns Junction:D {}
 
 Usage:
 
@@ -78,9 +72,7 @@ C<all>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-=begin code :signature
-    method one() returns Junction:D
-=end code
+    method one() returns Junction:D {}
 
 Usage:
 
@@ -98,9 +90,7 @@ C<one>-L<Junction|/type/Junction> from it.
 
 Defined as:
 
-=begin code :signature
-    method none() returns Junction:D
-=end code
+    method none() returns Junction:D {}
 
 Usage:
 
@@ -137,10 +127,8 @@ into the newly created Array.
 
 Defined as:
 
-=begin code :signature
-    multi sub    reverse(*@list ) returns List:D
-    multi method reverse(List:D:) returns List:D
-=end code
+    multi sub    reverse(*@list ) returns List:D {}
+    multi method reverse(List:D:) returns List:D {}
 
 Usage:
 
@@ -175,10 +163,8 @@ Examples:
 Defined as:
 
     proto method map(|) is nodal { * }
-=begin code :signature
-    multi method map(\SELF: &block;; :$label, :$item)
-    multi method map(HyperIterable:D: &block;; :$label)
-=end code
+    multi method map(\SELF: &block;; :$label, :$item) {}
+    multi method map(HyperIterable:D: &block;; :$label) {}
 
 C<map> will iterate over the invocant and apply the number of positional
 parameters of the code object from the invocant per call.  The returned values
@@ -188,9 +174,7 @@ of the code object will become elements of the returned C<Seq>.
 
 Defined as:
 
-=begin code :signature
-    method deepmap(&block -->List) is nodal
-=end code
+    method deepmap(&block -->List) is nodal {}
 
 C<deepmap> will apply C<&block> to each element and return a new C<List> with
 the return values of C<&block>, unless the element does the C<Iterable> role.
@@ -203,9 +187,7 @@ For those elements C<deepmap> will descend recursively into the sublist.
 
 Defined as:
 
-=begin code :signature
-    method duckmap(&block) is rw is nodal
-=end code
+    method duckmap(&block) is rw is nodal {}
 
 C<duckmap> will apply C<&block> on each element and return a new list with
 defined return values of the block. For undefined return values, C<duckmap>
@@ -264,9 +246,7 @@ Interprets the invocant as a list, and returns the last index of that list.
 
 =head2 method pairup
 
-=begin code :signature
-    method pairup() returns List
-=end code
+    method pairup() returns List {}
 
 Interprets the invocant as a list, and constructs a list of
 L<pairs|/type/Pair> from it, in the same way that assignment to a
@@ -279,9 +259,7 @@ list item, if any, is considered to be a key again).
 
 =head2 sub exit
 
-=begin code :signature
-    sub exit(Int() $status = 0)
-=end code
+    sub exit(Int() $status = 0) {}
 
 Exits the current process with return code C<$status>.
 

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -15,10 +15,8 @@ scalar containers, which means you can assign to array elements.
 
 Defined as:
 
-=begin code :signature
-    multi sub    pop(Array:D )
-    multi method pop(Array:D:)
-=end code
+    multi sub    pop(Array:D ) {}
+    multi method pop(Array:D:) {}
 
 Usage:
 
@@ -42,10 +40,8 @@ Example:
 
 Defined as:
 
-=begin code :signature
-    multi sub    push(Array:D, **@values) returns Array:D
-    multi method push(Array:D: **@values) returns Array:D
-=end code
+    multi sub    push(Array:D, **@values) returns Array:D {}
+    multi method push(Array:D: **@values) returns Array:D {}
 
 Usage:
 
@@ -92,11 +88,8 @@ Defined as
 =begin code :skip-test
     sub append(\array, elems)
 =end code
-=begin code :signature
-    multi method append(Array:D: \values)
-    multi method append(Array:D: **@values is raw)
-=end code
-
+    multi method append(Array:D: \values) {}
+    multi method append(Array:D: **@values is raw) {}
 
 Usage:
 
@@ -124,10 +117,8 @@ Example:
 
 Defined as:
 
-=begin code :signature
-    multi sub    shift(Array:D )
-    multi method shift(Array:D:)
-=end code
+    multi sub    shift(Array:D ) {}
+    multi method shift(Array:D:) {}
 
 Usage:
 
@@ -151,11 +142,8 @@ Example:
 
 Defined as:
 
-=begin code :signature
-    multi sub    unshift(Array:D, **@values) returns Array:D
-    multi method unshift(Array:D: **@values) returns Array:D
-=end code
-
+    multi sub    unshift(Array:D, **@values) returns Array:D {}
+    multi method unshift(Array:D: **@values) returns Array:D {}
 
 Usage:
 
@@ -187,11 +175,8 @@ Defined as
 =begin code :skip-test
     sub prepend(\array, elems)
 =end code
-=begin code :signature
-    multi method prepend(Array:D: \values)
-    multi method prepend(Array:D: **@values is raw)
-=end code
-
+    multi method prepend(Array:D: \values) {}
+    multi method prepend(Array:D: **@values is raw) {}
 
 Usage:
 
@@ -213,11 +198,8 @@ Example:
 
 Defined as:
 
-=begin code :signature
-    multi sub    splice(@list,  $start, $elems?, *@replacement) returns Array
-    multi method splice(Array:D $start, $elems?, *@replacement) returns Array
-=end code
-
+    multi sub    splice(@list,  $start, $elems?, *@replacement) returns Array {}
+    multi method splice(Array:D $start, $elems?, *@replacement) returns Array {}
 
 Usage:
 
@@ -261,9 +243,7 @@ Example:
 
 Defined as:
 
-=begin code :signature
-    method default
-=end code
+    method default {}
 
 Usage:
 
@@ -292,9 +272,7 @@ the type object C<(Any)>.
 
 Defined as:
 
-=begin code :signature
-    method of
-=end code
+    method of {}
 
 Usage:
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -36,9 +36,7 @@ The usual way to obtain an object of type C<Attribute> is by introspection:
 
 Defined as:
 
-=begin code :signature
-    method name(Attribute:D:) returns Str:D
-=end code
+    method name(Attribute:D:) returns Str:D {}
 
 Usage:
 
@@ -53,9 +51,7 @@ so if an attribute is declared as C<has $.a>, the name returned is C<$!a>.
 
 Defined as:
 
-=begin code :signature
-    method package(Attribute:D:) returns Mu:U
-=end code
+    method package(Attribute:D:) returns Mu:U {}
 
 Usage:
 
@@ -69,9 +65,7 @@ Returns the package (class/grammar/role) to which this attribute belongs.
 
 Defined as:
 
-=begin code :signature
-    method has_accessor(Attribute:D:) returns Bool:D
-=end code
+    method has_accessor(Attribute:D:) returns Bool:D {}
 
 Usage:
 
@@ -85,9 +79,7 @@ Returns C<True> if the attribute has a public accessor method.
 
 Defined as:
 
-=begin code :signature
-    method readonly(Attribute:D:) returns Bool:D
-=end code
+    method readonly(Attribute:D:) returns Bool:D {}
 
 Usage:
 
@@ -102,9 +94,7 @@ Returns C<False> for attributes marked as C<is rw>.
 
 Defined as:
 
-=begin code :signature
-    method type(Attribute:D:) returns Mu
-=end code
+    method type(Attribute:D:) returns Mu {}
 
 Usage:
 
@@ -118,9 +108,7 @@ Returns the type constraint of the attribute.
 
 Defined as:
 
-=begin code :signature
-    method get_value(Attribute:D: Mu $instance)
-=end code
+    method get_value(Attribute:D: Mu $instance) {}
 
 Usage:
 
@@ -137,9 +125,7 @@ used with care.  Here be dragons.
 
 Defined as:
 
-=begin code :signature
-    method set_value(Attribute:D: Mu $instance, Mu \new_val)
-=end code
+    method set_value(Attribute:D: Mu $instance, Mu \new_val) {}
 
 Usage:
 
@@ -154,9 +140,7 @@ used with care.  Here be dragons.
 
 =head2 trait is required
 
-=begin code :signature
-    multi sub trait_mod:<is> (Attribute $attr, :$required!)
-=end code
+    multi sub trait_mod:<is> (Attribute $attr, :$required!) {}
 
 Marks an attribute as being required.  If a value is not provided
 during object construction, an exception is thrown.
@@ -178,9 +162,7 @@ constructors written using L<bless>.
 
 =head2 trait is rw
 
-=begin code :signature
-    multi sub trait_mod:<is> (Attribute:D $attr, :$rw!)
-=end code
+    multi sub trait_mod:<is> (Attribute:D $attr, :$rw!) {}
 
 Marks an attribute as read/write as opposed to the default
 C<readonly>.  The default accessor for the attribute will return a

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -12,9 +12,7 @@ An enum for boolean true/false decisions.
 
 =head2 routine succ
 
-=begin code :signature
-    method succ() returns Bool:D
-=end code
+    method succ() returns Bool:D {}
 
 Returns C<True>.
 
@@ -25,9 +23,7 @@ C<succ> is short for "successor"; it returns the next enum value. Bool is a spec
 
 =head2 routine pred
 
-=begin code :signature
-    method pred() returns Bool:D
-=end code
+    method pred() returns Bool:D {}
 
 Returns C<False>.
 
@@ -38,9 +34,7 @@ C<pred> is short for "predecessor"; it returns the previous enum value. Bool is 
 
 =head2 routine enums
 
-=begin code :signature
-    method enums() returns Hash:D
-=end code
+    method enums() returns Hash:D {}
 
 Returns a L<Hash|/type/Hash> of enum-pairs. Works on both the C<Bool> type
 and any key.
@@ -52,17 +46,13 @@ and any key.
 
 =head2 prefix ?
 
-=begin code :signature
-    multi sub prefix:<?>(Mu) returns Bool:D
-=end code
+    multi sub prefix:<?>(Mu) returns Bool:D {}
 
 Coerces its argument to C<Bool>.
 
 =head2 prefix so
 
-=begin code :signature
-    multi sub prefix:<so>(Mu) returns Bool:D
-=end code
+    multi sub prefix:<so>(Mu) returns Bool:D {}
 
 Coerces its argument to C<Bool>, has looser precedence than C<< prefix:<?> >>.
 

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -77,18 +77,14 @@ data,) should be used to create a client or a server respectively.
 
 =head2 method connect
 
-=begin code :signature
-    method connect(Str $host, Int $port) returns Promise
-=end code
+    method connect(Str $host, Int $port) returns Promise {}
 
 Attempts to connect to the TCP server specified by C<$host> and C<$port>,
 returning a L<Promise> that will either be kept with a connected L<IO::Socket::Async> or broken if the connection cannot be made.
 
 =head2 method listen
 
-=begin code :signature
-    method listen(Str $host, Int $port) returns Supply
-=end code
+    method listen(Str $host, Int $port) returns Supply {}
 
 Creates a listening socket on the specified C<$host> and C<$port>, returning
 a L<Supply> to which the accepted client L<IO::Socket::Async>s will be C<emit>ted. This L<Supply> should be tapped to
@@ -99,9 +95,7 @@ should be C<close>d.
 
 =head2 method udp
 
-=begin code :signature
-    method udp(IO::Socket::Async:U: :$broadcast ) returns IO::Socket::Async
-=end code
+    method udp(IO::Socket::Async:U: :$broadcast ) returns IO::Socket::Async {}
 
 Returns an initialised C<IO::Socket::Async> client object that is
 configured to send UDP messages using C<print-to> or C<write-to>.  The
@@ -110,9 +104,7 @@ the socket to send packets to a broadcast address.
 
 =head2 method bind-udp
 
-=begin code :signature
-    method bind-udp(IO::Socket::Async:U: Str() $host, Int() $port, :$broadcast) returns IO::Socket::Async
-=end code
+    method bind-udp(IO::Socket::Async:U: Str() $host, Int() $port, :$broadcast) returns IO::Socket::Async {}
 
 This returns an initialised C<IO::Socket::Async> server object that is
 configured to receive UDP messages sent to the specified C<$host> and C<$port>
@@ -122,9 +114,7 @@ address.
 
 =head2 method print
 
-=begin code :signature
-    method print(Str $str) returns Promise
-=end code
+    method print(Str $str) returns Promise {}
 
 Attempt to send C<$str> on the L<IO::Socket::Async> that will
 have been obtained indirectly via C<connect> or C<listen>, returning a
@@ -133,9 +123,7 @@ sent or broken if there was an error sending.
 
 =head2 method print-to
 
-=begin code :signature
-    method print-to(IO::Socket::Async:D: Str() $host, Int() $port, Str() $str) returns Promise
-=end code
+    method print-to(IO::Socket::Async:D: Str() $host, Int() $port, Str() $str) returns Promise {}
 
 This is the equivalent of C<print> for UDP sockets that have been created with
 the C<udp> method, it will try send a UDP message of C<$str> to the specified
@@ -146,9 +134,7 @@ have been specified when the socket was created.
 
 =head2 method write
 
-=begin code :signature
-    method write(Blob $b) returns Promise
-=end code
+    method write(Blob $b) returns Promise {}
 
 Attempt to send the bytes in C<$b> on the L<IO::Socket::Async> that will
 have been obtained indirectly via C<connect> or C<listen>, returning a
@@ -157,9 +143,7 @@ sent or broken if there was an error sending.
 
 =head2 method write-to
 
-=begin code :signature
-    method write-to(IO::Socket::Async:D: Str() $host, Int() $port, Blob $b) returns Promise
-=end code
+    method write-to(IO::Socket::Async:D: Str() $host, Int() $port, Blob $b) returns Promise {}
 
 This is the equivalent of C<write> for UDP sockets that have been created
 with the C<udp> method, it will try send a UDP message comprised of
@@ -171,9 +155,7 @@ flag must have been specified when the socket was created.
 
 =head2 method Supply
 
-=begin code :signature
-    method Supply(:$bin, :$buf = buf8.new) returns Supply
-=end code
+    method Supply(:$bin, :$buf = buf8.new) returns Supply {}
 
 Returns a L<Supply> which can be tapped to obtain the data read from
 the connected L<IO::Socket::Async> as it arrives.  By default the data
@@ -183,9 +165,7 @@ case you can provide your own C<Buf> with the C<:buf> named parameter.
 
 =head2 method close
 
-=begin code :signature
-    method close()
-=end code
+    method close() {}
 
 Close the connected client L<IO::Socket::Async> which will have been
 obtained from the C<listen> L<Supply> or the C<connect>

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -29,9 +29,7 @@ Those label are objects of type C<Label>.
 
 Defined as:
 
-=begin code :signature
-    method next(Label:)
-=end code
+    method next(Label:) {}
 
 Usage:
 
@@ -45,9 +43,7 @@ Begin the next iteration of the loop associated with the label.
 
 Defined as:
 
-=begin code :signature
-    method last(Label:)
-=end code
+    method last(Label:) {}
 
 Usage:
 

--- a/doc/Type/Metamodel/AttributeContainer.pod6
+++ b/doc/Type/Metamodel/AttributeContainer.pod6
@@ -13,9 +13,7 @@ attributes is implemented by this role.
 
 =head2 method add_attribute
 
-=begin code :signature
-    method add_attribute(Metamodel::AttributeContainer: $obj, $name, $attribute)
-=end code
+    method add_attribute(Metamodel::AttributeContainer: $obj, $name, $attribute) {}
 
 Adds an attribute. C<$attribute> must be an object that supports the
 methods C<name>,  C<type> and C<package>, which are called without arguments.
@@ -23,18 +21,14 @@ It can for example be of L<type Attribute|/type/Attribute>.
 
 =head2 method attributes
 
-=begin code :signature
-    method attributes(Metamodel::AttributeContainer: $obj)
-=end code
+    method attributes(Metamodel::AttributeContainer: $obj) {}
 
 Returns a list of attributes. For most Perl 6 types, these will be objects of
 L<type Attribute|/type/Attribute>.
 
 =head2 method set_rw
 
-=begin code :signature
-    method set_rw(Metamodel::AttributeContainer: $obj)
-=end code
+    method set_rw(Metamodel::AttributeContainer: $obj) {}
 
 Marks a type whose attributes default to having a write accessor. For example
 in
@@ -54,9 +48,7 @@ making all the attributes implicitly writable, so that you can write;
 
 =head2 method rw
 
-=begin code :signature
-    method rw(Metamodel::AttributeContainer: $obj)
-=end code
+    method rw(Metamodel::AttributeContainer: $obj) {}
 
 Returns a true value if L<method set_rw|#method set_rw> has been called on
 this object, that is, if new public attributes are writable by default.

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -27,18 +27,14 @@ generally return L<Num> in Perl 6.
 
 =head2 method Real
 
-=begin code :signature
-    method Real(Numeric:D:) returns Real:D
-=end code
+    method Real(Numeric:D:) returns Real:D {}
 
 If this C<Numeric> is equivalent to a C<Real>, return that C<Real>.
 Fail with C<X::Numeric::Real> otherwise.
 
 =head2 method Int
 
-=begin code :signature
-    method Int(Numeric:D:) returns Int:D
-=end code
+    method Int(Numeric:D:) returns Int:D {}
 
 If this C<Numeric> is equivalent to a C<Real>, return the equivalent of
 calling C<truncate> on that C<Real> to get an C<Int>. Fail with
@@ -46,9 +42,7 @@ C<X::Numeric::Real> otherwise.
 
 =head2 method Rat
 
-=begin code :signature
-    method Rat(Numeric:D: Real $epsilon = 1.0e-6) returns Rat:D
-=end code
+    method Rat(Numeric:D: Real $epsilon = 1.0e-6) returns Rat:D {}
 
 If this C<Numeric> is equivalent to a C<Real>, return a C<Rat> which is
 within C<$epsilon> of that C<Real>'s value. Fail with C<X::Numeric::Real>
@@ -56,18 +50,14 @@ otherwise.
 
 =head2 method Num
 
-=begin code :signature
-    method Num(Numeric:D:) returns Num:D
-=end code
+    method Num(Numeric:D:) returns Num:D {}
 
 If this C<Numeric> is equivalent to a C<Real>, return that C<Real> as a C<Num>
 as accurately as is possible. Fail with C<X::Numeric::Real> otherwise.
 
 =head2 method narrow
 
-=begin code :signature
-    method narrow(Numeric:D) returns Numeric:D
-=end code
+    method narrow(Numeric:D) returns Numeric:D {}
 
 Returns the number converted to the narrowest type that can hold it without
 loss of precision.
@@ -77,64 +67,50 @@ loss of precision.
 
 =head2 method ACCEPTS
 
-=begin code :signature
-    multi method ACCEPTS(Numeric:D: $other)
-=end code
+    multi method ACCEPTS(Numeric:D: $other) {}
 
 Returns True if C<$other> is numerically the same as the invocant.
 
 =head2 routine log
 
-=begin code :signature
-    multi sub    log(Numeric:D, Numeric $base = e) returns Numeric:D
-    multi method log(Numeric:D: Numeric $base = e) returns Numeric:D
-=end code
+    multi sub    log(Numeric:D, Numeric $base = e) returns Numeric:D {}
+    multi method log(Numeric:D: Numeric $base = e) returns Numeric:D {}
 
 Calculates the logarithm to base C<$base>. Defaults to the natural logarithm.
 
 =head2 routine log10
 
-=begin code :signature
-    multi sub    log10(Numeric:D ) returns Numeric:D
-    multi method log10(Numeric:D:) returns Numeric:D
-=end code
+    multi sub    log10(Numeric:D ) returns Numeric:D {}
+    multi method log10(Numeric:D:) returns Numeric:D {}
 
 Calculates the logarithm to base 10.
 
 =head2 routine exp
 
-=begin code :signature
-    multi sub    exp(Numeric:D, Numeric:D $base = e) returns Numeric:D
-    multi method exp(Numeric:D: Numeric:D $base = e) returns Numeric:D
-=end code
+    multi sub    exp(Numeric:D, Numeric:D $base = e) returns Numeric:D {}
+    multi method exp(Numeric:D: Numeric:D $base = e) returns Numeric:D {}
 
 Returns C<$base> to the power of the number, or C<e> to the power of the
 number if called without a second argument.
 
 =head2 method roots
 
-=begin code :signature
-    multi method roots(Numeric:D: Int:D $n) returns Positional
-=end code
+    multi method roots(Numeric:D: Int:D $n) returns Positional {}
 
 Returns a list of the C<$n> complex roots, which evaluate to the original
 number when raised to the C<$n>th power.
 
 =head2 routine abs
 
-=begin code :signature
-    multi sub    abs(Numeric:D ) returns Real:D
-    multi method abs(Numeric:D:) returns Real:D
-=end code
+    multi sub    abs(Numeric:D ) returns Real:D {}
+    multi method abs(Numeric:D:) returns Real:D {}
 
 Returns the absolute value of the number.
 
 =head2 routine sqrt
 
-=begin code :signature
-    multi sub    sqrt(Numeric:D) returns Numeric:D
-    multi method sqrt(Numeric:D) returns Numeric:D
-=end code
+    multi sub    sqrt(Numeric:D) returns Numeric:D {}
+    multi method sqrt(Numeric:D) returns Numeric:D {}
 
 Returns a square root of the number. For real numbers the positive square
 root is returned.
@@ -146,34 +122,26 @@ use the C<roots> method.
 
 =head2 method conj
 
-=begin code :signature
-    multi method conj(Numeric:D) returns Numeric:D
-=end code
+    multi method conj(Numeric:D) returns Numeric:D {}
 
 Returns the complex conjugate of the number. Returns the number itself for
 real numbers.
 
 =head2 method Bool
 
-=begin code :signature
-    multi method Bool(Numeric:D:)
-=end code
+    multi method Bool(Numeric:D:) {}
 
 Returns C<False> if the number is equivalent to zero, and C<True> otherwise.
 
 =head2 method succ
 
-=begin code :signature
-    method succ(Numeric:D:)
-=end code
+    method succ(Numeric:D:) {}
 
 Returns the number incremented by one (successor).
 
 =head2 method pred
 
-=begin code :signature
-    method pred(Numeric:D:)
-=end code
+    method pred(Numeric:D:) {}
 
 Returns the number decremented by one (predecessor).
 

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -51,9 +51,7 @@ An example that opens an external program for writing:
 
 =head2 method new
 
-=begin code :signature
-    method new(:$path, *@args, :$w) returns Proc::Async:D
-=end code
+    method new(:$path, *@args, :$w) returns Proc::Async:D {}
 
 Creates a new C<Proc::Async> object with external program name or path C<$path>
 and the command line arguments C<@args>.
@@ -64,9 +62,7 @@ C<say>.
 
 =head2 method stdout
 
-=begin code :signature
-    method stdout(Proc::Async:D: :$bin) returns Supply:D
-=end code
+    method stdout(Proc::Async:D: :$bin) returns Supply:D {}
 
 Returns the L<Supply|/type/Supply> for the external program's standard output
 stream. If C<:bin> is passed, the standard output is passed along in  binary as
@@ -91,9 +87,7 @@ you try.
 
 =head2 method stderr
 
-=begin code :signature
-    method stderr(Proc::Async:D: :$bin) returns Supply:D
-=end code
+    method stderr(Proc::Async:D: :$bin) returns Supply:D {}
 
 Returns the L<Supply|/type/Supply> for the external program's standard error
 stream. If C<:bin> is passed, the standard error is passed along in  binary as
@@ -118,9 +112,7 @@ you try.
 
 =head2 method w
 
-=begin code :signature
-    method w(Proc::Async:D:)
-=end code
+    method w(Proc::Async:D:) {}
 
 Returns a true value if C<:w> was passed to the constructor, that is, if the
 external program is started with its input stream made available to output to
@@ -128,9 +120,7 @@ the program through the C<.print>, C<.say> and C<.write> methods.
 
 =head2 method start
 
-=begin code :signature
-    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$cwd = $*CWD) returns Promise:D
-=end code
+    method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$cwd = $*CWD) returns Promise:D {}
 
 Initiates spawning of the external program. Returns a promise that will be
 kept with a L<Proc|/type/Proc> object once the external
@@ -158,35 +148,27 @@ C<try>:
 
 =head2 method started
 
-=begin code :signature
-    method started(Proc::Async:D:) returns Bool:D
-=end code
+    method started(Proc::Async:D:) returns Bool:D {}
 
 Returns C<False> before C<.start> has been called, and C<True> afterwards.
 
 =head2 method path
 
-=begin code :signature
-    method path(Proc::Async:D:)
-=end code
+    method path(Proc::Async:D:) {}
 
 Returns the name and/or path of the external program that was passed to the
 C<new> method as first argument.
 
 =head2 method args
 
-=begin code :signature
-    method args(Proc::Async:D:) returns Positional:D
-=end code
+    method args(Proc::Async:D:) returns Positional:D {}
 
 Returns the command line arguments for the external programs, as passed to the
 C<new> method.
 
 =head2 method write
 
-=begin code :signature
-    method write(Proc::Async:D: Blob:D $b, :$scheduler = $*SCHEDULER)
-=end code
+    method write(Proc::Async:D: Blob:D $b, :$scheduler = $*SCHEDULER) {}
 
 Write the binary data in C<$b> to the standard input stream of the external
 program.
@@ -203,9 +185,7 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method print
 
-=begin code :signature
-    method print(Proc::Async:D: Str(Any) $str, :$scheduler = $*SCHEDULER)
-=end code
+    method print(Proc::Async:D: Str(Any) $str, :$scheduler = $*SCHEDULER) {}
 
 Write the text data in C<$str> to the standard input stream of the external
 program, encoding it as UTF-8.
@@ -222,9 +202,7 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method say
 
-=begin code :signature
-    method say(Proc::Async:D: $output, :$scheduler = $*SCHEDULER)
-=end code
+    method say(Proc::Async:D: $output, :$scheduler = $*SCHEDULER) {}
 
 Calls method C<gist> on the C<$output>, adds a newline, encodes it as UTF-8,
 and sends it to the standard input stream of the external
@@ -242,9 +220,7 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method close-stdin
 
-=begin code :signature
-    method close-stdin(Proc::Async:D:)
-=end code
+    method close-stdin(Proc::Async:D:) {}
 
 Closes the standard input stream of the external program. Programs that read
 from STDIN often only terminate when their input stream is closed. So if
@@ -260,9 +236,7 @@ L<X::Proc::Async::MustBeStarted> exception is thrown.
 
 =head2 method kill
 
-=begin code :signature
-    method kill(Proc::Async:D: $signal = "HUP")
-=end code
+    method kill(Proc::Async:D: $signal = "HUP") {}
 
 Sends a signal to the running program. The signal can be a signal name
 ("KILL" or "SIGKILL"), an integer (9) or an element of the C<Signal> enum

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -6,7 +6,6 @@
 
     class RatStr is Rat is Str {}
 
-
 The dual value types (often referred to as L<allomorphs|/language/glossary#Allomorph>)
 allow for the representation of a value as both a string and a numeric type, typically
 they will be created for you when the context is "stringy" but they can be determined
@@ -25,9 +24,7 @@ L<Rat|/type/Rat> :
 
 =head2 method new
 
-=begin code :signature
-    method new(Rat $i, Str $s)
-=end code
+    method new(Rat $i, Str $s) {}
 
 The constructor requires both the C<Rat> and the C<Str> value, when constructing one
 directly the values can be whatever is required:
@@ -38,9 +35,7 @@ directly the values can be whatever is required:
 
 =head2 method Numeric
 
-=begin code :signature
-    method Numeric
-=end code
+    method Numeric {}
 
 The numeric coercion is applied when the C<RatStr> is used in a numeric context,
 such as a numeric comparison or smart match against a numeric value. It will return
@@ -48,9 +43,7 @@ the C<Rat> value.
 
 =head2 method Rat
 
-=begin code :signature
-    method Rat
-=end code
+    method Rat {}
 
 Returns the C<Rat> value of the C<RatStr>.
 
@@ -62,9 +55,7 @@ Returns the string value of the C<RatStr>.
 
 =head2 infix cmp
 
-=begin code :signature
-    multi sub infix:<cmp>(RatStr:D $a, RatStr:D $b)
-=end code
+    multi sub infix:<cmp>(RatStr:D $a, RatStr:D $b) {}
 
 Compare two C<RatStr> objects.  The comparison is done on the C<Rat> value first and
 then on the C<Str> value. If you want to compare in a different order then you would

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -13,9 +13,7 @@ See L<Set> and L<SetHash>.
 
 =head2 method grab
 
-=begin code :signature
-    method grab($count = 1)
-=end code
+    method grab($count = 1) {}
 
 Removes and returns C<$count> elements chosen at random (without repetition)
 from the set.
@@ -28,9 +26,7 @@ exception.
 
 =head2 method grabpairs
 
-=begin code :signature
-    method grabpairs($count = 1)
-=end code
+    method grabpairs($count = 1) {}
 
 Removes C<$count> elements chosen at random (without repetition) from the set,
 and returns a list of C<Pair> objects whose keys are the grabbed elements and
@@ -45,9 +41,7 @@ exception.
 
 =head2 method pick
 
-=begin code :signature
-    multi method pick($count = 1)
-=end code
+    multi method pick($count = 1) {}
 
 Returns C<$count> elements chosen at random (without repetition) from the set.
 
@@ -56,9 +50,7 @@ size of the set, then all its elements are returned in random order.
 
 =head2 method roll
 
-=begin code :signature
-    multi method roll($count = 1)
-=end code
+    multi method roll($count = 1) {}
 
 Returns a lazy list of C<$count> elements, each randomly selected from the set.
 Each random choice is made independently, like a separate die roll where each
@@ -70,9 +62,7 @@ If C<*> is passed as C<$count>, the list is infinite.
 
 Defined as:
 
-=begin code :signature
-    multi method keys(Setty:D:) returns Seq:D
-=end code
+    multi method keys(Setty:D:) returns Seq:D {}
 
 Returns a L<Seq|/type/Seq> of all elements of the set.
 
@@ -83,9 +73,7 @@ Returns a L<Seq|/type/Seq> of all elements of the set.
 
 Defined as:
 
-=begin code :signature
-    multi method values(Setty:D:) returns Seq:D
-=end code
+    multi method values(Setty:D:) returns Seq:D {}
 
 Returns a L<Seq|/type/Seq> containing as many C<True> values as the set has elements.
 
@@ -96,9 +84,7 @@ Returns a L<Seq|/type/Seq> containing as many C<True> values as the set has elem
 
 Defined as:
 
-=begin code :signature
-    multi method kv(Setty:D:) returns Seq:D
-=end code
+    multi method kv(Setty:D:) returns Seq:D {}
 
 Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
@@ -107,26 +93,20 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-=begin code :signature
-    method elems(--> Int)
-=end code
+    method elems(--> Int) {}
 
 The number of elements of the set.
 
 =head2 method total
 
-=begin code :signature
-    method total(--> Int)
-=end code
+    method total(--> Int) {}
 
 The total of all the values of the C<QuantHash> object. For a C<Setty>
 object, this is just the number of elements.
 
 =head2 method ACCEPTS
 
-=begin code :signature
-    method ACCEPTS($other)
-=end code
+    method ACCEPTS($other) {}
 
 Returns C<True> if C<$other> and C<self> contain all the same elements,
 and no others.
@@ -135,9 +115,7 @@ and no others.
 
 Defined as:
 
-=begin code :signature
     method Bag(Setty:D:) returns Bag:D
-=end code
 
 Returns a L<Bag|/type/Bag> containing the elements of the invocant.
 
@@ -148,9 +126,7 @@ Returns a L<Bag|/type/Bag> containing the elements of the invocant.
 
 Defined as:
 
-=begin code :signature
     method BagHash(Setty:D:) returns BagHash:D
-=end code
 
 Returns a L<BagHash|/type/BagHash> containing the elements of the invocant.
 
@@ -161,9 +137,7 @@ Returns a L<BagHash|/type/BagHash> containing the elements of the invocant.
 
 Defined as:
 
-=begin code :signature
-    multi method Bool(Setty:D:) returns Bool:D
-=end code
+    multi method Bool(Setty:D:) returns Bool:D {}
 
 Returns C<True> if the invocant contains at least one element.
 

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -501,26 +501,20 @@ directly as raw parameter.
 
 =head2 method params
 
-=begin code :signature
-    method params(Signature:D:) returns Positional
-=end code
+    method params(Signature:D:) returns Positional {}
 
 Returns the list of L<C<Parameter>> objects that make up the signature.
 
 =head2 method arity
 
-=begin code :signature
-    method arity(Signature:D:) returns Int:D
-=end code
+    method arity(Signature:D:) returns Int:D {}
 
 Returns the I<minimal> number of positional arguments required to satisfy
 the signature.
 
 =head2 method count
 
-=begin code :signature
-    method count(Signature:D:) returns Real:D
-=end code
+    method count(Signature:D:) returns Real:D {}
 
 Returns the I<maximal> number of positional arguments which can be bound
 to the signature. Returns C<Inf> if there is a slurpy positional parameter.
@@ -533,12 +527,10 @@ Whatever the Signature's return constraint is:
 
 =head2 method ACCEPTS
 
-=begin code :signature
-    multi method ACCEPTS(Signature:D: Capture $topic)
-    multi method ACCEPTS(Signature:D: @topic)
-    multi method ACCEPTS(Signature:D: %topic)
-    multi method ACCEPTS(Signature:D: Signature $topic)
-=end code
+    multi method ACCEPTS(Signature:D: Capture $topic) {}
+    multi method ACCEPTS(Signature:D: @topic) {}
+    multi method ACCEPTS(Signature:D: %topic) {}
+    multi method ACCEPTS(Signature:D: Signature $topic) {}
 
 The first three see if the argument could be bound to the capture,
 i.e., if a function with that C<Signature> would be able to be called

--- a/doc/Type/X/AdHoc.pod6
+++ b/doc/Type/X/AdHoc.pod6
@@ -33,9 +33,7 @@ C<.message> method, which all C<Exception>s must have, is preferable.
 
 =head2 method payload
 
-=begin code :signature
-    method payload(X::AdHoc:D)
-=end code
+    method payload(X::AdHoc:D) {}
 
 Returns the original object which was passed to C<die>.
 

--- a/doc/Type/X/Anon/Augment.pod6
+++ b/doc/Type/X/Anon/Augment.pod6
@@ -26,9 +26,7 @@ Dies with
 
 =head2 method package-kind
 
-=begin code :signature
-    method package-kind returns Str:D
-=end code
+    method package-kind returns Str:D {}
 
 Returns the kind of package (module, class, grammar, ...) that the code
 tried to augment.

--- a/doc/Type/X/Proc/Async.pod6
+++ b/doc/Type/X/Proc/Async.pod6
@@ -12,9 +12,7 @@ All exceptions thrown by L<Proc::Async> do this common role.
 
 =head2 method proc
 
-=begin code :signature
-    method fproc(X::Proc::Async:D) returns Proc::Async
-=end code
+    method fproc(X::Proc::Async:D) returns Proc::Async {}
 
 Returns the object that threw the exception.
 

--- a/doc/Type/X/Syntax/Regex/Adverb.pod6
+++ b/doc/Type/X/Syntax/Regex/Adverb.pod6
@@ -22,17 +22,13 @@ because C<:g> belongs to a match operation, not a regex itself.
 
 =head2 method adverb
 
-=begin code :signature
-    method adverb() returns Str:D
-=end code
+    method adverb() returns Str:D {}
 
 Returns the illegally used adverb
 
 =head2 method construct
 
-=begin code :signature
-    method construct() returns Str:D
-=end code
+    method construct() returns Str:D {}
 
 Returns the name of the construct that adverb was used on (C<m>, C<ms>,
 C<rx>, C<s>, C<ss>).

--- a/util/extract-examples.p6
+++ b/util/extract-examples.p6
@@ -17,10 +17,9 @@ multi sub walk(Pod::Block::Code $_, @context is copy) {
 
     if .config<skip-test> {
         return ''
-    } else {
+    }else{
         my $content = .contents».&walk(@context).trim;
-        $content = $content.subst("\n", "\{\} \n", :g) if .config<signature>;
-        return '# ', '=' x 78, NL, '{', NL, (.config<signature> ?? $content ~ ' {' ~ '}' !! $content ), NL, '}';
+        return '# ', '=' x 78, NL, '{', NL, $content, NL, '}'
     }
 }
 


### PR DESCRIPTION
Reverts perl6/doc#814

It was decided to don't mix the logic and the presentation, hence the examples code extractor should detect and complete signatures by itself.
@tbrowder++