### PR TITLE
Consistent return types

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -150,7 +150,7 @@ occur over C<(SELF,)> (if C<:$item> is set) or C<SELF>.
 
 Defined as:
 
-    method deepmap(&block -->List) is nodal
+    method deepmap(&block) returns List is nodal
 
 C<deepmap> will apply C<&block> to each element and return a new C<List> with
 the return values of C<&block>, unless the element does the C<Iterable> role.

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -97,7 +97,7 @@ with detailed explanations.
 
 =head2 sub bag
 
-    sub bag(*@args --> Bag)
+    sub bag(*@args) returns Bag
 
 Creates a new C<Bag> from C<@args>.
 

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -218,7 +218,7 @@ Converts the invocant to L«C<DateTime>|/type/DateTime»
 
 =head2 sub sleep
 
-    sub sleep($seconds = Inf --> Nil)
+    sub sleep($seconds = Inf) returns Nil
 
 Attempt to sleep for the given number of C<$seconds>.  Returns C<Nil> on
 completion.  Accepts C<Int>, C<Num>, C<Rat>, or C<Duration> types as an
@@ -246,7 +246,7 @@ seconds and C<sleep 5.2> sleeps for 5.2 seconds:
 
 =head2 sub sleep-timer
 
-    sub sleep-timer(Real $seconds = Inf --> Duration)
+    sub sleep-timer(Real $seconds = Inf) returns Duration
 
 This function is just like C<sleep>, but returns the amount of time
 remaining to sleep as a C<Duration> (which will be 0 if the call was not
@@ -256,7 +256,7 @@ interrupted).
 
 =head2 sub sleep-until
 
