### PR TITLE
Fixed typo in "Traps". Changed variable name.

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -425,8 +425,8 @@ If you really do want to pass them as pairs you should use a L<List|/type/List>
 or L<Capture|/type/Capture> instead:
 
     my $list = ('b' => 2); # this is a List containing a single Pair
-    foo(|$arg, :$b); # okay: we passed the pair 'b' => 2 to the first argument
-    foo(1, |$arg);   # FAIL: Too many positionals passed; expected 1 argument but got 2
+    foo(|$list, :$b); # okay: we passed the pair 'b' => 2 to the first argument
+    foo(1, |$list);   # FAIL: Too many positionals passed; expected 1 argument but got 2
 
     my $cap = \('b' => 2); # a Capture with a single positional value
     foo(|$cap, :$b); # okay: we passed the pair 'b' => 2 to the first argument


### PR DESCRIPTION
Fixed typo in "Traps". Changed variable name "$arg" to "$list" so that it matches the declaration above it.