### PR TITLE
Fix typo from assoc<none> to assoc<non>

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -653,7 +653,7 @@ class or role, even after it has been redefined in the child class.
 =head2 prefix C«++»
 
 =begin code :skip-test
-multi sub prefix:<++>($x is rw) is assoc<none>
+multi sub prefix:<++>($x is rw) is assoc<non>
 =end code
 
 Increments its argument by one, and returns the incremented value.X<|increment operator>
@@ -669,7 +669,7 @@ semantics.
 =head2 prefix C«--»
 
 =begin code :skip-test
-multi sub prefix:<-->($x is rw) is assoc<none>
+multi sub prefix:<-->($x is rw) is assoc<non>
 =end code
 
 Decrements its argument by one, and returns the decremented value.X<|decrement operator>
@@ -686,7 +686,7 @@ semantics.
 =head2 postfix C«++»
 
 =begin code :skip-test
-multi sub postfix:<++>($x is rw) is assoc<none>
+multi sub postfix:<++>($x is rw) is assoc<non>
 =end code
 
 Increments its argument by one, and returns the unincremented value.X<|increment operator>
@@ -709,7 +709,7 @@ undefined values, it returns 0:
 =head2 postfix C«--»
 
 =begin code :skip-test
-multi sub postfix:<-->($x is rw) is assoc<none>
+multi sub postfix:<-->($x is rw) is assoc<non>
 =end code
 
 Decrements its argument by one, and returns the undecremented value.X<|decrement operator>
@@ -1148,7 +1148,7 @@ unsuccessfully, resetting the answer to 42.
 =head2 infix C«does»
 
 =begin code :skip-test
-sub infix:<does>(Mu $obj, Mu $role) is assoc<none>
+sub infix:<does>(Mu $obj, Mu $role) is assoc<non>
 =end code
 
 Mixes C<$role> into C<$obj> at run time. Requires C<$obj> to be mutable.
@@ -1159,7 +1159,7 @@ to act like a role, for example enum values.
 =head2 infix C«but»
 
 =begin code :skip-test
-sub infix:<but>(Mu $obj, Mu $role) is assoc<none>
+sub infix:<but>(Mu $obj, Mu $role) is assoc<non>
 =end code
 
 Creates a copy of C<$obj> with C<$role> mixed in. Since C<$obj> is not
@@ -1171,7 +1171,7 @@ to act like a role, for example enum values.
 =head2 infix C«cmp»
 
 =begin code :skip-test
-proto sub infix:<cmp>(Any, Any) returns Order:D is assoc<none>
+proto sub infix:<cmp>(Any, Any) returns Order:D is assoc<non>
 multi sub infix:<cmp>(Any,       Any)
 multi sub infix:<cmp>(Real:D,    Real:D)
 multi sub infix:<cmp>(Str:D,     Str:D)
@@ -1192,7 +1192,7 @@ if C<$a eqv $b>, then C<$a cmp $b> always returns C<Order::Same>.
 =head2 infix C«leg»
 
 =begin code :skip-test
-proto sub infix:<leg>($a, $b) returns Order:D is assoc<none>
+proto sub infix:<leg>($a, $b) returns Order:D is assoc<non>
 multi sub infix:<leg>(Any,   Any)
 multi sub infix:<leg>(Str:D, Str:D)
 =end code
@@ -1210,7 +1210,7 @@ say 'b' leg 'a';        More
 =head2 infix C«<=>»
 
 =begin code :skip-test
-multi sub infix:«<=>»($a, $b) returns Order:D is assoc<none>
+multi sub infix:«<=>»($a, $b) returns Order:D is assoc<non>
 =end code
 
 X<Numeric three-way comparator>.X<|spaceship operator>
@@ -1220,7 +1220,7 @@ Coerces both arguments to L<Real>, and then does a numeric comparison.
 =head2 infix C«..»
 
 =begin code :skip-test
-multi sub infix:<..>($a, $b) returns Range:D is assoc<none>
+multi sub infix:<..>($a, $b) returns Range:D is assoc<non>
 =end code
 
 X<Range operator>
@@ -1230,7 +1230,7 @@ Constructs a L<Range> from the arguments.
 =head2 infix C«..^»
 
 =begin code :skip-test
-multi sub infix:<..^>($a, $b) returns Range:D is assoc<none>
+multi sub infix:<..^>($a, $b) returns Range:D is assoc<non>
 =end code
 
 X<Right-open range operator>.
@@ -1240,7 +1240,7 @@ Constructs a L<Range> from the arguments, excluding the end point.
 =head2 infix C«^..»
 
 =begin code :skip-test
-multi sub infix:<^..>($a, $b) returns Range:D is assoc<none>
+multi sub infix:<^..>($a, $b) returns Range:D is assoc<non>
 =end code
 
 X<Left-open range operator>.
@@ -1250,7 +1250,7 @@ Constructs a L<Range> from the arguments, excluding the start point.
 =head2 infix C«^..^»
 
 =begin code :skip-test
-multi sub infix:<^..^>($a, $b) returns Range:D is assoc<none>
+multi sub infix:<^..^>($a, $b) returns Range:D is assoc<non>
 =end code
 
 X<Open range operator>


### PR DESCRIPTION
Fix #824 