### PR TITLE
Small bunch of changes to make examples compileable.

### DIFF
--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -213,8 +213,8 @@ Defined as:
 Returns an L<IO::Path|/type/IO::Path> object representing the stringified
 value of the Dateish object:
 
-    Date.today.IO.say   # "2016-10-03".IO
-    DateTime.now.IO.say # "2016-10-03T11:14:47.977994-04:00".IO
+    Date.today.IO.say;   # "2016-10-03".IO
+    DateTime.now.IO.say; # "2016-10-03T11:14:47.977994-04:00".IO
 
 B<PORTABILITY NOTE:> some operating systems (e.g. Windows) do not permit
 colons (C<:>) in filenames, which would be present in C<IO::Path> created from a

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -141,8 +141,8 @@ most idiomatic and unambiguous solution:
 
 You can assign to multiple keys at the same time with a slice.
 
-    my %h; %h<a b c> = 2 xx *; %h.perl.say  # {:a(2), :b(2), :c(2)}
-    my %h; %h<a b c> = ^3;     %h.perl.say  # {:a(0), :b(1), :c(2)}
+    my %h; %h<a b c> = 2 xx *; %h.perl.say;  # {:a(2), :b(2), :c(2)}
+    my %h; %h<a b c> = ^3;     %h.perl.say;  # {:a(0), :b(1), :c(2)}
 
 =head2 Non-string keys
 

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -36,8 +36,9 @@ respectively:
 
 These notations allow you to use variables, too:
 
-    :16($ninety-nine) # 153
-    :100[99, $two, 3] # 990203
+    my Int $ininety-nine = 99;
+    :16($ninety-nine); # 153
+    :100[99, $two, 3]; # 990203
 
 =head1 Methods
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -790,14 +790,14 @@ producing with an infix operator:
 The visual picture of a triangle C<[\> is not accidental. To produce a
 triangular list of of lists, you can use a "triangular comma":
 
-    [\,] 1..5
-    (
-     (1)
-     (1 2)
-     (1 2 3)
-     (1 2 3 4)
-     (1 2 3 4 5)
-    )
+    [\,] 1..5;
+    # (
+    # (1)
+    # (1 2)
+    # (1 2 3)
+    # (1 2 3 4)
+    # (1 2 3 4 5)
+    # )
 
 Since C<produce> is an implicit loop, it responds to C<next>, C<last> and
 C<redo> statements inside C<&with>:

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -85,7 +85,9 @@ The final digit produced is always rounded.
     say pi.base(10, 3);      # 3.142
     say (1/128).base(10, *); # 0.0078125
     say (1/100).base(10, *); # 0.01
+=begin code :skip-test
     say (1/3)  .base(10, *); # WRONG: endlessly repeating fractional part
+=end code
 
 For reverse operation, see L«C<parse-base>|/routine/parse-base»
 

--- a/doc/Type/Regex.pod6
+++ b/doc/Type/Regex.pod6
@@ -22,9 +22,9 @@ A named regex can be defined with the C<regex> declarator followed by its
 definition in curly braces. Since any regex does C<Callable> introspection requires
 referencing via C<&>-sigil.
 
-    my regexp R { \N }
+    my regex R { \N };
     say &R.WHAT;
-    # OUTPUT«Regex␤»
+    # OUTPUT: «(Regex)␤»
 
 To match a string against a regex, you can use the smart match operator:
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -440,6 +440,7 @@ B<flags>
 
 One or more of:
 
+=begin table
    space   prefix non-negative number with a space
    +       prefix non-negative number with a plus sign
    -       left-justify within the field
@@ -447,6 +448,7 @@ One or more of:
    #       ensure the leading "0" for any octal,
            prefix non-zero hexadecimal with "0x" or "0X",
            prefix non-zero binary with "0b" or "0B"
+=end table
 
 For example:
 
@@ -486,14 +488,18 @@ format to each integer in turn, then joins the resulting strings with
 a separator (a dot, C<'.'>, by default). This can be useful for
 displaying ordinal values of characters in arbitrary strings:
 
+=begin code :skip-test
   NYI sprintf "%vd", "AB\x{100}";           # "65.66.256"
   NYI sprintf "version is v%vd\n", $^V;     # Perl 6's version
+=end code
 
 You can also explicitly specify the argument number to use for the
 join string using something like C<*2$v>; for example:
 
+=begin code :skip-test
   NYI sprintf '%*4$vX %*4$vX %*4$vX',       # 3 IPv6 addresses
           @addr[1..3], ":";
+=end code
 
 B<(minimum) width>
 
@@ -505,7 +511,9 @@ from a specified argument (e.g., with C<*2$>):
  sprintf "<%s>", "a";           # "<a>"
  sprintf "<%6s>", "a";          # "<     a>"
  sprintf "<%*s>", 6, "a";       # "<     a>"
+=begin code :skip-test
  NYI sprintf '<%*2$s>', "a", 6; # "<     a>"
+=end code
  sprintf "<%2s>", "long";       # "<long>" (does not truncate)
 
 If a field width obtained through C<*> is negative, it has the same

--- a/doc/Type/WrapHandle.pod6
+++ b/doc/Type/WrapHandle.pod6
@@ -8,8 +8,8 @@ class WrapHandle { ... }
 
 C<WrapHandle> is created and returned by L<wrap|/type/Routine#method_wrap>. It's only use is to unwrap wrapped routines. Either call L<unwrap|/type/Routine#method_unwrap> on a routine object or call the method C<restore> on a C<WrapHandle> object.
 
-    sub f(){ say 'f was called' }
-    my $wrap-handle = &f.wrap({ say 'before'; callsame; say 'after' })
+    sub f(){ say 'f was called' };
+    my $wrap-handle = &f.wrap({ say 'before'; callsame; say 'after' });
 
     f;
     $wrap-handle.restore;


### PR DESCRIPTION
It includes such types of fixes:
1)Missed semicolons;
2)Typos;
3)Endless code without :skip-test;
4)Convert flags table to actual table, not code.

Review is welcome.