### PR TITLE
minor wording fix

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -269,7 +269,7 @@ The method itself takes the passed parameter – which must be an instance of
 the C<Task> class – and C<push>es it onto the invocant's C<@!dependencies>
 attribute.
 
-The second method contains the main logic of the dependency handler:
+The C<perform> method contains the main logic of the dependency handler:
 
     method perform() {
         unless $!done {


### PR DESCRIPTION
This method was referred to as the second method, which was confusing since the method before it was also referred to as the second method. Removed the ordinal; just use the name, for future-proofing.