### PR TITLE
Fix #889: Nix "previous chapters" sentence

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -105,13 +105,13 @@ X<|type object>
 X<|defined>
 X<|.defined>
 
-Declaring a class creates a I<type object> which, by default, is installed
-into the current package (just like a variable declared with C<our> scope).
-This type object is an "empty instance" of the class.  You've already seen
-these in previous chapters. For example, types such as C<Int> and C<Str>
-refer to the type object of one of the Perl 6 built-in classes. The example
-above uses the class name C<Task> so that other code can refer to it later,
-such as to create class instances by calling the C<new> method.
+Declaring a class creates a I<type object> which, by default, is installed into
+the current package (just like a variable declared with C<our> scope).  This
+type object is an "empty instance" of the class. For example, types such as
+C<Int> and C<Str> refer to the type object of one of the Perl 6 built-in
+classes. The example above uses the class name C<Task> so that other code can
+refer to it later, such as to create class instances by calling the C<new>
+method.
 
 Type objects are I<undefined>, in the sense that they return C<False> if you
 call the C<.defined> method on them. You can use this method to find out if


### PR DESCRIPTION
Looked to see if "chapter" occurred anywhere else too. It did not.