### PR TITLE
Delete trailing dollar symbols

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -64,10 +64,10 @@ supported. Newlines that are unspaced still count when the compiler produces
 line numbers. Usecases for unspace are separation of postfix operators and
 routine argument lists.
 
-    sub alignment(+@l) { +@l };$
-    sub long-name-alignment(+@l) { +@l };$
-    alignment\         (1,2,3,4)>>.say;$
-    long-name-alignment(3,5)\   >>.say;$
+    sub alignment(+@l) { +@l };
+    sub long-name-alignment(+@l) { +@l };
+    alignment\         (1,2,3,4)>>.say;
+    long-name-alignment(3,5)\   >>.say;
 
 =head2 Separating Statements
 


### PR DESCRIPTION
These examples with trailing dollar symbols seems incorrect.

```
$ perl6 -e 'sub alignment(+@l) { +@l };$'
WARNINGS for -e:
Useless use of unnamed $ variable in sink context (line 1)
```