### PR TITLE
Remove supplying explicit identity from produce examples. 

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -763,8 +763,8 @@ producing with an infix operator:
 
     # The following all do the same thing...
     my @numbers = (1,2,3,4,5);
-    say produce { $^a + $^b }, 0, |@numbers;
-    say produce * + *, 0, |@numbers;
+    say produce { $^a + $^b }, @numbers;
+    say produce * + *, @numbers;
     say produce &[+], @numbers; # operator does not need explicit identity
     say [\+] @numbers;          # most people write it this way
 


### PR DESCRIPTION
Prepending a zero to the result is unlikely to be desired.