-    sub sleep-until(Instant $until --> Bool)
+    sub sleep-until(Instant $until) returns Bool
 
 Works just like C<sleep> but checks the current time and goes back to sleep
 if accidentally woken up early, to guarantee waiting until the specified

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -293,8 +293,8 @@ sub spurt($where, $what,
     Str  :$enc        = 'utf8',
     Bool :$bin        = False,
     Bool :$append      = False,
-    Bool :$createonly = False,
-    --> Bool ) is export
+    Bool :$createonly = False
+    ) returns Bool
 
 Writes the indicated contents (2nd positional parameter, C<$what>) to the
 location indicated by the first positional parameter, C<$where> (which can

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -52,67 +52,67 @@ Returns C<True> if the read operations have exhausted the content of the file.
 
 =head2 method e
 
-    method e(--> Bool)
+    method e returns Bool
 
 Returns C<Bool::True> if the invocant is a valid path that exists.
 
 =head2 method d
 
-    method d(--> Bool)
+    method d returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the directory exists.
 
 =head2 method f
 
-    method f(--> Bool)
+    method f returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the file exists.
 
 =head2 method s
 
-    method s(--> Bool)
+    method s returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the size is bigger then 0.
 
 =head2 method l
 
-    method l(--> Bool)
+    method l returns Bool
 
 Returns C<Bool::True> if the invocant is a path and a symlink.
 
 =head2 method r
 
-    method r(--> Bool)
+    method r returns Bool
 
 Returns C<Bool::True> if the invocant is a path and accessible.
 
 =head2 method w
 
-    method w(--> Bool)
+    method w returns Bool
 
 Returns C<Bool::True> if the invocant is a path and writable.
 
 =head2 method rw
 
-    method rw(--> Bool)
+    method rw returns Bool
 
 Returns C<Bool::True> if the invocant is a path, read and writable.
 
 =head2 method x
 
-    method x(--> Bool)
+    method x returns Bool
 
 Returns C<Bool::True> if the invocant is a path and executable.
 
 =head2 method rwx
 
-    method rwx(--> Bool)
+    method rwx returns Bool
 
 Returns C<Bool::True> if the invocant is a path, executable, read and writable.
 
 =head2 method z
 
-    method z(--> Bool)
+    method z returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the size is 0.
 
@@ -175,7 +175,7 @@ $fn.comb(3, close => True); # Comb file contents by 3 characters and close after
 
 =head2 method print
 
-    method print(*@text --> Bool)
+    method print(*@text) returns Bool
 
 Text writing; writes the given C<@text> to the filehandle.  See L<write>
 to write bytes.
@@ -229,13 +229,13 @@ $fh.close;
 
 =head2 method read
 
-    method read(IO::Handle:D: Int(Cool:D) $bytes --> Blob)
+    method read(IO::Handle:D: Int(Cool:D) $bytes) returns Blob
 
 Binary reading; reads and returns up to C<$bytes> bytes from the filehandle.
 
 =head2 method readchars
 
-    method readchars(IO::Handle:D: Int(Cool:D) $chars --> Str)
+    method readchars(IO::Handle:D: Int(Cool:D) $chars) returns Str
 
 Reading chars; reads and returns up to C<$chars> chars (graphemes) from the
 filehandle.
@@ -271,14 +271,14 @@ offset if you want to position before the end of the file.
 
 =head2 method tell
 
-    method tell(IO::Handle:D: --> Int)
+    method tell(IO::Handle:D:) returns Int
 
 Return the current position of the file pointer in bytes.
 
 =head2 method slurp-rest
 
-    multi method slurp-rest(IO::Handle:D: :$bin!, :$close --> Buf)
-    multi method slurp-rest(IO::Handle:D: :$enc, :$close --> Str)
+    multi method slurp-rest(IO::Handle:D: :$bin!, :$close) returns Buf
+    multi method slurp-rest(IO::Handle:D: :$enc, :$close) returns Str
 
 Returns the remaining content of the file from the current file position
 (which may have been set by previous reads or by C<seek>.)  If the
@@ -294,7 +294,7 @@ my $rest-of-file = $fh.slurp-rest(:close);
 
 =head2 method Supply
 
-    multi method Supply(IO::Handle:D: :$size = 65536, :$bin --> Supply)
+    multi method Supply(IO::Handle:D: :$size = 65536, :$bin) returns Supply
 
 Returns a C<Supply> that will emit the contents of the handle in chunks.
 The size of the chunks is determined by the optional C<:size> named parameter
@@ -335,13 +335,13 @@ argument such as C<fcntl> or C<ioctl>.
 
 =head2 method opened
 
-    method opened(IO::Handle:D: --> Bool)
+    method opened(IO::Handle:D:) returns Bool
 
 Returns C<True> if the handle is open.
 
 =head2 method t
 
-    method t(IO::Handle:D: --> Bool)
+    method t(IO::Handle:D:) returns Bool
 
 Returns C<True> if the handle is opened to a tty.
 

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -44,7 +44,7 @@ basename passed as named arguments.
 
 =head2 method abspath
 
-    method abspath(IO::Path:D: --> Str)
+    method abspath(IO::Path:D:) returns Str
 
 Returns the absolute path as a string.
 
@@ -95,7 +95,7 @@ values the return values of the methods with the same names.
 
 =head2 method path
 
-    method path(IO::Path:D: --> Str)
+    method path(IO::Path:D:) returns Str
 
 Returns the full path as a string.
 
@@ -118,38 +118,38 @@ same as the L<open> function accepts.
 
 =head2 method watch
 
-    method watch(IO::Path:D: --> Supply)
+    method watch(IO::Path:D:) returns Supply
 
 Watches the path for modifications. Only implemented in Rakudo with the
 MoarVM backend at the moment.
 
 =head2 method is-absolute
 
-    method is-absolute(IO::Path:D: --> Bool)
+    method is-absolute(IO::Path:D:) returns Bool
 
 Returns C<True> if the path is an absolute path, and C<False> otherwise.
 
 =head2 method is-relative
 
-    method is-relative(IO::Path:D: --> Bool)
+    method is-relative(IO::Path:D:) returns Bool
 
 Returns C<True> if the path is a relative path, and C<False> otherwise.
 
 =head2 method absolute
 
-    method absolute(IO::Path:D: $base = ~$*CWD --> IO::Path)
+    method absolute(IO::Path:D: $base = ~$*CWD) returns IO::Path
 
 Returns a new C<IO::Path> object that is an absolute path, based on C<$base>.
 
 =head2 method relative
 
-    method relative(IO::Path:D: $base = ~$*CWD --> IO::Path)
+    method relative(IO::Path:D: $base = ~$*CWD) returns IO::Path
 
 Returns a new C<IO::Path> object relative to the C<$base> path.
 
 =head2 method parent
 
-    method parent(IO::Path:D: --> IO::Path)
+    method parent(IO::Path:D:) returns IO::Path
 
 Removes the last portion of the path and returns the result as a new C<IO::Path>.
 
@@ -158,7 +158,7 @@ Removes the last portion of the path and returns the result as a new C<IO::Path>
 
 =head2 method child
 
-    method child(IO::Path:D: $childname --> IO::Path)
+    method child(IO::Path:D: $childname) returns IO::Path
 
 Appends C<$childname> to the end of the path, adding path separators where
 needed and returns the result as a new C<IO::Path>.
@@ -168,7 +168,7 @@ needed and returns the result as a new C<IO::Path>.
 
 =head2 method resolve
 
-    method resolve(IO::Path:D: --> IO::Path)
+    method resolve(IO::Path:D:) returns IO::Path
 
 Returns a new C<IO::Path> object with all symbolic links and references to the
 parent directory (C<..>) resolved.  This means that the filesystem is examined
@@ -234,67 +234,67 @@ say $perl-files[1..3];
 
 =head2 method e
 
-    method e(--> Bool)
+    method e returns Bool
 
 Returns C<Bool::True> if the invocant is a valid path that exists.
 
 =head2 method d
 
-    method d(--> Bool)
+    method d returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the directory exists.
 
 =head2 method f
 
-    method f(--> Bool)
+    method f returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the file exists.
 
 =head2 method s
 
-    method s(--> Bool)
+    method s returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the size is bigger then 0.
 
 =head2 method l
 
-    method l(--> Bool)
+    method l returns Bool
 
 Returns C<Bool::True> if the invocant is a path and a symlink.
 
 =head2 method r
 
-    method r(--> Bool)
+    method r returns Bool
 
 Returns C<Bool::True> if the invocant is a path and accessible.
 
 =head2 method w
 
-    method w(--> Bool)
+    method w returns Bool
 
 Returns C<Bool::True> if the invocant is a path and writable.
 
 =head2 method rw
 
-    method rw(--> Bool)
+    method rw returns Bool
 
 Returns C<Bool::True> if the invocant is a path, readable and writable.
 
 =head2 method x
 
-    method x(--> Bool)
+    method x returns Bool
 
 Returns C<Bool::True> if the invocant is a path and executable.
 
 =head2 method rwx
 
-    method rwx(--> Bool)
+    method rwx returns Bool
 
 Returns C<Bool::True> if the invocant is a path, executable, readable and writable.
 
 =head2 method z
 
-    method z(--> Bool)
+    method z returns Bool
 
 Returns C<Bool::True> if the invocant is a path and the size is 0.
 
@@ -313,9 +313,9 @@ Write C<$contents> to this path, like L<spurt|/routine/spurt>.
 
 =head2 routine chdir
 
-    sub chdir(Str() $path, :$test = 'r' --> IO::Path)
-    multi method chdir(IO::Path:U: $path, :$test = 'r' --> IO::Path)
-    multi method chdir(IO::Path:D: Str() $path is copy, :$test = 'r' --> IO::Path)
+    sub chdir(Str() $path, :$test = 'r') returns IO::Path
+    multi method chdir(IO::Path:U: $path, :$test = 'r') returns IO::Path
+    multi method chdir(IO::Path:D: Str() $path is copy, :$test = 'r') returns IO::Path
 
 Alter the processes notion of the current working directory (as found in
 C<$*CWD>.)
@@ -333,9 +333,9 @@ L<fail|/routine/fail> with L<X::IO::Chdir>.
 
 =head2 routine mkdir
 
-    multi sub mkdir(Int:D $mode, *@dirnames --> List)
-    multi sub mkdir($path, $mode = 0o777 --> Bool)
-    method    mkdir(IO::Path:D: $mode = 0o777 --> Bool)
+    multi sub mkdir(Int:D $mode, *@dirnames) returns List
+    multi sub mkdir($path, $mode = 0o777) returns Bool
+    method    mkdir(IO::Path:D: $mode = 0o777) returns Bool
 
 Creates one or more directories with the L<permissions|
 https://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation>
@@ -351,8 +351,8 @@ returns the names of the directories that were successfully created.
 
 =head2 routine rmdir
 
-    sub    rmdir(IO $dir --> Bool)
-    method rmdir(IO::Path:D: --> Bool)
+    sub    rmdir(IO $dir) returns Bool
+    method rmdir(IO::Path:D:) returns Bool
 
 Remove the given directory if it is empty.
 
@@ -376,8 +376,8 @@ See also L<rmtree in File::Directory::Tree|https://github.com/labster/p6-file-di
 
 =head2 routine chmod
 
-    sub    chmod($mode, *@filenames --> List)
-    method chmod(IO::Path:D: $mode --> Bool)
+    sub    chmod($mode, *@filenames) returns List
+    method chmod(IO::Path:D: $mode) returns Bool
 
 Changes the POSIX permissions of a file (or in the subroutine form, any number
 of files) to C<$mode>.
@@ -403,8 +403,8 @@ chmod '0444', 'myfile';            # BAD!!! (interpreted as mode 0o674)
 
 =head2 routine rename
 
-    method rename(IO::Path:D: $to, :$createonly --> Bool)
-    sub    rename($from, $to, :$createonly --> Bool)
+    method rename(IO::Path:D: $to, :$createonly) returns Bool
+    sub    rename($from, $to, :$createonly) returns Bool
 
 Renames a file. Both C<$from> (the file to be renamed) and C<$to> (the
 destination) can take arbitrary paths. If C<:createonly> is set to C<True>,
@@ -442,8 +442,8 @@ physical storage device).
 
 =head2 routine symlink
 
