### PR TITLE
Document `is deafult` for Subs

### DIFF
--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -61,4 +61,26 @@ to it (or even themselves) and we can apply traits to objects at runtime.
     &trait_mod:<is>(&bar, :foo);
     # OUTPUT«is foo called␤is foo called␤»
 
+There is a special trait for C<Sub>s called C<is default>. This trait is
+designed as a way to disambiguate C<multi> function calls that would normally
+throw an error because Rakudo would not know which one to use. This means that
+given the following two C<Sub>s, the one with the C<is default> trait will be
+called.
+
+    multi sub f() is default { say "Hello there" }
+    multi sub f() { say "Hello friend" }
+    f();   #"Hello there" is printed.
+
+The C<is default> trait can become very useful for debugging and other uses but
+keep in mind that it will only resolve an ambiguous dispatch between two C<Sub>s
+of the same precedence. If one of the C<Sub>s are narrower than another, then
+that one will be called. For example:
+
+    multi sub f() is default { say "Hello there" }
+    multi sub f(:$greet) { say "Hello " ~ $greet }
+    f();   #"Use of uninitialized value $greet..."
+
+In this example, the C<multi> without C<is default> was called because it was
+actually narrower than the C<Sub> with it.
+
 =end pod


### PR DESCRIPTION
Added explanations and examples to document what `is default` does for Subs. This is to fix #1040.