### PR TITLE
Created external link SVG

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -562,3 +562,7 @@ div.highlight span.c-Singleline, div.highlight span.c {
         }
     }
 }
+
+a[href*="//"]:not([href*="perl6.org"])::after {
+    content: url(../images/LinkExternal12x12.svg);
+}

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -44,7 +44,7 @@ L<elsewhere|/language/functions#Blocks_and_Lambdas>.  For now it is just
 important to understand when blocks run and when they do not:
 
 =for code :skip-test
-    say "We get here"; { say "then here." }; { say "not here"; 0; } or die;
+say "We get here"; { say "then here." }; { say "not here"; 0; } or die;
 
 In the above example, after running the first statement, the first block stands
 alone as a second statement, so we run the statement inside it.  The second
@@ -90,8 +90,8 @@ The simplest way to run a block where it cannot be a stand-alone statement
 is by writing C<do> before it:
 
 =for code :skip-test
-    # This dies half of the time
-    do { say "Heads I win, tails I die."; Bool.pick } or die; say "I win.";
+# This dies half of the time
+do { say "Heads I win, tails I die."; Bool.pick } or die; say "I win.";
 
 Note that you need a space between the do and the block.
 
@@ -116,9 +116,9 @@ but this is mainly just useful for avoiding the syntactical need to
 parenthesize a statement if it is the last thing in an expression:
 
 =for code :skip-test
-    3, do if 1 { 2 }  ; #-> 3, 2
-    3,   (if 1 { 2 }) ; #-> 3, 2
-    3,    if 1 { 2 }  ; # Syntax error
+3, do if 1 { 2 }  ; #-> 3, 2
+3,   (if 1 { 2 }) ; #-> 3, 2
+3,    if 1 { 2 }  ; # Syntax error
 
 ...which brings us to C<if>.
 
@@ -132,10 +132,10 @@ Unlike some languages the condition does not have to be parenthesized,
 instead the C<{> and C<}> around the block are mandatory:
 
 =for code :skip-test
-    if 1 { "1 is true".say }  ; # says "1 is true"
-    if 1   "1 is true".say    ; # syntax error, missing block
-    if 0 { "0 is true".say }  ; # does not say anything, because 0 is false
-    if 42.say and 0 { 43.say }; # says "42" but does not say "43"
+if 1 { "1 is true".say }  ; # says "1 is true"
+if 1   "1 is true".say    ; # syntax error, missing block
+if 0 { "0 is true".say }  ; # does not say anything, because 0 is false
+if 42.say and 0 { 43.say }; # says "42" but does not say "43"
 
 There is also a form of C<if> called a "statement modifier" form.  In this
 case, the if and then the condition come after the code you want to run
@@ -179,16 +179,16 @@ with C<else> to provide an alternative block to run when the conditional
 expression is false:
 
 =for code :skip-test
-    if 0 { say "no" } else { say "yes" }   ; # says "yes"
-    if 0 { say "no" } else{ say "yes" }    ; # syntax error, space is required
+if 0 { say "no" } else { say "yes" }   ; # says "yes"
+if 0 { say "no" } else{ say "yes" }    ; # syntax error, space is required
 
 The C<else> cannot be separated from the conditional statement by a
 semicolon, but as a special case, it is OK to have a newline.
 
 =for code :skip-test
-    if 0 { say "no" }; else { say "yes" }  ; # syntax error
-    if 0 { say "no" }
-    else { say "yes" }                     ; # says "yes"
+if 0 { say "no" }; else { say "yes" }  ; # syntax error
+if 0 { say "no" }
+else { say "yes" }                     ; # says "yes"
 
 Additional conditions may be sandwiched between the C<if> and the
 C<else> using C<elsif>.  An extra condition will only be evaluated
@@ -209,14 +209,14 @@ instead of an C<else> if you want.
 You cannot use the statement modifier form with C<else> or C<elsif>:
 
 =for code :skip-test
-    42.say if 0 else { 43.say }            # syntax error
+42.say if 0 else { 43.say }            # syntax error
 
 All the same rules for semicolons and newlines apply, consistently
 
 =for code :skip-test
