### PR TITLE
Delete >>.say

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -66,8 +66,8 @@ routine argument lists.
 
     sub alignment(+@l) { +@l };
     sub long-name-alignment(+@l) { +@l };
-    alignment\         (1,2,3,4)>>.say;
-    long-name-alignment(3,5)\   >>.say;
+    alignment\         (1,2,3,4).say;
+    long-name-alignment(3,5)\   .say;
 
 =head2 Separating Statements
 


### PR DESCRIPTION
These are my two pointers:
+ `>>.say` is an incorrect usage, because `.say` has side effects.
+ `>>` doesn't make sense in this case, because both `alignment` and `long-name-alignment` return the number of the given arguments.
