### PR TITLE
Remove references to 'done' method (obsolete)

### DIFF
--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -127,11 +127,13 @@ A typical test file looks something like this:
 
     # .... tests
 
+    done-testing;  # optional with 'plan'
+
 We ensure that we're using Perl 6, via the C<use v6> pragma, then we load
 the C<Test> module and specify where our libraries are.  We then specify how
 many tests we I<plan> to run (such that the testing framework can tell us if
 more or fewer tests were run than we expected) and when finished with the
-tests, we tell the framework that we are I<done> testing.
+tests, we use I<done-testing> to tell the framework we are done.
 
 =head1 Running tests
 
@@ -544,8 +546,8 @@ The result of a group of subtests is only C<ok> if all subtests are C<ok>.
 =item X<subtest(&subtests, $description?)|subtest>
 
 The C<subtest> function executes the given block, consisting of usually more
-than one test, possibly including a C<plan> or C<done>, and counts as I<one>
-test in C<plan>, C<todo>, or C<skip> counts. It will pass the
+than one test, possibly including a C<plan> or C<done-testing>, and counts as
+I<one> test in C<plan>, C<todo>, or C<skip> counts. It will pass the
 test only if B<all> tests in the block, pass. The function accepts an
 optional C<$description> of the test.
 
@@ -649,7 +651,7 @@ ok womble();
 
 Note that C<skip-rest> requires a C<plan> to be set, otherwise the
 C<skip-rest> call will throw an error. If no plan was set, you can use
-C<done> to indicate the end of the test run (though of course the test
+C<done-testing> to indicate the end of the test run (though of course the test
 summary will not count skipped tests).  Note also the C<exit> is
 required in the example to prevent the skipped tests from running.
 Alternatively, you could enclose the remaining tests in an C<else>


### PR DESCRIPTION
Clarify to refer to the done-testing method.