### PR TITLE
Fix a typo in functions.pod6

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -249,7 +249,7 @@ parameter, allowing a C<multi> which takes additional arguments. The third call
 fails at compile time because the proto's C<signature> becomes the common
 signature of all three, and C<42> doesn't match C<Str>.
 
-=fod code :skip-test
+=for code :skip-test
 say &congratulate.signature #-> (Str $reason, Str $name, | is raw)
 
 You can give the C<proto> a function body, and place the C<{*}> where


### PR DESCRIPTION
It's preventing a code sample from rendering.