-    method symlink(IO::Path:D: Str $name --> Bool)
-    sub    symlink(Str $target, Str $name --> Bool)
+    method symlink(IO::Path:D: Str $name) returns Bool
+    sub    symlink(Str $target, Str $name) returns Bool
 
 Create a new symbolic link named as $target (or the name of the invocant in
 the method form,) to the existing file named C<$name>.
@@ -453,8 +453,8 @@ L<X::IO::Symlink> if the symbolic link could not be created.
 
 =head2 routine link
 
-    method link(IO::Path:D: Str $name --> Bool)
-    sub    link(Str $target, Str $name --> Bool)
+    method link(IO::Path:D: Str $name) returns Bool
+    sub    link(Str $target, Str $name) returns Bool
 
 Create a new link named as $target (or the name of the invocant in the
 method form,) to the existing file named C<$name>.
@@ -464,8 +464,8 @@ L<X::IO::Link> if the link operation could not be performed.
 
 =head2 routine unlink
 
-    method unlink(IO::Path:D: --> Bool)
-    sub    unlink(*@filenames --> List)
+    method unlink(IO::Path:D:) returns Bool
+    sub    unlink(*@filenames) returns List
 
 Delete all specified ordinary files, links, or symbolic links.
 
@@ -476,13 +476,13 @@ completed.
 
 =head2 method IO
 
