### PR TITLE
Document the undefined sort order of standard collections

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -596,7 +596,7 @@ X<Hyper method call operator>. Will call a method on all elements of a C<List> o
 Take care to avoid a common mistake of expecting side-effects to occur in order. The following
 C<say> is B<not> guaranteed to produce the output in order:
 
-    @a».say;  # WRONG! Could produce a␤b␤c␤ or c␤b␤a␤ or any other order
+    @a».say;  # Could produce a␤b␤c␤ or c␤b␤a␤ or any other order
 
 =head2 postfix C<.postfix> / C<.postcircumfix>
 X<|.( )>X<|.[ ]>X<|.{ }>

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -156,6 +156,37 @@ Instead, use an expression that produces a value when you want a value.
     $ perl6 -e 'my $a = 2; say join ",", (+$a, ++$a)'
     2,3
 
+=head1 Containers
+
+=head2 Set and Bag do not give any ordering guarantees
+
+This is a devious one, because it is so easy to just have assumptions about
+an order, and it all works because in small test examples it's unlikely that
+the order will really change.
+
+You put elements into a Bag - don't expect to get them out in the same order.
+
+You cloned a Bag - original and clone might return elements in a different
+order.
+
+You pulled out elements from a Bag - dont't expect them to come out in the
+same order for the second time you try this: the Bag may have decided to
+reorganize itself, it may have gotten moved around during a garbage collection
+cycle and data structures are now organized differently, or it may just be
+a new phase of the moon.
+
+You add another element to a Bag - don't expect it to be added near the end,
+or near to the beginning. In fact the elements might now come out in a
+totally different order.
+
+Even if it works for you, this won't save you in the long term: Everything
+may be different in the next version, or in that other Perl6 implementation
+your friend at the next desk is using.
+
+TODO: Some code examples, plus talk about how to deal with this (mostly: prefer
+sorted variants of Set and Bag if you can). Also, there might be more types
+than just Set and Bag.
+
 =head1 Arrays
 
 =head2 Referencing the last element of an array


### PR DESCRIPTION
Also, removed a WRONG marker: it is not wrong to output Bag
elements in an undefined order, i.e. if the user didn't care
about output order.