### PR TITLE
Remove sigil from perl6 constant in accordance with the Term doc

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1051,7 +1051,7 @@ initialization expression (evaluated at compile time).
 So, change the C«=>» to C<=> , and add a sigil.
 
     use constant DEBUG => 0; # Perl 5
-    constant $DEBUG = 0;     # Perl 6
+    constant DEBUG = 0;      # Perl 6
 
     use constant pi => 4 * atan2(1, 1); # Perl 5
     # pi, e, i are built-in constants in  Perl 6


### PR DESCRIPTION
Following https://docs.perl6.org/language/terms#index-entry-constant_%28Terms%29: 

"Constants are declared with constant and do not require a sigil"