### PR TITLE
Fix the example of the Attribute.type method

### DIFF
--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -110,10 +110,10 @@ Returns the type constraint of the attribute.
         has @.mystery;
     }
     my @types = TypeHouse.^attributes(:local)[0..2];
-    for 0..2 { say @types[$_] }
-    # OUTPUT: «Positional[Int] @!array
-    # Mu $!scalar
-    # Positional @!mystery␤»
+    for 0..2 { say @types[$_].type }
+    # OUTPUT: «(Positional[Int])
+    # (Mu)
+    # (Positional)␤»
 
 =head2 method get_value
 


### PR DESCRIPTION
Fix #947 