-    if 0 { say 0 }; elsif 1 { say 1 }  else { say "how?" } ; # syntax error
-    if 0 { say 0 }  elsif 1 { say 1 }; else { say "how?" } ; # syntax error
-    if 0 { say 0 }  elsif 1 { say 1 }  else { say "how?" } ; # says "1"
+if 0 { say 0 }; elsif 1 { say 1 }  else { say "how?" } ; # syntax error
+if 0 { say 0 }  elsif 1 { say 1 }; else { say "how?" } ; # syntax error
+if 0 { say 0 }  elsif 1 { say 1 }  else { say "how?" } ; # says "1"
 
     if 0 { say 0 } elsif 1 { say 1 }
     else { say "how?" }                                    ; # says "1"
@@ -255,9 +255,9 @@ with C<unless> because that ends up getting confusing.  Other than those
 two differences C<unless> works the same as L<#if>:
 
 =for code :skip-test
-    unless 1 { "1 is false".say }  ; # does not say anything, since 1 is true
-    unless 1   "1 is false".say    ; # syntax error, missing block
-    unless 0 { "0 is false".say }  ; # says "0 is false"
+unless 1 { "1 is false".say }  ; # does not say anything, since 1 is true
+unless 1   "1 is false".say    ; # syntax error, missing block
+unless 0 { "0 is false".say }  ; # says "0 is false"
 
     unless 42.say and 1 { 43.say } ; # says "42" but does not say "43"
     43.say unless 42.say and 0;      # says "42" and then says "43"
@@ -335,7 +335,7 @@ list when they are needed, so to read a file line by line, you could
 use:
 
 =for code :skip-test
-    for $*IN.lines -> $line { .say }
+for $*IN.lines -> $line { .say }
 
 Iteration variables are always lexical, so you don't need to use C<my> to give
 them the appropriate scope. Also, they are read-only aliases. If you need them
@@ -490,11 +490,11 @@ block, skipping the rest of the statements, and resuming after the block.
 This prevents the C<when> or C<default> from exiting the outer block.
 
 =for code :skip-test
-    default {
-        proceed;
-        "This never says".say
-    }
-    "This says".say;
+default {
+    proceed;
+    "This never says".say
+}
+"This says".say;
 
 This is most often used to enter multiple C<when> blocks.  C<proceed> will
 resume matching after a successful match, like so:
@@ -589,7 +589,7 @@ iteration.
 The infinite loop does not require parentheses.
 
 =for code :skip-test
-    loop { say 'forever' }
+loop { say 'forever' }
 
 The C<loop> statement may be used to produce values from the result of each
 run of the attached block if it appears in lists:

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -665,7 +665,14 @@ All these forms may produce a return value the same way C<loop> does.
 
 =head1 X<return|control flow>
 
-The routine C<return> will stop execution of a subroutine or method, run all relevant L<phasers|/language/phasers#Block_Phasers> and provide the given return value to the caller. The default return value is C<Nil>. If a return L<type constraint|/type/Signature#Constraining_Return_Types> is provided it will be checked unless the return value is C<Nil>. A control exception is raised and can be caught with L<CONTROL|/language/phasers#CONTROL>.
+The routine C<return> will stop execution of a subroutine or method, run all
+relevant L<phasers|/language/phasers#Block_Phasers> and provide the given
+return value to the caller. The default return value is C<Nil>. If a return
+L<type constraint|/type/Signature#Constraining_Return_Types> is provided it
+will be checked unless the return value is C<Nil>. If the type check fails the
+exception L<X::TypeCheck::Return|/type/X::TypeCheck::Return> is thrown. If it
+passes a control exception is raised and can be caught with
+L<CONTROL|/language/phasers#CONTROL>.
 
 =comment TODO add link to section in /language/function that shows how return values are produces/handled
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -56,7 +56,7 @@ if True {say "Hello"}
 
 though you can't leave out any of the remaining whitespace.
 
-=head2 Unspace
+=head2 X<Unspace|syntax,\>
 
 In many places where the compiler would not allow a space you can use any
 whitespace that is quoted with a backslash. Unspaces in tokens are not

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -64,10 +64,10 @@ supported. Newlines that are unspaced still count when the compiler produces
 line numbers. Usecases for unspace are separation of postfix operators and
 routine argument lists.
 
