### PR TITLE
Fixed confusing wording in the state variables docs

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -591,14 +591,6 @@ Therefore, the subroutine
 
     say a for 1..6;
 
-This works per "clone" of the containing code object, so:
-
-    ({ state $i = 1; $i++.say; } xx 3).map: {$_(), $_()}; # says 1 then 2 thrice
-
-Note that this is B<not> a thread-safe construct when the same clone of the same
-block is run by multiple threads.  Also remember that methods only have one
-clone per class, not per object.
-
 will continue to increment C<$l> and append it to C<@x> each time it is
 called. So it will output
 
@@ -612,6 +604,15 @@ called. So it will output
 [A B C D E F]
 
 =end code
+
+This works per "clone" of the containing code object, as in this example:
+
+    ({ state $i = 1; $i++.say; } xx 3).map: {$_(), $_()}; # says 1 then 2 thrice
+
+Note that this is B<not> a thread-safe construct when the same clone of the same
+block is run by multiple threads.  Also remember that methods only have one
+clone per class, not per object.
+
 
 As with C<my>, declaring multiple C<state> variables must be placed
 in parentheses and for declaring a single variable, parentheses may


### PR DESCRIPTION
#906 - I moved a paragraph up to make it clear what code sample it belongs to. 