### PR TITLE
Fix example that mixed up q:w and Q:w

### DIFF
--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -162,7 +162,8 @@ X<|qw word quote>
 
 =for code :allow<B L>
 B<qw|>! @ # $ % ^ & * \| < > B<|> eqv '! @ # $ % ^ & * | < >'.words
-B<Q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}')
+B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}')
+B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}')
 
 The C<:w> form, usually written as C<qw>, splits the string into
 "words".  In this context, words are defined as sequences of non-whitespace


### PR DESCRIPTION
The original example had very strange behavior; not sure how to
document this:

    Q:w { [ ] \{ \} } eqv ('[', ']', '{', '}') # False

    > Q:w { [ ] \{ \} }.perl
    ("[", "]", "\\\{\\}")