-    sub alignment(+@l) { +@l };$
-    sub long-name-alignment(+@l) { +@l };$
-    alignment\         (1,2,3,4)>>.say;$
-    long-name-alignment(3,5)\   >>.say;$
+    sub alignment(+@l) { +@l };
+    sub long-name-alignment(+@l) { +@l };
+    alignment\         (1,2,3,4)>>.say;
+    long-name-alignment(3,5)\   >>.say;
 
 =head2 Separating Statements
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -185,7 +185,7 @@ by not actually generating the list if it is not necessary.
 
     multi method sum() returns Numeric:D
 
-Returns the sum of all elements in the Range. Throws X::Str::Numeric if an element can not be coerced into Numeric.    
+Returns the sum of all elements in the Range. Throws X::Str::Numeric if an element can not be coerced into Numeric.
 
     (1..10).sum #55
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -339,10 +339,9 @@ Directives guide the use (if any) of the arguments. When a directive
 (other than C<%>) is used, it indicates how the next argument
 passed is to be formatted into the string to be created.
 
-NOTE:  The information below is for a fully functioning C<sprintf> implementation which hasn't been
-achieved yet due, in part, to Rakudo issues with native uint64 types. The following section will
-be annotated to indicate what parts do NOT yet work properly after a thorough test is made of
-each example below.
+NOTE: The information below is for a fully functioning C<sprintf>
+implementation which hasn't been achieved yet. Formats or features not
+yet implemented are marked NYI.
 
 The directives are:
 
@@ -392,10 +391,10 @@ no-ops (the semantics are still being determined).
 =begin table
 
  h  interpret integer as native "short" (typically int16)
- l  interpret integer as native "long" (typically int32 or int64)
- ll interpret integer as native "long long" (typically int64)
- L  interpret integer as native "long long" (typically uint64)
- q  interpret integer as native "quads" (typically int64 or larger)
+ NYI l  interpret integer as native "long" (typically int32 or int64)
+ NYI ll interpret integer as native "long long" (typically int64)
+ NYI L  interpret integer as native "long long" (typically uint64)
+ NYI q  interpret integer as native "quads" (typically int64 or larger)
 
 =end table
 
@@ -419,7 +418,7 @@ One or more of:
    space   prefix non-negative number with a space
    +       prefix non-negative number with a plus sign
    -       left-justify within the field
-   0       use zeros, not spaces, to right-justify
+   0       use leading zeros, not spaces, for required padding
    #       ensure the leading "0" for any octal,
            prefix non-zero hexadecimal with "0x" or "0X",
            prefix non-zero binary with "0b" or "0B"
@@ -450,9 +449,9 @@ is ignored:
 When the C<#> flag and a precision are given in the C<%o> conversion, the
 precision is incremented if it's necessary for the leading "0":
 
-  sprintf '<%#.5o>', 012;      # "<00012>"
+  sprintf '<%#.5o>', 012;      # "<000012>"
   sprintf '<%#.5o>', 012345;   # "<012345>"
-  sprintf '<%#.0o>', 0;        # "<0>"
+  sprintf '<%#.0o>', 0;        # "<>" # zero precision results in no output!
 
 =head3 vector flag
 
@@ -462,13 +461,13 @@ format to each integer in turn, then joins the resulting strings with
 a separator (a dot, C<'.'>, by default). This can be useful for
 displaying ordinal values of characters in arbitrary strings:
 
-  sprintf "%vd", "AB\x{100}";           # "65.66.256"
-  sprintf "version is v%vd\n", $^V;     # Perl 6's version
+  NYI sprintf "%vd", "AB\x{100}";           # "65.66.256"
+  NYI sprintf "version is v%vd\n", $^V;     # Perl 6's version
 
 You can also explicitly specify the argument number to use for the
 join string using something like C<*2$v>; for example:
 
-  sprintf '%*4$vX %*4$vX %*4$vX',       # 3 IPv6 addresses
+  NYI sprintf '%*4$vX %*4$vX %*4$vX',       # 3 IPv6 addresses
           @addr[1..3], ":";
 
 =head3 (minimum) width
