### PR TITLE
Clarifications on numeric literals

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -316,7 +316,7 @@ number:
 Integers default to signed base-10, but you can use other bases. For details,
 see L<Int|/type/Int>.
 
-    -2
+    -2          # actually not a literal, but unary - operator applied to numeric literal 2
     12345
     0xBEEF      # base 16
     0o755       # base 8
@@ -328,19 +328,20 @@ L<Rat|/type/Rat> literals (rationals) are very common, and take the place of dec
 
     1.0
     3.14159
-    -2.5
+    -2.5        # Not actually a literal, but still a Rat
     :3<21.0012> # Base 3 rational
     2/3         # Not actually a literal, but still a Rat
 
 =head4 Num literals
 
-Scientific notation with an exponent to base ten after an C<e> produces
+Scientific notation with an integer exponent to base ten after an C<e> produces
 L<floating point number|/type/Num>:
 
     1e0
     6.022e23
     1e-9
     -2e48
+    2e2.5       # error
 
 =head4 Complex literals
 
@@ -349,7 +350,7 @@ L<Complex|/type/Complex> numbers are written either as an imaginary number
 a real and an imaginary number:
 
     1+2i
-    6.123e5i
+    6.123e5i    # note that this is 6.123e5 * i and not 6.123 * 10 ** (5i)
 
 
 =head3 Pair literals


### PR DESCRIPTION
Belief in negative numeric literals creates false expectations regarding precedence conflicts (see #971)
