### PR TITLE
group optional slash(/) and data so data does not parse without slash

### DIFF
--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -127,11 +127,11 @@ Of course, the data can be accessed directly by using $match<subject> or $match<
 
 =head2 Adding some flexibility
 
-The REST grammar so far will handle retrieves, deletes and updates ok. However, a I<create> command doesn't have the third part (the I<data> portion). This means our grammar will fail to match if we try to parse an update URL, and everyone will scream. To avoid this, we need to make that last I<data> position match optional, along with the '/' preceding it. This is easily accomplished by adding two question marks to the TOP token, to indicate their optional nature, just like a normal regex. So now we have:
+The REST grammar so far will handle retrieves, deletes and updates ok. However, a I<create> command doesn't have the third part (the I<data> portion). This means our grammar will fail to match if we try to parse a create URL, and everyone will scream. To avoid this, we need to make that last I<data> position match optional, along with the '/' preceding it. This is easily accomplished by adding a question mark for the grouped '/' and I<data> components of the TOP token, to indicate their optional nature, just like a normal regex. So now we have:
 
     =begin code
     grammar REST {
-        token TOP     { '/' <subject> '/' <command> '/'? <data>? }
+        token TOP     { '/' <subject> '/' <command> [ '/' <data> ]? }
         token subject { \w+ }
         token command { \w+ }
         token data    { .* }
@@ -147,7 +147,7 @@ Let's imagine, for the sake of demonstration, that we might want to allow these 
 
     =begin code
     grammar REST {
-        token TOP     { <slash><subject><slash><command><slash>?<data>? }
+        token TOP     { <slash><subject><slash><command>[<slash><data>]? }
         token subject { \w+ }
         token command { \w+ }
         token data    { .* }
@@ -222,7 +222,7 @@ This is what we've come up for processing our RESTful URIs so far:
     =begin code
     grammar REST
     {
-        token TOP { <slash><subject><slash><command><slash>?<data>? }
+        token TOP { <slash><subject><slash><command>[<slash><data>]? }
 
         proto token command {*}
         token command:sym<create>   { <sym> }
@@ -290,7 +290,7 @@ Here we are back to our grammar, as we left it.
     =begin code
     grammar REST
     {
-        token TOP { <slash><subject><slash><command><slash>?<data>? }
+        token TOP { <slash><subject><slash><command>[<slash><data>]? }
 
         proto token command {*}
         token command:sym<create>   { <sym> }
@@ -428,7 +428,7 @@ And this is the grammar and grammar actions that got us there, to recap:
     =begin code
     grammar REST
     {
-        token TOP { <slash><subject><slash><command><slash>?<data>? }
+        token TOP { <slash><subject><slash><command>[<slash><data>]? }
 
         proto token command {*}
         token command:sym<create>   { <sym> }


### PR DESCRIPTION
The current grammar allows '/product/update7/notify' to parse as well as '/product/update/7/notify'.  This change restricts to second case.