@@ -478,11 +477,11 @@ display the given value. You can override the width by putting a
 number here, or get the width from the next argument (with C<*> ) or
 from a specified argument (e.g., with C<*2$>):
 
- sprintf "<%s>", "a";       # "<a>"
- sprintf "<%6s>", "a";      # "<     a>"
- sprintf "<%*s>", 6, "a";   # "<     a>"
- sprintf '<%*2$s>', "a", 6; # "<     a>"
- sprintf "<%2s>", "long";   # "<long>" (does not truncate)
+ sprintf "<%s>", "a";           # "<a>"
+ sprintf "<%6s>", "a";          # "<     a>"
+ sprintf "<%*s>", 6, "a";       # "<     a>"
+ NYI sprintf '<%*2$s>', "a", 6; # "<     a>"
+ sprintf "<%2s>", "long";       # "<long>" (does not truncate)
 
 If a field width obtained through C<*> is negative, it has the same
 effect as the C<-> flag: left-justification.
@@ -519,12 +518,15 @@ For integer conversions, specifying a precision implies that the
 output of the number itself should be zero-padded to this width, where
 the C<0> flag is ignored:
 
-  sprintf '<%.6d>', 1;      # "<000001>"
-  sprintf '<%+.6d>', 1;     # "<+000001>"
-  sprintf '<%-10.6d>', 1;   # "<000001    >"
-  sprintf '<%10.6d>', 1;    # "<    000001>"
-  sprintf '<%010.6d>', 1;   # "<    000001>"
-  sprintf '<%+10.6d>', 1;   # "<   +000001>"
+(Note that this feature currenly works for unsigned integer conversions, but not
+for signed integer.)
+
+  NYI sprintf '<%.6d>', 1;      # "<000001>"
+  NYI sprintf '<%+.6d>', 1;     # "<+000001>"
+  NYI sprintf '<%-10.6d>', 1;   # "<000001    >"
+  NYI sprintf '<%10.6d>', 1;    # "<    000001>"
+  NYI sprintf '<%010.6d>', 1;   # "<    000001>"
+  NYI sprintf '<%+10.6d>', 1;   # "<   +000001>"
   sprintf '<%.6x>', 1;      # "<000001>"
   sprintf '<%#.6x>', 1;     # "<0x000001>"
   sprintf '<%-10.6x>', 1;   # "<000001    >"
@@ -543,8 +545,8 @@ from a specified argument (e.g., with C<.*2$>):
 
   sprintf '<%.6x>', 1;       # "<000001>"
   sprintf '<%.*x>', 6, 1;    # "<000001>"
-  sprintf '<%.*2$x>', 1, 6;  # "<000001>"
-  sprintf '<%6.*2$x>', 1, 4; # "<  0001>"
+  NYI sprintf '<%.*2$x>', 1, 6;  # "<000001>"
+  NYI sprintf '<%6.*2$x>', 1, 4; # "<  0001>"
 
 If a precision obtained through C<*> is negative, it counts as having
 no precision at all:
@@ -566,6 +568,8 @@ numbers are usually assumed to be whatever the default integer size is
 on your platform (usually 32 or 64 bits), but you can override this to
 use instead one of the standard C types, as supported by the compiler
 used to build Perl 6:
+
+(Note: None of the following have been implemented.)
 
    hh          interpret integer as C type "char" or "unsigned
                               char"
@@ -594,12 +598,13 @@ the next argument.
 
 So:
 
-   sprintf "<%*.*s>", $a, $b, $c;
+   my $a = 5; my $b = 2; my $c = 'net';
+   sprintf "<%*.*s>", $a, $b, $c; # <   ne>
 
 uses C<$a> for the width, C<$b> for the precision, and C<$c> as the value to
 format; while:
 
-  sprintf '<%*1$.*s>', $a, $b;
+  NYI sprintf '<%*1$.*s>', $b, 'b';
 
 would use C<$a> for the width and precision and C<$b> as the value to format.
 
