### PR TITLE
Issue #968: document methods corresponding to file test operators

### DIFF
--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -471,12 +471,6 @@ If you have a string - a path to something in the filesystem:
         say 'file exists';
     }
 
-Instead of the colonpair syntax, you can use method calls too:
-
-    if 'path/to/file'.IO.e {
-        say 'file exists';
-    }
-
 If you already have an IO object in $file, either by creating one yourself,
 or by getting it from another subroutine, such as C<dir>,
 you can write this:
@@ -485,6 +479,89 @@ you can write this:
     if $file ~~ :e {
         say 'file exists';
     }
+
+Instead of the colonpair syntax, you can use method calls too:
+
+    if 'path/to/file'.IO.e {
+        say 'file exists';
+    }
+
+=head2 method e
+
+    method e(--> Bool) 
+
+Returns C<True> if path exists or C<False> if not.
+
+=head2 method d
+
+    method d(--> Bool)
+
+Returns C<True> if path is a directory, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method f
+
+    method f(--> Bool)
+
+Returns C<True> if path is a file, C<False> if not, orL<fails|/routine/fail>
+with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method l
+
+    method l(--> Bool)
+
+Returns C<True> if path is a symbolic link, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method r
+
+    method r(--> Bool)
+
+Returns C<True> if path is readable, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method w 
+
+    method w(--> Bool)
+
+Returns C<True> if path is writable, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method x
+
+    method w(--> Bool)
+
+Returns C<True> if path is executable, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method s
+
+    method s(--> Int)
+
+Returns size of file in bytes or L<fails|/routine/fail> with L<X::IO::DoesNotExist> if the path does not exist or L<X::IO::NotAFile> if path is not a file.
+
+=head2 method z
+
+    method z(--> Bool)
+
+Returns C<True> is path is zero length file or L<fails|/routine/fail> with
+L<X::IO::DoesNotExist> if path does not exist or L<X::IO::NotAFile> if
+path is not a file.
+
+=head2 method rw
+
+    method rw(--> Bool)
+
+Returns C<True> if path is readable and writable, C<False> if not, or
+L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not exist.
+
+=head2 method rwx
+
+    method rwx(--> Bool)
+
+Returns C<True> if path is readable, writable, and executable, C<False> if not,
+or L<fails|/routine/fail> with L<X::IO::DoesNotExist> if path does not
+exist.
 
 =head1 File timestamp retrieval
 


### PR DESCRIPTION
Issue #968: document methods corresponding to file test operators in IO::Path.
