### PR TITLE
Remove some 'seems' usage

### DIFF
--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -53,7 +53,7 @@ I<actually> do.
 
 Works as you would expect. The caveat in Perl 5's perlop about C<**>
 binding more tightly than unary minus (i. e. "-2**4" evaluates as "-(2**4)"
-rather than "(-2)**4)") seems to hold true for Perl 6.
+rather than "(-2)**4)") is also true for Perl 6.
 
 =head2 Symbolic Unary Operators
 

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -25,7 +25,6 @@ variables.
 
 =item $_
 
-
 Thankfully, C<$_> is the general default variable as in Perl 5. The
 main difference in Perl 6 seems to be that you can now call methods on
 it. For instance, Perl 5's C<say $_> can be rendered in Perl 6 as
@@ -195,11 +194,11 @@ of all loaded modules (compilation units) like so:
 
 =item $^I
 
-S28 suggests $*INPLACE_EDIT, but it does not yet seem to exist.
+S28 suggests $*INPLACE_EDIT, but it does not yet exist.
 
 =item $^M
 
-S28 suggests $*EMERGENCY_MEMORY, but it does not yet seem to exist.
+S28 suggests $*EMERGENCY_MEMORY, but it does not yet exist.
 
 =item $OSNAME
 
@@ -242,7 +241,7 @@ As with C<$]> this has been replaced with C<$*PERL.version>.
 
 =item ${^WIN32_SLOPPY_STAT}
 
-There does not seem to be any analog to this in Perl 6.
+There is no analog to this in Perl 6.
 
 =item $EXECUTABLE_NAME
 
@@ -275,7 +274,7 @@ to C<$/[0]>, C<$1> is equivalent to C<$/[1]>, etc.
 
 C<$/> now contains the match object, so the Perl 5 behavior of C<$&> can
 be obtained by stringifying it, i. e. C<~$/>. C<$/.Str> also should
-work, but C<~$/> seems to be the consensus preference.
+work, but C<~$/> is the currently more common idiom.
 
 =item ${^MATCH}
 

--- a/doc/Type/IO/Notification.pod6
+++ b/doc/Type/IO/Notification.pod6
@@ -33,8 +33,9 @@ IO::Notification.watch-path($?FILE).act( -> $change {
 await $finish;
 
 The type of the change is very much dependent both on the platform and on
-specific system calls that were used initiate the change. At this point in
-time, relying on them seems to be a bad idea.
+specific system calls that were used initiate the change. At this point in time
+you should not rely on the type of change in general, and test your particular
+situaton.
 
 =head1 Methods
 


### PR DESCRIPTION
Per the suggestion of issue #619, this removes some weak language.