@@ -609,21 +614,16 @@ index, the C<$> may need escaping:
  sprintf "%2\$d %d\n",      12, 34;     # "34 12\n"
  sprintf "%2\$d %d %d\n",   12, 34;     # "34 12 34\n"
  sprintf "%3\$d %d %d\n",   12, 34, 56; # "56 12 34\n"
- sprintf "%2\$*3\$d %d\n",  12, 34,  3; # " 34 12\n"
- sprintf "%*1\$.*f\n",       4,  5, 10; # "5.0000\n"
+ NYI sprintf "%2\$*3\$d %d\n",  12, 34,  3; # " 34 12\n"
+ NYI sprintf "%*1\$.*f\n",       4,  5, 10; # "5.0000\n"
 
 =comment TODO: document effects of locale
-
-
-
-
-
-
 
 Other examples:
 
 =for code :skip-test
-sprintf "%ld a big number, %lld a bigger number\n", 4294967295, 4294967296;
+NYI sprintf "%ld a big number", 4294967295;
+NYI sprintf "%%lld a bigger number", 4294967296;
 sprintf('%c', 97);                  # a
 sprintf("%.2f", 1.969);             # 1.97
 sprintf("%+.3f", 3.141592);         # +3.142
@@ -634,9 +634,9 @@ Special case: 'sprintf("<b>%s</b>\n", "Perl 6")' will not work, but
 one of the following will:
 
 =for code :skip-test
- sprintf Q:b "<b>%s</b>\n",  "Perl 6";
- sprintf     "<b>\%s</b>\n", "Perl 6";
- sprintf     "<b>%s\</b>\n", "Perl 6";
+ sprintf Q:b "<b>%s</b>\n",  "Perl 6"; # "<b>Perl 6</b>\n"
+ sprintf     "<b>\%s</b>\n", "Perl 6"; # "<b>Perl 6</b>\n"
+ sprintf     "<b>%s\</b>\n", "Perl 6"; # "<b>Perl 6</b>\n"
 
 =head2 method starts-with
 

--- a/doc/Type/UInt.pod6
+++ b/doc/Type/UInt.pod6
@@ -9,7 +9,7 @@ The C<UInt> is defined as a subset of C<Int>:
 =for code :skip-test
 my subset UInt of Int where * >= 0;
 
-Consequently it can be instantiated or subclassed; however, that shouldn't affect most normal uses.
+Consequently, it cannot be instantiated or subclassed; however, that shouldn't affect most normal uses.
 
 Some examples of its behavior and uses:
 

--- a/doc/Type/UInt.pod6
+++ b/doc/Type/UInt.pod6
@@ -1,0 +1,12 @@
+=begin pod
+
+=TITLE class UInt
+
+=SUBTITLE Unsigned Integer (arbitrary-precision)
+
+The C<UInt> is defined as a subset of C<Int>:
+
+=for code :skip-test
+my subset UInt of Int where * >= 0;
+
+=end pod

--- a/doc/Type/UInt.pod6
+++ b/doc/Type/UInt.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE class UInt
+=TITLE subset UInt
 
 =SUBTITLE Unsigned Integer (arbitrary-precision)
 
@@ -9,4 +9,20 @@ The C<UInt> is defined as a subset of C<Int>:
 =for code :skip-test
 my subset UInt of Int where * >= 0;
 
+Consequently it can be instantiated or subclassed; however, that shouldn't affect most normal uses.
+
+Some examples of its behavior and uses:
+
+=for code :skip-test
+  my UInt $u = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff; # 64-bit unsigned value
+  say $u.base(16); # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF (32 digits)
+  ++$u;
+  say $u.base(16); # 100000000000000000000000000000000 (33 digits!)
+  my Int $i = $u;
+  say $i.base(16); # same
+  say $u.WHAT;     # (UInt)
+  say $i.WHAT;     # (Int)
+  $u = $i;
+  say $u.WHAT;     # (Int)!! a subset of Int is an Int
+  
 =end pod

