### PR TITLE
Part of the call with example was marked as output

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -688,11 +688,7 @@ For example
         say "Back in Int with $res";
     }
 
-    # OUTPUT:
-    # a 1;
-    # Int 1
-    # Any 2
-    # Back in Int with 5
+    a 1;        # Int 1\n Any 2\n Back in Int with 5
 
 Here C<a 1> calls the most specific C<Int> candidate first, and C<callwith>
 re-dispatches to the less specific C<Any> candidate.


### PR DESCRIPTION
And, I made the output look like the that for the 
other examples in that section. Note that those 
examples have extra spaces after "\n" that aren't 
part of the actual output.