### PR TITLE
update hyperlink

### DIFF
--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -47,8 +47,8 @@ Z<<
 <hr/>
 
 
-<p>The Perl 6 homepage offers <a href="https://perl6.org/documentation/">a
-comprehensive list of Perl 6 documentation</a>, including tutorials, how-tos
+<p>The Perl 6 homepage offers <a href="https://perl6.org/resources/">a
+comprehensive list of Perl 6 resources</a>, including tutorials, how-tos
 and <a href="/language/faq">FAQs (Frequently Asked Questions)</a>.</p>
 
 <p>


### PR DESCRIPTION
replace  https://perl6.org/documentation/ by https://perl6.org/resources/