-    method IO(IO::Path:D: --> IO::Path)
+    method IO(IO::Path:D:) returns IO::Path
 
 Returns the invocant.
 
 =head2 method SPEC
 
-    method SPEC(IO::Path:D: --> IO::Spec)
+    method SPEC(IO::Path:D:) returns IO::Spec
 
 Returns the L<IO::Spec|/type/IO::Spec> object that was (implicitly) specified at object
 creation time.

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -70,7 +70,7 @@ with detailed explanations.
 
 =head2 sub mix
 
-    sub mix(*@args --> Mix) {}
+    sub mix(*@args) returns Mix
 
 Creates a new C<Mix> from C<@args>.
 

--- a/doc/Type/Mixy.pod6
+++ b/doc/Type/Mixy.pod6
@@ -14,7 +14,7 @@ C<Mixy> are L<Real>s rather than L<Int>s.
 
 =head2 method total
 
-    method total(--> Real)
+    method total returns Real
 
 Returns the sum of all the weights
 

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -21,7 +21,7 @@ routine even when the routine specifies a particular return type. It may also
 be returned regardless of the definedness of the return type, however, C<Nil>
 is considered undefined for all other purposes.
 
-    sub a( --> Int:D ) { return Nil }
+    sub a returns Int:D { return Nil }
     a().say;                    # Nil
 
 C<Nil> is what is returned from empty routines or closure, or routines
