### PR TITLE
Edit headers to 'is default' sections

### DIFF
--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -61,7 +61,7 @@ to it (or even themselves) and we can apply traits to objects at runtime.
     &trait_mod:<is>(&bar, :foo);
     # OUTPUT«is foo called␤is foo called␤»
 
-=head trait is default (Sub class)
+=head2 trait is default (Sub class)
 
 There is a special trait for C<Sub>s called C<is default>. This trait is
 designed as a way to disambiguate C<multi> function calls that would normally

--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -61,6 +61,8 @@ to it (or even themselves) and we can apply traits to objects at runtime.
     &trait_mod:<is>(&bar, :foo);
     # OUTPUT«is foo called␤is foo called␤»
 
+=head trait is default (Sub class)
+
 There is a special trait for C<Sub>s called C<is default>. This trait is
 designed as a way to disambiguate C<multi> function calls that would normally
 throw an error because Rakudo would not know which one to use. This means that

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -21,7 +21,7 @@ introspect and manipulate variables.
 
 Returns the name of the variable, including the sigil.
 
-=head2 trait is default
+=head2 trait is default (Variables)
 
     multi sub trait_mod:<is>(Variable:D, :$default!)
 


### PR DESCRIPTION
This adds a header to the 'is default' section of the Sub type so that it is indexed. The 'is default' section for variables has also been changed a bit so that it is in the same format as the Sub one.