### PR TITLE
Two minor fixes

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -465,7 +465,7 @@ To share your module, do the following:
     »
 
     =begin item
-    Make your C<META6.json> file look something like this:
+    Make your X<C<META6.json>|META6.json> file look something like this:
 
     =for code :allow<R>
     {

--- a/template/search_template.js
+++ b/template/search_template.js
@@ -64,22 +64,24 @@ $(function(){
         }
       },
       position: { my: "right top", at: "right bottom", of: "#search div" },
-      source: [
-          {
-              category: "Syntax",
-              value: "# single-line comment",
-              url: "/language/syntax#Single-line_comments"
-          }, {
-              category: "Syntax",
-              value: "#` multi-line comment",
-              url: "/language/syntax#Multi-line_/_embedded_comments"
-          }, {
-              category: "Signature",
-              value: ";; (long name)",
-              url: "/type/Signature#index-entry-Long_Names"
-          },
-          ITEMS
-      ],
+      source: function(request, response) {
+          var items = [
+              {
+                  category: "Syntax",
+                  value: "# single-line comment",
+                  url: "/language/syntax#Single-line_comments"
+              }, {
+                  category: "Syntax",
+                  value: "#` multi-line comment",
+                  url: "/language/syntax#Multi-line_/_embedded_comments"
+              }, {
+                  category: "Signature",
+                  value: ";; (long name)",
+                  url: "/type/Signature#index-entry-Long_Names"
+              }, ITEMS ];
+          var results = $.ui.autocomplete.filter(items, request.term);
+          response(results.slice(0, 50));
+      },
       select: function (event, ui) { window.location.href = ui.item.url; },
       autoFocus: true
   });


### PR DESCRIPTION
First fix is related to https://github.com/perl6/doc/issues/1050 - limit results of search to 50 or something like that.
I just used "default" google way to limit results in autocomplete plugin and tested it for work - nothing special.

Second fix is related to this minor issue - https://github.com/perl6/doc/issues/550. I just made it searchable. It still lacks of documentation, but we have two another issues about this matter: https://github.com/perl6/doc/issues/764 and https://github.com/perl6/doc/issues/551. This is a temporary link until someone great enough will write a paragraph about meta-document with its own header.