@@ -64,12 +64,12 @@ type container will fail with a runtime error.
     $x = Nil;
     $x.say;                     # (Int)
 
-    sub f( --> Int:D ){ Nil }; # this definedness constraint is ignored
+    sub f returns Int:D { Nil }; # this definedness constraint is ignored
     my Int:D $i = f; # this definedness constraint is not ignored, so throws
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $y; expected Int but got Any (Any)»
 
-    sub g( --> Int:D ){ fail "oops" }; # this definedness constraint is ignored
+    sub g returns Int:D { fail "oops" }; # this definedness constraint is ignored
     my Any:D $h = g; # failure object matches Any:D, so is assigned
 
 but

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -82,7 +82,7 @@ list of set operators with detailed explanations.
 
 =head2 sub set
 
-    sub set(*@args --> Set)
+    sub set(*@args) returns Set
 
 Creates a C<Set> from the given C<@args>
 

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -109,13 +109,13 @@ Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
 =head2 method elems
 
-    method elems(--> Int)
+    method elems returns Int
 
 The number of elements of the set.
 
 =head2 method total
 
-    method total(--> Int)
+    method total returns Int
 
 The total of all the values of the C<QuantHash> object. For a C<Setty>
 object, this is just the number of elements.

--- a/t/return-type.t
+++ b/t/return-type.t
@@ -15,17 +15,17 @@ for @files -> $file {
     { pass "$file return types are valid" ; next } if $file ~~ /Signature/;
     my @lines;
     my Int $line-no = 1;
-     for $file.IO.lines -> $line {
-	 if so $line ~~ /(method|sub) .+? '-->'/
-	 && $line !~~ /'--> True'/
-	 && $line !~~ /'--> False'/ {
-	     @lines.push($line-no);
-	 }
-	 $line-no++;
-     }
-     if @lines {
-	 flunk "$file has bad return type: {@lines}";
-     } else {
-	 pass "$file return types are ok";
-     }
+    for $file.IO.lines -> $line {
+        if so $line ~~ /(method|sub) .+? '-->'/
+        && $line !~~ /'--> True'/
+        && $line !~~ /'--> False'/ {
+        @lines.push($line-no);
+        }
+    $line-no++;
+    }
+    if @lines {
+        flunk "$file has bad return type: {@lines}";
+    } else {
+        pass "$file return types are ok";
+    }
 }

--- a/t/return-type.t
+++ b/t/return-type.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+use lib 'lib';
+
+my @files;
+
+# Every .pod6 file in the Type directory.
+@files = qx<git ls-files>.lines.grep(* ~~ /'.pod6'/).grep(* ~~ /Type/);
+
+plan +@files;
+
+for @files -> $file {
+    # If it is the any Signature-related exception
+    # or Signature.pod, then presence of '-->' is valid.
+    { pass "$file return types are valid" ; next } if $file ~~ /Signature/;
+    my @lines;
+    my Int $line-no = 1;
+     for $file.IO.lines -> $line {
+	 if so $line ~~ /(method|sub) .+? '-->'/
+	 && $line !~~ /'--> True'/
+	 && $line !~~ /'--> False'/ {
+	     @lines.push($line-no);
+	 }
+	 $line-no++;
+     }
+     if @lines {
+	 flunk "$file has bad return type: {@lines}";
+     } else {
+	 pass "$file return types are ok";
+     }
+}


### PR DESCRIPTION
Here are two commits:
* First makes the consistent types consistent.
* Seconds adds a test to check it automatically.
Questions and reviews are welcome!

It closes https://github.com/perl6/doc/issues/1024, see it for a previous discussion.