### PR TITLE
fix typo in doc about how to fix typo in doc, doc

### DIFF
--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -67,7 +67,7 @@ next directive of the same level, will be considered part of the
 documentable. So, in:
 
 =begin code :allow<R> :skip-test
-d2 R<My Definition>
+=head2 R<My Definition>
 
 Some paragraphs, followed by some code:
 


### PR DESCRIPTION
the first example "=head2" block was spelled as "d2" instead of "=head2" which probably did actually blow some minds... it at least caused a misfire in mine.

(fixes apparent mistake from https://github.com/perl6/doc/commit/fb947c098cd6e9cec6874f5d77d38cee08f6a7a1 )