### PR TITLE
Commented out :rotate adverb example, add back when it works. Fixes #895

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -35,7 +35,8 @@ convenient places:
 
     q:w"foo bar"   # ":w" is a Quotelike form modifier adverb
     m:g/a|b|c/     # ":g" is also
-    4 +> 5 :rotate # ":rotate" is an operator adverb
+=comment TODO: Add this back in when :rotate on infix operators is supported
+=comment 4 +> 5 :rotate # ":rotate" is an operator adverb 
     @h{3}:exists   # ":exists" is also, but is known as a subscript adverb
 
 Adverbs are usually expressed with colon pair notation, and for this


### PR DESCRIPTION
#895 