### PR TITLE
Revert "Fix a ;; index again (use C<<;;>>)"

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -451,7 +451,7 @@ X<|Long Names>
 =head2 Long Names
 
 To exclude certain parameters from being considered in multiple dispatch,
-separate them with a double semi-colon X<C<<;;>>|;;>.
+separate them with a double semi-colon.
 
     multi sub f(Int $i, Str $s;; :$b) { dd $i, $s, $b };
     f(10, 'answer');


### PR DESCRIPTION
Reverts perl6/doc#844

`X<C<<;;>>|;;>` is the incorrect form. 
Sorry for reverting many times.