--- a/html/css/style.css
+++ b/html/css/style.css
@@ -25,8 +25,8 @@ html, body {
   margin: 0;
   background: #EFEFEF !important;
   font-family: sans-serif !important;
-  /*override font from perl.css
-        stylesheet, until we can get rid of it*/ }
+                                /*override font from perl.css
+stylesheet, until we can get rid of it*/ }
 
 html {
   padding: 0;
@@ -65,7 +65,6 @@ a code {
 pre a {
   text-decoration: underline;
   color: black; }
-
 pre a:hover {
   text-decoration: none;
   color: inherit; }
@@ -158,7 +157,6 @@ td, th {
   color: white;
   text-decoration: underline;
   font-weight: bold; }
-
 #not-found-message a:hover,
 #not-found-message a:active {
   text-decoration: none; }
@@ -184,12 +182,12 @@ td, th {
   #search div {
     overflow: hidden;
     /*
-        border-width: 0.1em;
-        border-style: solid;
-        border-radius: 0.5em;
-        padding: 0 0.5em;
-        background-color: #FFFFFF;
-*/ }
+            border-width: 0.1em;
+            border-style: solid;
+            border-radius: 0.5em;
+            padding: 0 0.5em;
+            background-color: #FFFFFF;
+    */ }
 
 #query {
   outline: none;
@@ -324,19 +322,22 @@ td, th {
     width: 60em;
     display: table;
     background-image: none; }
+
   div.pod-body {
     min-width: 60em;
     max-width: 60em;
     margin-left: 22em; }
+
   div.pod-body.no-toc {
     margin-left: 0em; }
+
   nav.indexgroup {
     float: left; }
+
   table#TOC {
     max-width: 20em; }
     table#TOC a {
       color: black; } }
-
 .title-anchor {
   visibility: hidden;
   color: #333;
@@ -406,21 +407,29 @@ div.highlight span.c-Singleline, div.highlight span.c {
       padding: 5px 10px 0;
       margin: 0;
       text-align: center; }
+
   #home_logo {
     display: none; }
+
   body {
     padding: 0; }
+
   .pretty-box {
     padding: 3px; }
+
   .menu-items {
     height: auto;
     padding: 0 10px; }
     .menu-items .menu-item + .menu-item {
       border: none; }
+
   .menu-item.selected {
     box-shadow: none;
     border-radius: 3px; }
+
   table#TOC tr[class^=toc-level] td {
     padding: 8px 0; }
   table#TOC tr.toc-level-1 td {
     padding-top: 18px; } }
+a[href*="//"]:not([href*="perl6.org"])::after {
+  content: url(../images/LinkExternal12x12.svg); }

--- a/html/images/LinkExternal12x12.svg
+++ b/html/images/LinkExternal12x12.svg
@@ -1,0 +1,17 @@
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="12" width="12" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <defs></defs>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g fill-rule="nonzero" transform="translate(0,-4)" fill="blue">
+  <path d="M2,7c-1.108,0-2,0.892-2,2v5c0,1.108,0.892,2,2,2h5c1.108,0,2-0.892,2-2v-3h-2v3h-5v-5h3v-2z"/>
+  <path d="M6,4,6,6,8.5938,6,3.625,10.938,5.0625,12.375,10,7.4062,10,10,12,10,12,4,6,4z"/>
+ </g>
+</svg>

--- a/template/footer.html
+++ b/template/footer.html
@@ -9,6 +9,8 @@
       This documentation is provided under the terms of the
       <a href="https://raw.githubusercontent.com/perl6/doc/master/LICENSE">Artistic License 2.0</a>.
       The Camelia image is copyright © 2009 by Larry Wall.
+      <!-- CREDITS -->
+      <!-- External Link Image  by Zapyon, CCA-SA 4.0 Derived from Wikimedia Foundation https://commons.wikimedia.org/wiki/File:External-link-04-bold-12x12.svg -->
   </p>
   <p>
     <small>


### PR DESCRIPTION
#822 

I added a css class for links that do not match *.perl6.org . It adds the SVG file here at the end: 
https://commons.wikimedia.org/wiki/File:External-link-04-bold-12x12.svg . I'm not married to this file, but I know we can distribute it freely.


I'm a little concerned that I used this URL in the scss.  
`../images/LinkExternal12x12.svg`

On my local deploy of the documentation web server, this was rewritten to /css/images/LinkExternal12x12.svg. I'm not familiar enough with sass to know why this happened. 