### PR TITLE
Make comment style the same in Type/ directory

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -41,8 +41,8 @@ Defined as:
 Interprets the invocant as a list and creates an
 C<any>-L<Junction|/type/Junction> from it.
 
-    say so 2 == <1 2 3>.any;        # True
-    say so 5 == <1 2 3>.any;        # False
+    say so 2 == <1 2 3>.any;        # OUTPUT: «True␤»
+    say so 5 == <1 2 3>.any;        # OUTPUT: «False␤»
 
 =head2 method all
 
@@ -53,8 +53,8 @@ Defined as:
 Interprets the invocant as a list and creates an
 C<all>-L<Junction|/type/Junction> from it.
 
-    say so 1 < <2 3 4>.all;         # True
-    say so 3 < <2 3 4>.all;         # False
+    say so 1 < <2 3 4>.all;         # OUTPUT: «True␤»
+    say so 3 < <2 3 4>.all;         # OUTPUT: «False␤»
 
 =head2 method one
 
@@ -65,8 +65,8 @@ Defined as:
 Interprets the invocant as a list and creates a
 C<one>-L<Junction|/type/Junction> from it.
 
-    say so 1 == (1, 2, 3).one;      # True
-    say so 1 == (1, 2, 1).one;      # False
+    say so 1 == (1, 2, 3).one;      # OUTPUT: «True␤»
+    say so 1 == (1, 2, 1).one;      # OUTPUT: «False␤»
 
 =head2 method none
 
@@ -77,15 +77,15 @@ Defined as:
 Interprets the invocant as a list and creates a
 C<none>-L<Junction|/type/Junction> from it.
 
-    say so 1 == (1, 2, 3).none;     # False
-    say so 4 == (1, 2, 3).none;     # True
+    say so 1 == (1, 2, 3).none;     # OUTPUT: «False␤»
+    say so 4 == (1, 2, 3).none;     # OUTPUT: «True␤»
 
 =head2 method list
 
 Interprets the invocant as a list, and returns that L<List|/type/List>.
 
-    say 42.list.^name;           # List
-    say 42.list.elems;           # 1
+    say 42.list.^name;           # OUTPUT: «List␤»
+    say 42.list.elems;           # OUTPUT: «1␤»
 
 =head2 method push
 
@@ -95,9 +95,9 @@ implements C<Positional> already.  The argument provided will then be pushed
 into the newly created Array.
 
     my %h;
-    dd %h<a>; # Any (and therefor undefined)
+    dd %h<a>;      # Any (and therefore undefined)
     %h<a>.push(1); # .push on Any
-    dd %h; # «Hash %h = {:a($[1])}␤» # please note the Array
+    dd %h;         # «Hash %h = {:a($[1])}␤» # please note the Array
 
 =head2 routine reverse
 
@@ -113,8 +113,8 @@ to reverse the characters in a string, use L<flip>.
 
 Examples:
 
-    say <hello world!>.reverse;     # (world! hello)
-    say reverse ^10;                # (9 8 7 6 5 4 3 2 1 0)
+    say <hello world!>.reverse;     # OUTPUT: «(world! hello)␤»
+    say reverse ^10;                # OUTPUT: «(9 8 7 6 5 4 3 2 1 0)␤»
 
 =head2 method sort
 
@@ -122,10 +122,10 @@ Sorts iterables with C<infix:<cmp>> or given code object and returns a new C<Lis
 
 Examples:
 
-    say <b c a>.sort;                           # (a b c)
-    say 'bca'.comb.sort.join;                   # abc
-    say 'bca'.comb.sort({$^b cmp $^a}).join;    # cba
-    say '231'.comb.sort(&infix:«<=>»).join;     # 123
+    say <b c a>.sort;                           # OUTPUT: «(a b c)␤»
+    say 'bca'.comb.sort.join;                   # OUTPUT: «abc␤»
+    say 'bca'.comb.sort({$^b cmp $^a}).join;    # OUTPUT: «cba␤»
+    say '231'.comb.sort(&infix:«<=>»).join;     # OUTPUT: «123␤»
 
 =head2 method map
 
@@ -178,8 +178,8 @@ L<halting problem|https://en.wikipedia.org/wiki/Halting_problem> for you.
 If you flat an infinite list C<.flat> may return that infinite list, eating
 all your RAM in the process.
 
-    say ((1, 2), (3)).elems;        # 2
-    say ((1, 2), (3)).flat.elems;   # 3
+    say ((1, 2), (3)).elems;        # OUTPUT: «2␤»
+    say ((1, 2), (3)).flat.elems;   # OUTPUT: «3␤»
 
 Please not that C<flat> does not recurse into sub lists. You have to recurse by
 hand or reconsider your data structures. A single level of nesting can often be
@@ -188,30 +188,29 @@ signatures. For deeper structures you may consider
 L<gather/take|/syntax/gather take> to create a lazy list.
 
     my @a = [[1,2,3],[[4,5],6,7]];
-    say gather deepmap *.take, @a;
-    # (1 2 3 4 5 6 7)
+    say gather deepmap *.take, @a; # OUTPUT: «(1 2 3 4 5 6 7)␤»
 
 =head2 method eager
 
 Interprets the invocant as a list, evaluates it eagerly, and returns that
 list.
 
-    say (1..10).eager;              # (1 2 3 4 5 6 7 8 9 10)
+    say (1..10).eager;              # OUTPUT: «(1 2 3 4 5 6 7 8 9 10)␤»
 
 =head2 method elems
 
 Interprets the invocant as a list, and returns the number of elements in the
 list.
 
-    say 42.elems;                   # 1
-    say <a b c>.elems;              # 3
+    say 42.elems;                   # OUTPUT: «1␤»
+    say <a b c>.elems;              # OUTPUT: «3␤»
 
 =head2 method end
 
 Interprets the invocant as a list, and returns the last index of that list.
 
-    say 6.end;                      # 0
-    say <a b c>.end;                # 2
+    say 6.end;                      # OUTPUT: «0␤»
+    say <a b c>.end;                # OUTPUT: «2␤»
 
 =head2 method pairup
 
@@ -224,7 +223,7 @@ constructs a pair from them, unless the item in the key position already is a
 pair (in which case the pair is passed is passed through, and the next
 list item, if any, is considered to be a key again).
 
-    say (a => 1, 'b', 'c').pairup.perl;     # (:a(1), :b("c")).Seq
+    say (a => 1, 'b', 'c').pairup.perl;     # OUTPUT: «(:a(1), :b("c")).Seq␤»
 
 =head2 sub exit
 
@@ -247,14 +246,14 @@ Defined as:
 
 Forces given object to be evaluated in item context and returns the value of it.
 
-    say item([1,2,3]).perl;              # $[1, 2, 3]
-    say item({ apple => 10 }).perl;      # ${:apple(10)}
-    say item("abc").perl;                # "abc"
+    say item([1,2,3]).perl;              # OUTPUT: «$[1, 2, 3]␤»
+    say item({ apple => 10 }).perl;      # OUTPUT: «${:apple(10)}␤»
+    say item("abc").perl;                # OUTPUT: «"abc"␤»
 
 You can also use C<$> as item contextualizer.
 
-    say $[1,2,3].perl;                   # $[1, 2, 3]
-    say $("abc").perl;                   # "abc"
+    say $[1,2,3].perl;                   # OUTPUT: «$[1, 2, 3]␤»
+    say $("abc").perl;                   # OUTPUT: «"abc"␤»
 
 =end pod
 

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -46,7 +46,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.push: 'd';
-    say @foo;                   # [a b c d]
+    say @foo;                   # OUTPUT: «[a b c d]␤»
 
 Note that C<push> does not attempt to flatten its argument list.  If you pass
 an array or list as the thing to push, it becomes one additional element:
@@ -54,8 +54,8 @@ an array or list as the thing to push, it becomes one additional element:
     my @a = <a b c>;
     my @b = <d e f>;
     @a.push: @b;
-    say @a.elems;               # 4
-    say @a[3].join;             # def
+    say @a.elems;               # OUTPUT: «4␤»
+    say @a[3].join;             # OUTPUT: «def␤»
 
 Only if you supply multiple values as separate arguments to C<push> are
 multiple values added to the array:
@@ -64,7 +64,7 @@ multiple values added to the array:
    my @b = <a b>;
    my @c = <E F>;
    @a.push: @b, @c;
-   say @a.elems;                # 3
+   say @a.elems;                # OUTPUT: «3␤»
 
 See L<method append|#method append> for when you want to append multiple
 values that are stored in a single array.
@@ -91,8 +91,8 @@ Example:
     my @a = <a b c>;
     my @b = <d e f>;
     @a.append: @b;
-    say @a.elems;               # 6
-    say @a;                     # [a b c d e f]
+    say @a.elems;               # OUTPUT: «6␤»
+    say @a;                     # OUTPUT: «[a b c d e f]␤»
 
 =head2 routine shift
 
@@ -106,8 +106,8 @@ Removes and returns the first item from the array.  Fails for an empty arrays.
 Example:
 
     my @foo = <a b>;
-    say @foo.shift;             # a
-    say @foo.shift;             # b
+    say @foo.shift;             # OUTPUT: «a␤»
+    say @foo.shift;             # OUTPUT: «b␤»
     say @foo.shift;
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::Cannot::Empty: Cannot shift from an empty Array␤»
@@ -126,7 +126,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.unshift: 1, 3 ... 11;
-    say @foo;                   # [(1 3 5 7 9 11) a b c]
+    say @foo;                   # OUTPUT: «[(1 3 5 7 9 11) a b c]␤»
 
 The notes in L<the documentation for method push|#method push> apply,
 regarding how many elements are added to the array.
@@ -151,7 +151,7 @@ Example:
 
     my @foo = <a b c>;
     @foo.prepend: 1, 3 ... 11;
-    say @foo;                   # [1 3 5 7 9 11 a b c]
+    say @foo;                   # OUTPUT: «[1 3 5 7 9 11 a b c]␤»
 
 =head2 routine splice
 
@@ -181,8 +181,8 @@ C<$start>—and its return value is used the value of C<$elems>.
 Example:
 
     my @foo = <a b c d e f g>;
-    say @foo.splice(2, 3, <M N O P>);        # [c d e]
-    say @foo;                                # [a b M N O P f g]
+    say @foo.splice(2, 3, <M N O P>);        # OUTPUT: «[c d e]␤»
+    say @foo;                                # OUTPUT: «[a b M N O P f g]␤»
 
 =head2 method shape
 
@@ -195,9 +195,9 @@ Returns the shape of the array as a list.
 Example:
 
     my @foo[2;3] = ( < 1 2 3 >, < 4 5 6 > ); # Array with fixed dimensions
-    say @foo.shape;                          # (2 3)
+    say @foo.shape;                          # OUTPUT: «(2 3)␤»
     my @bar = ( < 1 2 3 >, < 4 5 6 > );      # Normal array (of arrays)
-    say @bar.shape;                          # (*)
+    say @bar.shape;                          # OUTPUT: «(*)␤»
 
 =head2 method default
 
@@ -213,14 +213,14 @@ value by using the L<is default|/routine/is default> trait the method returns
 the type object C<(Any)>.
 
     my @a1 = 1, "two", 2.718;
-    say @a1.default;                                       # (Any)
-    say @a1[4];                                            # (Any)
+    say @a1.default;                                       # OUTPUT: «(Any)␤»
+    say @a1[4];                                            # OUTPUT: «(Any)␤»
 
     my @a2 is default(17) = 1, "two", 3;
-    say @a2.default;                                       # 17
-    say @a2[4];                                            # 17
+    say @a2.default;                                       # OUTPUT: «17␤»
+    say @a2[4];                                            # OUTPUT: «17␤»
     @a2[1] = Nil;                                          # (resets element to its default)
-    say @a2[1];                                            # 17
+    say @a2[1];                                            # OUTPUT: «17␤»
 
 =head2 method of
 
@@ -233,10 +233,10 @@ i.e. if no type constraint is given during declaration, the method
 returns C<(Mu)>.
 
     my @a1 = 1, 'two', 3.14159;              # (no type constraint specified)
-    say @a1.of;                              # (Mu)
+    say @a1.of;                              # OUTPUT: «(Mu)␤»
 
     my Int @a2 = 1, 2, 3;                    # (values must be of type Int)
-    say @a2.of;                              # (Int)
+    say @a2.of;                              # OUTPUT: «(Int)␤»
     @a2.push: 'd';
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to @a2; expected Int but got Str ("d")␤»

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -19,16 +19,16 @@ The usual way to obtain an object of type C<Attribute> is by introspection:
         has @!things;
     }
     my $a = Useless.^attributes(:local)[0];
-    say $a.name;            # @!things
-    say $a.package;         # (Useless)
-    say $a.has_accessor;    # False
+    say $a.name;            # OUTPUT: «@!things␤»
+    say $a.package;         # OUTPUT: «(Useless)␤»
+    say $a.has_accessor;    # OUTPUT: «False␤»
 
     # modifying an attribute from the outside
     # this is usually not possible, but since Attribute
     # is at the level of the meta class, all is fair game
     my $instance = Useless.new;
     $a.set_value($instance, [1, 2, 3]);
-    say $a.get_value($instance);        # [1 2 3]
+    say $a.get_value($instance);        # OUTPUT: «[1 2 3]␤»
 
 =head1 Methods
 

--- a/doc/Type/Backtrace/Frame.pod6
+++ b/doc/Type/Backtrace/Frame.pod6
@@ -94,6 +94,6 @@ Returns C<True> if the frame is part of a setting.
 
     my $bt = Backtrace.new;
     my $btf = $bt[0];
-    say $btf.is-setting; # True
+    say $btf.is-setting; # OUTPUT: «True␤»
 
 =end pod

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -22,11 +22,11 @@ you can also easily get back the expanded list of items (without the order):
 =begin code
 my $breakfast = bag <spam eggs spam spam bacon spam>;
 
-say $breakfast.elems;      # 3
-say $breakfast.keys.sort;  # bacon eggs spam
+say $breakfast.elems;      # OUTPUT: «3␤»
+say $breakfast.keys.sort;  # OUTPUT: «bacon eggs spam␤»
 
-say $breakfast.total;      # 6
-say $breakfast.kxxv.sort;  # bacon eggs spam spam spam spam
+say $breakfast.total;      # OUTPUT: «6␤»
+say $breakfast.kxxv.sort;  # OUTPUT: «bacon eggs spam spam spam spam␤»
 =end code
 
 C<Bag>s can be treated as object hashes using the C<{ }> postcircumfix operator,
@@ -35,9 +35,9 @@ corresponding integer weight for keys that are elements of the bag, and C<0> for
 keys that aren't:
 
     my $breakfast = bag <spam eggs spam spam bacon spam>;
-    say $breakfast<bacon>;    # 1
-    say $breakfast<spam>;     # 4
-    say $breakfast<sausage>;  # 0
+    say $breakfast<bacon>;    # OUTPUT: «1␤»
+    say $breakfast<spam>;     # OUTPUT: «4␤»
+    say $breakfast<sausage>;  # OUTPUT: «0␤»
 
 =head1 Creating C<Bag> objects
 
@@ -46,9 +46,9 @@ which it is a shorthand).  Any positional parameters, regardless of their type,
 become elements of the bag:
 
     my $n = bag "a" => 0, "b" => 1, "c" => 2, "c" => 2;
-    say $n.keys.perl;        # (:c(2), :b(1), :a(0)).Seq
-    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
-    say $n.values.perl;      # (2, 1, 1).Seq
+    say $n.keys.perl;        # OUTPUT: «(:c(2), :b(1), :a(0)).Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Pair) (Pair) (Pair))␤»
+    say $n.values.perl;      # OUTPUT: «(2, 1, 1).Seq␤»
 
 Alternatively, the C<.Bag> coercer (or its functional form, C<Bag()>) can be
 called on an existing object to coerce it to a C<Bag>.  Its semantics depend on
@@ -58,16 +58,16 @@ Hash-like objects or Pair items, only the keys become elements of the bag, and
 the (cumulative) values become the associated integer weights:
 
     my $n = ("a" => 0, "b" => 1, "c" => 2, "c" => 2).Bag;
-    say $n.keys.perl;        # ("b", "c").Seq
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
-    say $n.values.perl;      # (1, 4).Seq
+    say $n.keys.perl;        # OUTPUT: «("b", "c").Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
+    say $n.values.perl;      # OUTPUT: «(1, 4).Seq␤»
 
 Furthermore, you can get a C<Bag> by using bag operators (see next section) on
 objects of other types such as L<List>, which will internally call C<.Bag>
 on them before performing the operation.  Be aware of the tight precedence of
 those operators though, which may require you to use parentheses around arguments:
 
-    say (1..5) (+) 4;  # bag(1, 2, 3, 4(2), 5)
+    say (1..5) (+) 4;  # OUTPUT: «bag(1, 2, 3, 4(2), 5)␤»
 
 =head1 Operators
 
@@ -78,16 +78,16 @@ values.  For example:
 =begin code
 my ($a, $b) = bag(2, 2, 4), bag(2, 3, 3, 4);
 
-say $a (<) $b;   # True
-say $a (<+) $b;  # False
-say $a (^) $b;   # set(3)
-say $a (+) $b;   # bag(2(3), 4(2), 3(2))
+say $a (<) $b;   # OUTPUT: «True␤»
+say $a (<+) $b;  # OUTPUT: «False␤»
+say $a (^) $b;   # OUTPUT: «set(3)␤»
+say $a (+) $b;   # OUTPUT: «bag(2(3), 4(2), 3(2))␤»
 
 # Unicode versions:
-say $a ⊂ $b;  # True
-say $a ≼ $b;  # False
-say $a ⊖ $b;  # set(3)
-say $a ⊎ $b;  # bag(2(3), 4(2), 3(2))
+say $a ⊂ $b;  # OUTPUT: «True␤»
+say $a ≼ $b;  # OUTPUT: «False␤»
+say $a ⊖ $b;  # OUTPUT: «set(3)␤»
+say $a ⊎ $b;  # OUTPUT: «bag(2(3), 4(2), 3(2))␤»
 =end code
 
 See L<Set/Bag Operators|/language/setbagmix#Set/Bag_Operators> for a complete list of set and bag operators

--- a/doc/Type/BagHash.pod6
+++ b/doc/Type/BagHash.pod6
@@ -20,11 +20,11 @@ order):
 =begin code
 my $breakfast = <spam eggs spam spam bacon spam>.BagHash;
 
-say $breakfast.elems;      # 3
-say $breakfast.keys.sort;  # bacon eggs spam
+say $breakfast.elems;      # OUTPUT: «3␤»
+say $breakfast.keys.sort;  # OUTPUT: «bacon eggs spam␤»
 
-say $breakfast.total;      # 6
-say $breakfast.kxxv.sort;  # bacon eggs spam spam spam spam
+say $breakfast.total;      # OUTPUT: «6␤»
+say $breakfast.kxxv.sort;  # OUTPUT: «bacon eggs spam spam spam spam␤»
 =end code
 
 C<BagHash>es can be treated as object hashes using the C<{ }> postcircumfix
@@ -36,13 +36,13 @@ didn't already exist:
 
 =begin code
 my $breakfast = <spam eggs spam spam bacon spam>.BagHash;
-say $breakfast<bacon>;     # 1
-say $breakfast<spam>;      # 4
-say $breakfast<sausage>;   # 0
+say $breakfast<bacon>;     # OUTPUT: «1␤»
+say $breakfast<spam>;      # OUTPUT: «4␤»
+say $breakfast<sausage>;   # OUTPUT: «0␤»
 
 $breakfast<sausage> = 2;
 $breakfast<bacon>--;
-say $breakfast.kxxv.sort;  # eggs sausage sausage spam spam spam spam
+say $breakfast.kxxv.sort;  # OUTPUT: «eggs sausage sausage spam spam spam spam␤»
 =end code
 
 =head1 Creating C<BagHash> objects
@@ -51,9 +51,9 @@ C<BagHash>es can be composed using C<BagHash.new>.  Any positional parameters,
 regardless of their type, become elements of the bag:
 
     my $n = BagHash.new: "a" => 0, "b" => 1, "c" => 2, "c" => 2;
-    say $n.keys.perl;        # (:c(2), :b(1), :a(0)).Seq
-    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
-    say $n.values.perl;      # (2, 1, 1).Seq
+    say $n.keys.perl;        # OUTPUT: «(:c(2), :b(1), :a(0)).Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Pair) (Pair) (Pair))␤»
+    say $n.values.perl;      # OUTPUT: «(2, 1, 1).Seq␤»
 
 Alternatively, the C<.BagHash> coercer (or its functional form, C<BagHash()>)
 can be called on an existing object to coerce it to a C<BagHash>.  Its semantics
@@ -63,9 +63,9 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the bag, and the (cumulative) values become the associated integer weights:
 
     my $n = ("a" => 0, "b" => 1, "c" => 2, "c" => 2).BagHash;
-    say $n.keys.perl;        # ("b", "c").Seq
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
-    say $n.values.perl;      # (1, 4).Seq
+    say $n.keys.perl;        # OUTPUT: «("b", "c").Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
+    say $n.values.perl;      # OUTPUT: «(1, 4).Seq␤»
 
 =head1 Operators
 
@@ -76,16 +76,16 @@ values. For example:
 =begin code
 my ($a, $b) = BagHash.new(2, 2, 4), BagHash.new(2, 3, 3, 4);
 
-say $a (<) $b;   # True
-say $a (<+) $b;  # False
-say $a (^) $b;   # set(3)
-say $a (+) $b;   # bag(2(3), 4(2), 3(2))
+say $a (<) $b;   # OUTPUT: «True␤»
+say $a (<+) $b;  # OUTPUT: «False␤»
+say $a (^) $b;   # OUTPUT: «set(3)␤»
+say $a (+) $b;   # OUTPUT: «bag(2(3), 4(2), 3(2))␤»
 
 # Unicode versions:
-say $a ⊂ $b;  # True
-say $a ≼ $b;  # False
-say $a ⊖ $b;  # set(3)
-say $a ⊎ $b;  # bag(2(3), 4(2), 3(2))
+say $a ⊂ $b;  # OUTPUT: «True␤»
+say $a ≼ $b;  # OUTPUT: «False␤»
+say $a ⊖ $b;  # OUTPUT: «set(3)␤»
+say $a ⊎ $b;  # OUTPUT: «bag(2(3), 4(2), 3(2))␤»
 =end code
 
 See L<Set/Bag Operators|/language/setbagmix#Set/Bag_Operators> for a complete list of

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -21,8 +21,7 @@ Constructs a Baggy objects from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:
 
     say Mix.new-from-pairs: 'butter' => 0.22, 'sugar' => 0.1, 'sugar' => 0.02;
-    # OUTPUT:
-    # mix(butter(0.22), sugar(0.12))
+    # OUTPUT: «mix(butter(0.22), sugar(0.12))␤»
 
 B<Note:> be sure you aren't accidentally passing the Pairs as positional arguments;
 the quotes around the keys in the above example are significant.
@@ -46,9 +45,9 @@ when it reaches 0). By definition, the C<total> of the invocant also decreases b
 probabilities stay consistent through subsequent C<grab> operations.
 
     my $cars = ('Ford' => 2, 'Rover' => 3).BagHash;
-    say $cars.grab;                                   # Ford
-    say $cars.grab(2);                                # [Rover Rover]
-    say $cars.grab(*);                                # [Rover Ford]
+    say $cars.grab;                                   # OUTPUT: «Ford␤»
+    say $cars.grab(2);                                # OUTPUT: «[Rover Rover]␤»
+    say $cars.grab(*);                                # OUTPUT: «[Rover Ford]␤»
 
     my $breakfast = ('eggs' => 2, 'bacon' => 3).Bag;
     say $breakfast.grab;
@@ -74,10 +73,10 @@ What makes C<grabpairs> different from L<pickpairs|#method pickpairs> is that th
 'grabbed' elements are in fact removed from the invocant.
 
     my $breakfast = (eggs => 2, bacon => 3).BagHash;
-    say $breakfast.grabpairs;                         # bacon => 3
-    say $breakfast;                                   # BagHash.new(eggs(2))
-    say $breakfast.grabpairs(1);                      # [eggs => 2]
-    say $breakfast.grabpairs(*);                      # []
+    say $breakfast.grabpairs;                         # OUTPUT: «bacon => 3␤»
+    say $breakfast;                                   # OUTPUT: «BagHash.new(eggs(2))␤»
+    say $breakfast.grabpairs(1);                      # OUTPUT: «[eggs => 2]␤»
+    say $breakfast.grabpairs(*);                      # OUTPUT: «[]␤»
 
     my $diet = ('eggs' => 2, 'bacon' => 3).Bag;
     say $diet.grabpairs;
@@ -104,11 +103,11 @@ Note that each C<pick> invocation maintains its own private state and has
 no effect on subsequent C<pick> invocations.
 
     my $breakfast = bag <eggs bacon bacon bacon>;
-    say $breakfast.pick;                              # eggs
-    say $breakfast.pick(2);                           # (eggs bacon)
+    say $breakfast.pick;                              # OUTPUT: «eggs␤»
+    say $breakfast.pick(2);                           # OUTPUT: «(eggs bacon)␤»
 
-    say $breakfast.total;                             # 4
-    say $breakfast.pick(*);                           # (bacon bacon bacon eggs)
+    say $breakfast.total;                             # OUTPUT: «4␤»
+    say $breakfast.pick(*);                           # OUTPUT: «(bacon bacon bacon eggs)␤»
 
 =head2 method pickpairs
 
@@ -128,9 +127,9 @@ Note that each C<pickpairs> invocation maintains its own private state and has
 no effect on subsequent C<pickpairs> invocations.
 
     my $breakfast = bag <eggs bacon bacon bacon>;
-    say $breakfast.pickpairs;                         # eggs => 1
-    say $breakfast.pickpairs(1);                      # (bacon => 3)
-    say $breakfast.pickpairs(*);                      # (eggs => 1 bacon => 3)
+    say $breakfast.pickpairs;                         # OUTPUT: «eggs => 1␤»
+    say $breakfast.pickpairs(1);                      # OUTPUT: «(bacon => 3)␤»
+    say $breakfast.pickpairs(*);                      # OUTPUT: «(eggs => 1 bacon => 3)␤»
 
 =head2 method roll
 
@@ -154,11 +153,11 @@ If C<*> is passed to C<$count>, returns a lazy, infinite sequence of randomly
 chosen elements from the invocant.
 
     my $breakfast = bag <eggs bacon bacon bacon>;
-    say $breakfast.roll;                                  # bacon
-    say $breakfast.roll(3);                               # (bacon eggs bacon)
+    say $breakfast.roll;                                  # OUTPUT: «bacon␤»
+    say $breakfast.roll(3);                               # OUTPUT: «(bacon eggs bacon)␤»
 
     my $random_dishes := $breakfast.roll(*);
-    say $random_dishes[^5];                               # (bacon eggs bacon bacon bacon)
+    say $random_dishes[^5];                               # OUTPUT: «(bacon eggs bacon bacon bacon)␤»
 
 =head2 method pairs
 
@@ -171,7 +170,7 @@ where the key is the element itself and the value is the weight of that element.
 
     my $breakfast = bag <bacon eggs bacon>;
     my $seq = $breakfast.pairs;
-    say $seq.sort;                                    # (bacon => 2 eggs => 1)
+    say $seq.sort;                                    # OUTPUT: «(bacon => 2 eggs => 1)␤»
 
 =head2 method antipairs
 
@@ -185,7 +184,7 @@ the opposite of method L<pairs|#method pairs>.
 
     my $breakfast = bag <bacon eggs bacon>;
     my $seq = $breakfast.antipairs;
-    say $seq.sort;                                    # (1 => eggs 2 => bacon)
+    say $seq.sort;                                    # OUTPUT: «(1 => eggs 2 => bacon)␤»
 
 =head2 method invert
 
@@ -200,7 +199,7 @@ Baggy type returns the same result as L<antipairs|#method_antipairs>.
 
     my $breakfast = bag <bacon eggs bacon>;
     my $seq = $breakfast.invert;
-    say $seq.sort;                                    # (1 => eggs 2 => bacon)
+    say $seq.sort;                                    # OUTPUT: «(1 => eggs 2 => bacon)␤»
 
 =head2 method classify-list
 
@@ -291,10 +290,10 @@ Returns a list of all keys in the C<Baggy> object without taking
 their individual weights into account as opposed to L<kxxv|#method kxxv>.
 
     my $breakfast = bag <eggs spam spam spam>;
-    say $breakfast.keys.sort;                        # (eggs spam)
+    say $breakfast.keys.sort;                        # OUTPUT: «(eggs spam)␤»
 
     my $n = ("a" => 5, "b" => 2).BagHash;
-    say $n.keys.sort;                                # (a b)
+    say $n.keys.sort;                                # OUTPUT: «(a b)␤»
 
 =head2 method values
 
@@ -305,10 +304,10 @@ Defined as:
 Returns a list of all values, i.e. weights, in the C<Baggy> object.
 
     my $breakfast = bag <eggs spam spam spam>;
-    say $breakfast.values.sort;                      # (1 3)
+    say $breakfast.values.sort;                      # OUTPUT: «(1 3)␤»
 
     my $n = ("a" => 5, "b" => 2, "a" => 1).BagHash;
-    say $n.values.sort;                              # (2 6)
+    say $n.values.sort;                              # OUTPUT: «(2 6)␤»
 
 =head2 method kv
 
@@ -319,10 +318,10 @@ Defined as:
 Returns a list of keys and values interleaved.
 
     my $breakfast = bag <eggs spam spam spam>;
-    say $breakfast.kv;                                # (spam 3 eggs 1)
+    say $breakfast.kv;                                # OUTPUT: «(spam 3 eggs 1)␤»
 
     my $n = ("a" => 5, "b" => 2, "a" => 1).BagHash;
-    say $n.kv;                                        # (a 6 b 2)
+    say $n.kv;                                        # OUTPUT: «(a 6 b 2)␤»
 
 =head2 method kxxv
 
@@ -335,10 +334,10 @@ weight. Note that C<kxxv> only works for C<Baggy> types which have integer
 weights, i.e. L<Bag> and L<BagHash>.
 
     my $breakfast = bag <spam eggs spam spam bacon>;
-    say $breakfast.kxxv.sort;                         # (bacon eggs spam spam spam)
+    say $breakfast.kxxv.sort;                         # OUTPUT: «(bacon eggs spam spam spam)␤»
 
     my $n = ("a" => 0, "b" => 1, "b" => 2).BagHash;
-    say $n.kxxv;                                      # (b b b)
+    say $n.kxxv;                                      # OUTPUT: «(b b b)␤»
 
 =head2 method elems
 
@@ -350,10 +349,10 @@ Returns the number of elements in the C<Baggy> object without
 taking the individual elements weight into account.
 
     my $breakfast = bag <eggs spam spam spam>;
-    say $breakfast.elems;                             # 2
+    say $breakfast.elems;                             # OUTPUT: «2␤»
 
     my $n = ("b" => 9.4, "b" => 2).MixHash;
-    say $n.elems;                                     # 1
+    say $n.elems;                                     # OUTPUT: «1␤»
 
 =head2 method total
 
@@ -365,10 +364,10 @@ Returns the sum of weights for all elements in the C<Baggy>
 object.
 
     my $breakfast = bag <eggs spam spam bacon>;
-    say $breakfast.total;                             # 4
+    say $breakfast.total;                             # OUTPUT: «4␤»
 
     my $n = ("a" => 5, "b" => 1, "b" => 2).BagHash;
-    say $n.total;                                     # 8
+    say $n.total;                                     # OUTPUT: «8␤»
 
 =head2 method default
 
@@ -379,7 +378,7 @@ Defined as:
 Returns zero.
 
     my $breakfast = bag <eggs bacon>;
-    say $breakfast.default;                           # 0
+    say $breakfast.default;                           # OUTPUT: «0␤»
 
 =head2 method hash
 
@@ -392,8 +391,8 @@ are the keys and their respective weights the values;
 
     my $breakfast = bag <eggs bacon bacon>;
     my $h = $breakfast.hash;
-    say $h.WHAT;                                      # (Hash)
-    say $h;                                           # {bacon => 2, eggs => 1}
+    say $h.WHAT;                                      # OUTPUT: «(Hash)␤»
+    say $h;                                           # OUTPUT: «{bacon => 2, eggs => 1}␤»
 
 =head2 method Bool
 
@@ -404,9 +403,9 @@ Defined as:
 Returns C<True> if the invocant contains at least one element.
 
     my $breakfast = ('eggs' => 1).BagHash;
-    say $breakfast.Bool;                              # True   (since we have one element)
+    say $breakfast.Bool;                              # OUTPUT: «True   (since we have one element)␤»
     $breakfast<eggs> = 0;                             # weight == 0 will lead to element removal
-    say $breakfast.Bool;                              # False
+    say $breakfast.Bool;                              # OUTPUT: «False␤»
 
 =head2 method Set
 
@@ -417,7 +416,7 @@ Defined as:
 Returns a L<Set|/type/Set> whose elements are the L<keys|#method keys> of the invocant.
 
     my $breakfast = (eggs => 2, bacon => 3).BagHash;
-    say $breakfast.Set;                               # set(bacon, eggs)
+    say $breakfast.Set;                               # OUTPUT: «set(bacon, eggs)␤»
 
 =head2 method SetHash
 
@@ -429,8 +428,8 @@ Returns a L<SetHash|/type/SetHash> whose elements are the L<keys|#method keys> o
 
     my $breakfast = (eggs => 2, bacon => 3).BagHash;
     my $sh = $breakfast.SetHash;
-    say $sh.WHAT;                                     # (SetHash)
-    say $sh.elems;                                    # 2
+    say $sh.WHAT;                                     # OUTPUT: «(SetHash)␤»
+    say $sh.elems;                                    # OUTPUT: «2␤»
 
 =head2 method ACCEPTS
 
@@ -448,14 +447,14 @@ If the right hand side is a C<Baggy> object, C<True> is returned only if
 C<$other> has the same elements, with the same weights, as the invocant.
 
     my $breakfast = bag <eggs bacon>;
-    say $breakfast ~~ Baggy;                            # True
-    say $breakfast.does(Baggy);                         # True
+    say $breakfast ~~ Baggy;                            # OUTPUT: «True␤»
+    say $breakfast.does(Baggy);                         # OUTPUT: «True␤»
 
     my $second-breakfast = (eggs => 1, bacon => 1).Mix;
-    say $breakfast ~~ $second-breakfast;                # True
+    say $breakfast ~~ $second-breakfast;                # OUTPUT: «True␤»
 
     my $third-breakfast = (eggs => 1, bacon => 2).Bag;
-    say $second-breakfast ~~ $third-breakfast;          # False
+    say $second-breakfast ~~ $third-breakfast;          # OUTPUT: «False␤»
 
 =head1 See Also
 

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -53,9 +53,9 @@ Defined as:
 
 Returns the number of bytes used by the elements in the buffer.
 
-    say Blob.new([1, 2, 3]).bytes;      # 3
-    say blob16.new([1, 2, 3]).bytes;    # 6
-    say blob64.new([1, 2, 3]).bytes;    # 24
+    say Blob.new([1, 2, 3]).bytes;      # OUTPUT: «3␤»
+    say blob16.new([1, 2, 3]).bytes;    # OUTPUT: «6␤»
+    say blob64.new([1, 2, 3]).bytes;    # OUTPUT: «24␤»
 
 =head2 method decode
 
@@ -82,14 +82,14 @@ Extracts a part of the invocant buffer, starting from the index with
 elements C<$from>, and taking C<$len> elements (or less if the buffer is
 shorter), and creates a new buffer as the result.
 
-    say Blob.new(1..10).subbuf(2, 4);    # Blob:0x<03 04 05 06>
-    say Blob.new(1..10).subbuf(*-2);     # Blob:0x<09 0a>
-    say Blob.new(1..10).subbuf(*-5,2);   # Blob:0x<06 07>
+    say Blob.new(1..10).subbuf(2, 4);    # OUTPUT: «Blob:0x<03 04 05 06>␤»
+    say Blob.new(1..10).subbuf(*-2);     # OUTPUT: «Blob:0x<09 0a>␤»
+    say Blob.new(1..10).subbuf(*-5,2);   # OUTPUT: «Blob:0x<06 07>␤»
 
 For convenience, also allows a C<Range> to be specified to indicate which
 part of the invocant buffer you would like:
 
-    say Blob.new(1..10).subbuf(2..5);    # Blob:0x<03 04 05 06>
+    say Blob.new(1..10).subbuf(2..5);    # OUTPUT: «Blob:0x<03 04 05 06>␤»
 
 =head2 method unpack
 

--- a/doc/Type/Block.pod6
+++ b/doc/Type/Block.pod6
@@ -13,13 +13,13 @@ Without an explicit signature or placeholder arguments, a block has C<$_>
 as a positional argument
 
     my $block = { uc $_; };
-    say $block.WHAT;            # (Block)
-    say $block('hello');        # HELLO
+    say $block.WHAT;            # OUTPUT: «(Block)␤»
+    say $block('hello');        # OUTPUT: «HELLO␤»
 
 A block can have a signature between C<< -> >> or C<< <-> >> and the block:
 
     my $add = -> $a, $b = 2 { $a + $b };
-    say $add(40);               # 42
+    say $add(40);               # OUTPUT: «42␤»
 
 If the signature is introduced with C<< <-> >>, then the parameters are marked
 as C<rw> by default:
@@ -28,7 +28,7 @@ X«|<->»
     my $swap = <-> $a, $b { ($a, $b) = ($b, $a) };
     my ($a, $b) = (2, 4);
     $swap($a, $b);
-    say $a;                     # 4
+    say $a;                     # OUTPUT: «4␤»
 
 Blocks that aren't of type C<Routine> (which is a subclass of C<Block>) are
 transparent to L<return|/syntax/return>.
@@ -40,7 +40,7 @@ transparent to L<return|/syntax/return>.
 
 The last statement is the implicit return value of the block.
 
-    say {1}.(); # 1
+    say {1}.(); # OUTPUT: «1␤»
 
 Bare blocks in sink context are automatically executed:
 

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -16,8 +16,8 @@ An enum for boolean true/false decisions.
 
 Returns C<True>.
 
-    say True.succ;                                    # True
-    say False.succ;                                   # True
+    say True.succ;                                    # OUTPUT: «True␤»
+    say False.succ;                                   # OUTPUT: «True␤»
 
 C<succ> is short for "successor"; it returns the next enum value. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<True> is its successor. And since C<True> is the "highest" Bool enum value, its own successor is also C<True>.
 
@@ -27,8 +27,8 @@ C<succ> is short for "successor"; it returns the next enum value. Bool is a spec
 
 Returns C<False>.
 
-    say True.pred;                                    # False
-    say False.pred;                                   # False
+    say True.pred;                                    # OUTPUT: «False␤»
+    say False.pred;                                   # OUTPUT: «False␤»
 
 C<pred> is short for "predecessor"; it returns the previous enum value. Bool is a special enum with only two values, C<False> and C<True>. When sorted, C<False> comes first, so C<False> is the predecessor to C<True>. And since C<False> is the "lowest" Bool enum value, its own predecessor is also C<False>.
 
@@ -39,8 +39,8 @@ C<pred> is short for "predecessor"; it returns the previous enum value. Bool is 
 Returns a L<Hash|/type/Hash> of enum-pairs. Works on both the C<Bool> type
 and any key.
 
-    say Bool.enums;                                   # {False => 0, True => 1}
-    say False.enums;                                  # {False => 0, True => 1}
+    say Bool.enums;                                   # OUTPUT: «{False => 0, True => 1}␤»
+    say False.enums;                                  # OUTPUT: «{False => 0, True => 1}␤»
 
 =head2 routine pick
 
@@ -52,9 +52,9 @@ C<$count> elements chosen at random (without repetition) from the C<enum>. If
 C<*> is passed as C<$count>, or C<$count> is greater than or equal to two, then
 both elements are returned in random order.
 
-    say Bool.pick;                                    # True
-    say Bool.pick(1);                                 # (False)
-    say Bool.pick(*);                                 # (False True)
+    say Bool.pick;                                    # OUTPUT: «True␤»
+    say Bool.pick(1);                                 # OUTPUT: «(False)␤»
+    say Bool.pick(*);                                 # OUTPUT: «(False True)␤»
 
 =head2 routine roll
 
@@ -67,9 +67,9 @@ C<enum> is made independently, like a separate coin toss where each side of the
 coin represents one of the two values of the C<enum>. If C<*> is passed as
 C<$count> an infinite L<Seq|/type/Seq> of C<Bool>s is returned.
 
-    say Bool.roll;                                    # True
-    say Bool.roll(3);                                 # (True False False)
-    say Bool.roll(*);                                 # (...)
+    say Bool.roll;                                    # OUTPUT: «True␤»
+    say Bool.roll(3);                                 # OUTPUT: «(True False False)␤»
+    say Bool.roll(*);                                 # OUTPUT: «(...)␤»
 
 =head2 routine Numeric
 
@@ -77,8 +77,8 @@ C<$count> an infinite L<Seq|/type/Seq> of C<Bool>s is returned.
 
 Returns the value part of the C<enum> pair.
 
-    say False.Numeric;                                # 0
-    say True.Numeric;                                 # 1
+    say False.Numeric;                                # OUTPUT: «0␤»
+    say True.Numeric;                                 # OUTPUT: «1␤»
 
 =head1 Operators
 

--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -38,8 +38,7 @@ container, is has to implement Callable.
         submethod CALL-ME(|c){ 'called' }
     }
     my &a = A;
-    say a();
-    # OUTPUT«called␤»
+    say a(); # OUTPUT: «called␤»
 
 =head2 method assuming
 
@@ -54,8 +53,7 @@ corresponding parameters.
     # takes only one parameter and as such wont forward $n
     sub bench(&c){ c, now - ENTER now };
 
-    say &slow.assuming(10000000).&bench;
-    # OUTPUT«(10000000 7.5508834)␤»
+    say &slow.assuming(10000000).&bench; # OUTPUT: «(10000000 7.5508834)␤»
 
 =comment according to design docs it's Callable but in rakudo it's assuming is in Block
 
@@ -72,8 +70,8 @@ left function.
     sub f($p){ say 'f'; $p / 2 }
     sub g($p){ say 'g'; $p * 2 }
     my &f-g = &f ∘ &g;
-    say f-g(2); # OUTPUT«g␤f␤2␤»
+    say f-g(2);     # OUTPUT: «g␤f␤2␤»
     # equivalent to:
-    say 2.&g.&f
+    say 2.&g.&f;    # OUTPUT: «g␤f␤2␤»
 
 =end pod

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -20,11 +20,12 @@ named argument: 1) use an unquoted key naming a parameter, followed by
 C«=>», followed by the argument and 2) use a colon-pair literal named
 after the parameter:
 
-    say unique 1, -2, 2, 3, as => { abs $_ }; # (1 -2 3)
+    say unique 1, -2, 2, 3, as => { abs $_ };   # OUTPUT: «(1 -2 3)␤»
     # ... is the same thing as:
-    say unique 1, -2, 2, 3, :as({ abs $_ });  # (1 -2 3)
+    say unique 1, -2, 2, 3, :as({ abs $_ });    # OUTPUT: «(1 -2 3)␤»
     # Be careful not to quote the name of a named parameter:
-    say unique 1, -2, 2, 3, 'as' => { abs $_ }; # (1 -2 2 3 as => -> ;; $_? is raw { #`(Block|78857320) ... })
+    say unique 1, -2, 2, 3, 'as' => { abs $_ };
+    # OUTPUT: «(1 -2 2 3 as => -> ;; $_? is raw { #`(Block|78857320) ... })␤»
 
 A stand-alone Capture can also be made, stored, and used later.  A literal
 Capture can be created by prefixing a term with a backslash C<\>.
@@ -42,8 +43,8 @@ arguments will be passed as positional arguments.  You may re-use the Capture
 as many times as you want, even with different functions.
 
     my $c = \(4, 2, 3);
-    reverse(|$c).say; # 3 2 4
-    sort(5,|$c).say;  # 2 3 4 5
+    reverse(|$c).say; # OUTPUT: «3 2 4␤»
+    sort(5,|$c).say;  # OUTPUT: «2 3 4 5␤»
 
 Inside a Signature, a Capture may be created by prefixing a sigilless parameter
 with a vertical bar C<|>.  This packs the remainder of the argument list
@@ -59,9 +60,9 @@ just values:
 
     my $b = 1;
     my $c = \(4, 2, $b, 3);
-    sort(|$c).say;        # 1 2 3 4
+    sort(|$c).say;        # OUTPUT: «1 2 3 4␤»
     $b = 6;
-    sort(|$c).say;        # 2 3 4 6
+    sort(|$c).say;        # OUTPUT: «2 3 4 6␤»
 
 =head1 Methods
 
@@ -74,7 +75,7 @@ Defined as:
 Returns the positional part of the Capture.
 
     my Capture $c = \(2, 3, 5, apples => (red => 2));
-    say $c.list;                                      # (2 3 5)
+    say $c.list;                                      # OUTPUT: «(2 3 5)␤»
 
 =head2 method hash
 
@@ -85,7 +86,7 @@ Defined as:
 Returns the named/hash part of the Capture.
 
     my Capture $c = \(2, 3, 5, apples => (red => 2));
-    say $c.hash; # Map.new((:apples(:red(2))))
+    say $c.hash; # OUTPUT: «Map.new((:apples(:red(2))))␤»
 
 =head2 method elems
 
@@ -96,7 +97,7 @@ Defined as:
 Returns the number of positional elements in the Capture.
 
     my Capture $c = \(2, 3, 5, apples => (red => 2));
-    say $c.elems;                                     # 3
+    say $c.elems;                                     # OUTPUT: «3␤»
 
 =head2 method keys
 
@@ -109,7 +110,7 @@ named keys. For positional arguments the keys are the respective arguments
 ordinal position starting from zero.
 
     my $capture = \(2, 3, 5, apples => (red => 2));
-    say $capture.keys;                                # (0 1 2 apples)
+    say $capture.keys;                                # OUTPUT: «(0 1 2 apples)␤»
 
 =head2 method values
 
@@ -121,7 +122,7 @@ Returns a L<Seq|/type/Seq> containing all positional values followed by all
 named argument values.
 
     my $capture = \(2, 3, 5, apples => (red => 2));
-    say $capture.values;                              # (2 3 5 red => 2)
+    say $capture.values;                              # OUTPUT: «(2 3 5 red => 2)␤»
 
 =head2 method kv
 
@@ -134,7 +135,7 @@ L<values|#method_values>. The positional keys and values, if any, comes
 first followed by the named keys and values.
 
     my $capture = \(2, 3, apples => (red => 2));
-    say $capture.kv;                                  # (0 2 1 3 apples red => 2)
+    say $capture.kv;                                  # OUTPUT: «(0 2 1 3 apples red => 2)␤»
 
 =head2 method pairs
 
@@ -148,7 +149,7 @@ their respective ordinal value, starting at zero, as key while the
 named arguments have their names as key.
 
     my Capture $c = \(2, 3, apples => (red => 2));
-    say $c.pairs;                                     # (0 => 2 1 => 3 apples => red => 2)
+    say $c.pairs;                                     # OUTPUT: «(0 => 2 1 => 3 apples => red => 2)␤»
 
 =head2 method antipairs
 
@@ -163,7 +164,7 @@ the value. This behavior is the opposite of the L<pairs|#method_pairs>
 method.
 
     my $capture = \(2, 3, apples => (red => 2));
-    say $capture.antipairs;                           # (2 => 0 3 => 1 (red => 2) => apples)
+    say $capture.antipairs;                           # OUTPUT: «(2 => 0 3 => 1 (red => 2) => apples)␤»
 
 =head2 method Bool
 
@@ -174,8 +175,8 @@ Defined as:
 Returns C<True> if the Capture contains at least one named or one
 positional argument.
 
-    say \(1,2,3, apples => 2).Bool;                   # True
-    say \().Bool;                                     # False
+    say \(1,2,3, apples => 2).Bool;                   # OUTPUT: «True␤»
+    say \().Bool;                                     # OUTPUT: «False␤»
 
 =head2 method Capture
 
@@ -185,7 +186,7 @@ Defined as:
 
 Returns itself, i.e. the invocant.
 
-    say \(1,2,3, apples => 2).Capture; # \(1, 2, 3, :apples(2))
+    say \(1,2,3, apples => 2).Capture; # OUTPUT: «\(1, 2, 3, :apples(2))␤»
 
 =head2 method Numeric
 
@@ -195,6 +196,6 @@ Defined as:
 
 Returns the number of positional elements in the Capture.
 
-    say \(1,2,3, apples => 2).Numeric;                # 3
+    say \(1,2,3, apples => 2).Numeric;                # OUTPUT: «3␤»
 
 =end pod

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -36,9 +36,9 @@ code object's C<Signature> do not contribute, nor do named parameters.
     sub argless() { }
     sub args($a, $b?) { }
     sub slurpy($a, $b, *@c) { }
-    say &argless.arity;             # 0
-    say &args.arity;                # 1
-    say &slurpy.arity;              # 2
+    say &argless.arity;             # OUTPUT: «0␤»
+    say &args.arity;                # OUTPUT: «1␤»
+    say &slurpy.arity;              # OUTPUT: «2␤»
 
 =head2 method count
 
@@ -54,9 +54,9 @@ C<count> will return C<Inf>. Named parameters do not contribute.
     sub argless() { }
     sub args($a, $b?) { }
     sub slurpy($a, $b, *@c) { }
-    say &argless.count;             # 0
-    say &args.count;                # 2
-    say &slurpy.count;              # Inf
+    say &argless.count;             # OUTPUT: «0␤»
+    say &args.count;                # OUTPUT: «2␤»
+    say &slurpy.count;              # OUTPUT: «Inf␤»
 
 =head2 of
 
@@ -67,8 +67,7 @@ Defined as:
 Returns the L<return type constraint|/type/Signature#Constraining_Return_Types>
 of the C<Code>:
 
-    m: say -> () --> Int {}.of
-    # OUTPUT: (Int)
+    say -> () --> Int {}.of; # OUTPUT: «(Int)␤»
 
 =head2 method signature
 
@@ -80,7 +79,7 @@ Returns the L<C<Signature>> object for this code object, which describes
 its parameters.
 
     sub a(Int $one, Str $two) {};
-    say &a.signature; # (Int $one, Str $two)
+    say &a.signature; # OUTPUT: «(Int $one, Str $two)␤»
 
 =head2 method Str
 
@@ -91,9 +90,8 @@ Defined as:
 Will produce a warning. Use C<.perl> or C<.gist> instead.
 
     sub marine() { }
-    say ~&marine;    # marine
-    say &marine.Str; # marine
-
+    say ~&marine;    # OUTPUT: «marine␤»
+    say &marine.Str; # OUTPUT: «marine␤»
 
 =head2 method file
 

--- a/doc/Type/Complex.pod6
+++ b/doc/Type/Complex.pod6
@@ -39,7 +39,7 @@ Defined as:
 
 Returns the real part of the complex number.
 
-    say (3+5i).re;    # 3
+    say (3+5i).re;    # OUTPUT: «3␤»
 
 =head2 method im
 
@@ -49,7 +49,7 @@ Defined as:
 
 Returns the imaginary part of the complex number.
 
-    say (3+5i).im;    # 5
+    say (3+5i).im;    # OUTPUT: «5␤»
 
 =head2 method reals
 
@@ -59,7 +59,7 @@ Defined as:
 
 Returns a two-element list containing the real and imaginary parts for this value.
 
-    say (3+5i).reals;    # (3 5)
+    say (3+5i).reals;    # OUTPUT: «(3 5)␤»
 
 =head2 method isNaN
 
@@ -69,8 +69,8 @@ Defined as:
 
 Returns true if the real or imaginary part is L<C<NaN>|/type/Num#NaN> (not a number).
 
-    say (NaN+5i).isNaN; # True
-    say (7+5i).isNaN;   # False
+    say (NaN+5i).isNaN; # OUTPUT: «True␤»
+    say (7+5i).isNaN;   # OUTPUT: «False␤»
 
 =head2 method polar
 
@@ -81,7 +81,7 @@ Defined as:
 Returns a two-element list of the polar coordinates for this value,
 i.e. magnitude and angle in radians.
 
-    say (10+7i).polar; # (12.2065556157337 0.610725964389209)
+    say (10+7i).polar; # OUTPUT: «(12.2065556157337 0.610725964389209)␤»
 
 =head2 method floor
 
@@ -93,7 +93,7 @@ Returns C<self.re.floor + self.im.floor>. That is, each of the real and
 imaginary parts is rounded to the highest integer not greater than
 the value of that part.
 
-    say (1.2-3.8i).floor;           # 1-4i
+    say (1.2-3.8i).floor;           # OUTPUT: «1-4i␤»
 
 =head2 method ceiling
 
@@ -105,7 +105,7 @@ Returns C<self.re.ceiling + self.im.ceiling>. That is, each of the real and
 imaginary parts is rounded to the lowest integer not less than the value
 of that part.
 
-    say (1.2-3.8i).ceiling;         # 2-3i
+    say (1.2-3.8i).ceiling;         # OUTPUT: «2-3i␤»
 
 =head2 method round
 
@@ -119,8 +119,8 @@ integer and returns a new C<Complex> number. If C<$scale> is given, rounds both
 parts of the invocant to the nearest multiple of C<$scale>. Uses the same
 algorithm as L<Real.round|/type/Real#method_round> on each part of the number.
 
-    say (1.2-3.8i).round;           # 1-4i
-    say (1.256-3.875i).round(0.1);  # 1.3-3.9i
+    say (1.2-3.8i).round;           # OUTPUT: «1-4i␤»
+    say (1.256-3.875i).round(0.1);  # OUTPUT: «1.3-3.9i␤»
 
 =head2 method truncate
 
@@ -131,7 +131,7 @@ Defined as:
 Removes the fractional part of both the real and imaginary parts of the
 number, using L<Real.truncate|/type/Real#method_truncate>, and returns the result as a new C<Complex>.
 
-    say (1.2-3.8i).truncate;        # 1-3i
+    say (1.2-3.8i).truncate;        # OUTPUT: «1-3i␤»
 
 =head2 method abs
 
@@ -144,7 +144,7 @@ Returns the absolute value of the invocant (or the argument in sub form).
 For a given complex number C<$z> the absolute value C<|$z|> is defined as
 C<sqrt($z.re * $z.re + $z.im * $z.im)>.
 
-    say (3+4i).abs;                 # 5
+    say (3+4i).abs;                 # OUTPUT: «5␤»
                                     # sqrt(3*3 + 4*4) == 5
 
 =head2 method conj
@@ -156,7 +156,7 @@ Defined as:
 Returns the complex conjugate of the invocant (that is, the number with the
 sign of the imaginary part negated).
 
-    say (1-4i).conj;                # 1+4i
+    say (1-4i).conj;                # OUTPUT: «1+4i␤»
 
 =head2 method gist
 
@@ -167,7 +167,7 @@ Defined as:
 Returns a string representation of the form "1+2i", without internal spaces.
 (Str coercion also returns this.)
 
-    say (1-4i).gist;                # 1-4i
+    say (1-4i).gist;                # OUTPUT: «1-4i␤»
 
 =head2 method perl
 
@@ -180,6 +180,6 @@ representation of complex literals, of the form "<1+2i>", without internal
 spaces, and including the angles that keep the + from being treated as a
 normal addition operator.
 
-    say (1-3i).perl;                # <1-3i>
+    say (1-3i).perl;                # OUTPUT: «<1-3i>␤»
 
 =end pod

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -11,7 +11,7 @@ allow for the representation of a value as both a string and a numeric type, typ
 they will be created for you when the context is "stringy" but they can be determined
 to be numbers, such as in some L<quoting constructs|/language/quoting>:
 
-    my $f = <42+0i>; say $f.WHAT; # (ComplexStr)
+    my $f = <42+0i>; say $f.WHAT; # OUTPUT: «(ComplexStr)␤»
 
 As a subclass of both L«C<Complex>|/type/Complex» and L«C<Str>|/type/Str»,
 a C<ComplexStr> will be accepted where either is expected. However,
@@ -33,8 +33,8 @@ The constructor requires both the C<Complex> and the C<Str> value, when construc
 directly the values can be whatever is required:
 
     my $f = ComplexStr.new(42+0i, "forty two (but complicated)");
-    say +$f; # -> 42+0i
-    say ~$f; # -> "forty two (but complicated)"
+    say +$f; # OUTPUT: «42+0i␤»
+    say ~$f; # OUTPUT: «"forty two (but complicated)"␤»
 
 =head2 method Numeric
 
@@ -66,8 +66,8 @@ coerce to the C<Complex> or C<Str> values first:
 
     my $f = ComplexStr.new(42+0i, "smaller");
     my $g = ComplexStr.new(43+0i, "larger");
-    say $f cmp $g;          # Less
-    say $f.Str cmp $g.Str;  # More
+    say $f cmp $g;          # OUTPUT: «Less␤»
+    say $f.Str cmp $g.Str;  # OUTPUT: «More␤»
 
 =end pod
 

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -124,8 +124,8 @@ Coerces the invocant (or in the sub form, the argument) to
 L<Numeric|/type/Numeric> and returns the absolute value (that is, a
 non-negative number).
 
-    say (-2).abs;       # 2
-    say abs "6+8i";     # 10
+    say (-2).abs;       # OUTPUT: «2␤»
+    say abs "6+8i";     # OUTPUT: «10␤»
 
 =head2 method conj
 
@@ -137,7 +137,7 @@ Coerces the invocant to L<Numeric|/type/Numeric> and returns the
 L<complex|/type/Complex> conjugate (that is, the number with the sign of the
 imaginary part negated).
 
-    say (1+2i).conj;        # 1-2i
+    say (1+2i).conj;        # OUTPUT: «1-2i␤»
 
 =head2 routine sqrt
 
@@ -151,8 +151,8 @@ argument) and returns the square root,
 that is, a non-negative number that, when multiplied with itself, produces the
 original number.
 
-    say 4.sqrt;             # 2
-    say sqrt(2);            # 1.4142135623731
+    say 4.sqrt;             # OUTPUT: «2␤»
+    say sqrt(2);            # OUTPUT: «1.4142135623731␤»
 
 =head2 method sign
 
@@ -163,9 +163,9 @@ Defined as:
 Coerces the invocant to L<Numeric|/type/Real> and returns its sign, that
 is, 0 if the number is 0, 1 for positive and -1 for negative values.
 
-    say 6.sign;             # 1
-    say (-6).sign;          # -1
-    say "0".sign;           # 0
+    say 6.sign;             # OUTPUT: «1␤»
+    say (-6).sign;          # OUTPUT: «-1␤»
+    say "0".sign;           # OUTPUT: «0␤»
 
 =head2 method rand
 
@@ -176,7 +176,7 @@ Defined as:
 Coerces the invocant to L<Num|/type/Num> and returns a pseudo-random value
 between zero and the number.
 
-    say 1e5.rand;           # 33128.495184283
+    say 1e5.rand;           # OUTPUT: «33128.495184283␤»
 
 =head2 routine sin
 
@@ -188,9 +188,9 @@ Defined as:
 Coerces the invocant (or in the sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<sine|https://en.wikipedia.org/wiki/Sine>.
 
-    say sin(0);             # 0
-    say sin(pi/4);          # 0.707106781186547
-    say sin(pi/2);          # 1
+    say sin(0);             # OUTPUT: «0␤»
+    say sin(pi/4);          # OUTPUT: «0.707106781186547␤»
+    say sin(pi/2);          # OUTPUT: «1␤»
 
 Note that Perl 6 is no computer algebra system, so C<sin(pi)> typically does
 not produce an exact 0, but rather a very small L<floating-point
@@ -207,8 +207,8 @@ Coerces the invocant (or in the sub form, the argument) to L<Numeric|/type/Numer
 L<arc-sine|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say 0.1.asin;               # 0.10016742116156
-    say asin(0.1);              # 0.10016742116156
+    say 0.1.asin;               # OUTPUT: «0.10016742116156␤»
+    say asin(0.1);              # OUTPUT: «0.10016742116156␤»
 
 =head2 routine cos
 
@@ -220,9 +220,9 @@ Defined as:
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<cosine|https://en.wikipedia.org/wiki/Cosine>.
 
-    say 0.cos;                  # 1
-    say pi.cos;                 # -1
-    say cos(pi/2);              # 6.12323399573677e-17
+    say 0.cos;                  # OUTPUT: «1␤»
+    say pi.cos;                 # OUTPUT: «-1␤»
+    say cos(pi/2);              # OUTPUT: «6.12323399573677e-17␤»
 
 =head2 routine acos
 
@@ -235,8 +235,8 @@ Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>,
 L<arc-cosine|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say 1.acos;                 # 0
-    say acos(-1);               # 3.14159265358979
+    say 1.acos;                 # OUTPUT: «0␤»
+    say acos(-1);               # OUTPUT: «3.14159265358979␤»
 
 =head2 routine tan
 
@@ -248,8 +248,8 @@ Defined as:
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
 returns its L<tangent|https://en.wikipedia.org/wiki/Tangent>.
 
-    say tan(3);                 # -0.142546543074278
-    say 3.tan;                  # -0.142546543074278
+    say tan(3);                 # OUTPUT: «-0.142546543074278␤»
+    say 3.tan;                  # OUTPUT: «-0.142546543074278␤»
 
 =head2 routine atan
 
@@ -262,8 +262,8 @@ Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>,
 L<arc-tangent|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say atan(3);                # 1.24904577239825
-    say 3.atan;                 # 1.24904577239825
+    say atan(3);                # OUTPUT: «1.24904577239825␤»
+    say 3.atan;                 # OUTPUT: «1.24904577239825␤»
 
 =head2 routine atan2
 
@@ -277,8 +277,8 @@ and returns their two-argument
 L<arc-tangent|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say atan2(3);               # 1.24904577239825
-    say 3.atan2;                # 1.24904577239825
+    say atan2(3);               # OUTPUT: «1.24904577239825␤»
+    say 3.atan2;                # OUTPUT: «1.24904577239825␤»
 
 =head2 method sec
 
@@ -291,8 +291,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 returns its L<secant|https://en.wikipedia.org/wiki/Trigonometric_functions#Reciprocal_functions>,
 that is, the reciprocal of its cosine.
 
-    say 45.sec;                 # 1.90359440740442
-    say sec(45);                # 1.90359440740442
+    say 45.sec;                 # OUTPUT: «1.90359440740442␤»
+    say sec(45);                # OUTPUT: «1.90359440740442␤»
 
 =head2 routine asec
 
@@ -305,8 +305,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 L<arc-secant|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say 1.asec;                 # 0
-    say sqrt(2).asec;           # 0.785398163397448
+    say 1.asec;                 # OUTPUT: «0␤»
+    say sqrt(2).asec;           # OUTPUT: «0.785398163397448␤»
 
 =head2 routine cosec
 
@@ -319,8 +319,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 returns its L<cosecant|https://en.wikipedia.org/wiki/Trigonometric_functions#Reciprocal_functions>,
 that is, the reciprocal of its sine.
 
-    say 0.45.cosec;             # 2.29903273150897
-    say cosec(0.45);            # 2.29903273150897
+    say 0.45.cosec;             # OUTPUT: «2.29903273150897␤»
+    say cosec(0.45);            # OUTPUT: «2.29903273150897␤»
 
 =head2 routine acosec
 
@@ -333,8 +333,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 L<arc-cosecant|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say 45.acosec;              # 0.0222240516182672
-    say acosec(45)              # 0.0222240516182672
+    say 45.acosec;              # OUTPUT: «0.0222240516182672␤»
+    say acosec(45)              # OUTPUT: «0.0222240516182672␤»
 
 =head2 routine cotan
 
@@ -347,8 +347,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 returns its L<cotangent|https://en.wikipedia.org/wiki/Trigonometric_functions#Reciprocal_functions>,
 that is, the reciprocal of its tangent.
 
-    say 45.cotan;               # 0.617369623783555
-    say cotan(45);              # 0.617369623783555
+    say 45.cotan;               # OUTPUT: «0.617369623783555␤»
+    say cotan(45);              # OUTPUT: «0.617369623783555␤»
 
 =head2 routine acotan
 
@@ -361,8 +361,8 @@ Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>,
 L<arc-cotangent|https://en.wikipedia.org/wiki/Inverse_trigonometric_functions> in
 radians.
 
-    say 45.acotan;              # 0.0222185653267191
-    say acotan(45)              # 0.0222185653267191
+    say 45.acotan;              # OUTPUT: «0.0222185653267191␤»
+    say acotan(45)              # OUTPUT: «0.0222185653267191␤»
 
 =head2 routine sinh
 
@@ -374,8 +374,8 @@ Defined as:
 Coerces the invocant (or in method form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Sine hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say 1.sinh;                 # 1.1752011936438
-    say sinh(1);                # 1.1752011936438
+    say 1.sinh;                 # OUTPUT: «1.1752011936438␤»
+    say sinh(1);                # OUTPUT: «1.1752011936438␤»
 
 =head2 routine asinh
 
@@ -387,8 +387,8 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse Sine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
 
-    say 1.asinh;                # 0.881373587019543
-    say asinh(1);               # 0.881373587019543
+    say 1.asinh;                # OUTPUT: «0.881373587019543␤»
+    say asinh(1);               # OUTPUT: «0.881373587019543␤»
 
 =head2 routine cosh
 
@@ -400,7 +400,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Cosine hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say cosh(0.5);              # 1.12762596520638
+    say cosh(0.5);              # OUTPUT: «1.12762596520638␤»
 
 =head2 routine acosh
 
@@ -412,7 +412,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse Cosine hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
 
-    say acosh(45);              # 4.4996861906715
+    say acosh(45);              # OUTPUT: «4.4996861906715␤»
 
 =head2 routine tanh
 
@@ -424,8 +424,8 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, interprets it as
 radians and returns its L<Tangent hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say tanh(0.5);              # 0.46211715726001
-    say tanh(atanh(0.5));       # 0.5
+    say tanh(0.5);              # OUTPUT: «0.46211715726001␤»
+    say tanh(atanh(0.5));       # OUTPUT: «0.5␤»
 
 =head2 routine atanh
 
@@ -437,7 +437,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse tangent hyperbolicus|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
 
-    say atanh(0.5);             # 0.549306144334055
+    say atanh(0.5);             # OUTPUT: «0.549306144334055␤»
 
 =head2 routine sech
 
@@ -449,7 +449,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Secant hyperbolicus|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say 0.sech;                 # 1
+    say 0.sech;                 # OUTPUT: «1␤»
 
 =head2 routine asech
 
@@ -461,7 +461,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic secant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say 0.8.asech;              # 0.693147180559945
+    say 0.8.asech;              # OUTPUT: «0.693147180559945␤»
 
 =head2 routine cosech
 
@@ -473,7 +473,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Hyperbolic cosecant|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say cosech(pi/2);           # 0.434537208094696
+    say cosech(pi/2);           # OUTPUT: «0.434537208094696␤»
 
 =head2 routine acosech
 
@@ -485,7 +485,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic cosecant|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
 
-    say acosech(4.5);           # 0.220432720979802
+    say acosech(4.5);           # OUTPUT: «0.220432720979802␤»
 
 =head2 routine cotanh
 
@@ -497,7 +497,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Hyperbolic cotangent|https://en.wikipedia.org/wiki/Hyperbolic_function>.
 
-    say cotanh(pi);             # 1.00374187319732
+    say cotanh(pi);             # OUTPUT: «1.00374187319732␤»
 
 =head2 routine acotanh
 
@@ -509,7 +509,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns its
 L<Inverse hyperbolic cotangent|https://en.wikipedia.org/wiki/Inverse_hyperbolic_function>.
 
-    say acotanh(2.5);           # 0.423648930193602
+    say acotanh(2.5);           # OUTPUT: «0.423648930193602␤»
 
 =head2 routine cis
 
@@ -521,7 +521,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and returns
 L<cos(argument) + i*sin(argument)|https://en.wikipedia.org/wiki/Cis_%28mathematics%29>.
 
-    say cis(pi/4);              # 0.707106781186548+0.707106781186547i
+    say cis(pi/4);              # OUTPUT: «0.707106781186548+0.707106781186547i␤»
 
 =head2 routine log
 
@@ -537,7 +537,7 @@ base C<e> (Euler's Number) if no base was supplied
 (L<Natural logarithm|https://en.wikipedia.org/wiki/Natural_logarithm>).
 Returns C<NaN> if C<$base> is negative. Throws an exception if C<$base> is C<1>.
 
-    say (e*e).log;              # 2
+    say (e*e).log;              # OUTPUT: «2␤»
 
 =head2 routine log10
 
@@ -552,7 +552,7 @@ L<Logarithm|https://en.wikipedia.org/wiki/Logarithm> to base 10, that is, a
 number that approximately produces the original number when raised to the power
 of 10. Returns C<NaN> for negative arguments and C<-Inf> for C<0>.
 
-    say log10(1001);            # 3.00043407747932
+    say log10(1001);            # OUTPUT: «3.00043407747932␤»
 
 =head2 method exp
 
@@ -565,9 +565,9 @@ Coerces the arguments (including the invocant in the method from) to L<Numeric|/
 raised to the power of the first number. If no C<$base> is supplied, C<e> (Euler's
 Number) is used.
 
-    say 0.exp;      # 1
-    say 1.exp;      # 2.71828182845905
-    say 10.exp;     # 22026.4657948067
+    say 0.exp;      # OUTPUT: «1␤»
+    say 1.exp;      # OUTPUT: «2.71828182845905␤»
+    say 10.exp;     # OUTPUT: «22026.4657948067␤»
 
 =head2 method unpolar
 
@@ -579,7 +579,7 @@ Coerces the arguments (including the invocant in the method form) to L<Numeric|/
 a complex number from the given polar coordinates. The invocant (or the first argument in sub form) is the magnitude while
 the argument (i.e. the second argument in sub form) is the angle. The angle is assumed to be in radians.
 
-    say sqrt(2).unpolar(pi/4);      # 1+1i
+    say sqrt(2).unpolar(pi/4);      # OUTPUT: «1+1i␤»
 
 =head2 routine round
 
@@ -591,16 +591,16 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and rounds it to the unit of
 C<$unit>. If C<$unit> is 1, rounds to the nearest integer.
 
-    say 1.7.round;          # 2
-    say 1.07.round(0.1);    # 1.1
-    say 21.round(10);       # 20
+    say 1.7.round;          # OUTPUT: «2␤»
+    say 1.07.round(0.1);    # OUTPUT: «1.1␤»
+    say 21.round(10);       # OUTPUT: «20␤»
 
 Always rounds B<up> if the number is at mid-point:
 
-    say (−.5 ).round;       # 0
-    say ( .5 ).round;       # 1
-    say (−.55).round(.1);   # -0.5
-    say ( .55).round(.1);   # 0.6
+    say (−.5 ).round;       # OUTPUT: «0␤»
+    say ( .5 ).round;       # OUTPUT: «1␤»
+    say (−.55).round(.1);   # OUTPUT: «-0.5␤»
+    say ( .55).round(.1);   # OUTPUT: «0.6␤»
 
 =head2 routine floor
 
@@ -612,9 +612,9 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and rounds it downwards to
 the nearest integer.
 
-    say "1.99".floor;       # 1
-    say "-1.9".floor;       # -2
-    say 0.floor;            # 0
+    say "1.99".floor;       # OUTPUT: «1␤»
+    say "-1.9".floor;       # OUTPUT: «-2␤»
+    say 0.floor;            # OUTPUT: «0␤»
 
 =head2 routine ceiling
 
@@ -626,9 +626,9 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Numeric|/type/Numeric>, and rounds it upwards to
 the nearest integer.
 
-    say "1".ceiling;        # 1
-    say "-0.9".ceiling;     # 0
-    say "42.1".ceiling;     # 43
+    say "1".ceiling;        # OUTPUT: «1␤»
+    say "-0.9".ceiling;     # OUTPUT: «0␤»
+    say "42.1".ceiling;     # OUTPUT: «43␤»
 
 =head2 routine truncate
 
@@ -640,8 +640,8 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to
 L<Numeric|/type/Numeric>, and rounds it towards zero.
 
-    say 1.2.truncate;       # 1
-    say truncate -1.2;      # -1
+    say 1.2.truncate;       # OUTPUT: «1␤»
+    say truncate -1.2;      # OUTPUT: «-1␤»
 
 =head2 routine ord
 
@@ -655,7 +655,7 @@ L<Str|/type/Str>, and returns the L<Unicode code
 point|https://en.wikipedia.org/wiki/Code_point> number of the first
 code point.
 
-    say 'a'.ord;            # 97
+    say 'a'.ord;            # OUTPUT: «97␤»
 
 The inverse operation is L<chr|#method chr>.
 
@@ -672,7 +672,7 @@ Coerces the invocant (or in sub form, its argument) to L<Int|/type/Int>, interpr
 L<Unicode code points|https://en.wikipedia.org/wiki/Code_point>,
 and returns a L<string|/type/Str> made of that code point.
 
-    say '65'.chr;       # A
+    say '65'.chr;       # OUTPUT: «A␤»
 
 The inverse operation is L<ord|#method ord>.
 
@@ -689,7 +689,7 @@ Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and ret
 number of characters in the string. Please note that on the JVM, you currently get
 codepoints instead of graphemes.
 
-    say 'møp'.chars;    # 3
+    say 'møp'.chars;    # OUTPUT: «3␤»
 
 =head2 routine codes
 
@@ -701,7 +701,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns the number of
 L<Unicode code points|https://en.wikipedia.org/wiki/Code_point>.
 
-    say 'møp'.codes;    # 3
+    say 'møp'.codes;    # OUTPUT: «3␤»
 
 =head2 routine flip
 
@@ -712,7 +712,7 @@ Defined as:
 
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns a reversed version.
 
-    say 421.flip;       # 124
+    say 421.flip;       # OUTPUT: «124␤»
 
 =head2 routine trim
 
@@ -725,7 +725,7 @@ Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and ret
 leading and trailing whitespace stripped.
 
     my $stripped = '  abc '.trim;
-    say "<$stripped>";          # <abc>
+    say "<$stripped>";          # OUTPUT: «<abc>␤»
 
 =head2 routine trim-leading
 
@@ -738,7 +738,7 @@ Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and ret
 leading whitespace stripped.
 
     my $stripped = '  abc '.trim-leading;
-    say "<$stripped>";          # <abc >
+    say "<$stripped>";          # OUTPUT: «<abc >␤»
 
 =head2 routine trim-trailing
 
@@ -751,7 +751,7 @@ Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and
 returns the string with trailing whitespace stripped.
 
     my $stripped = '  abc '.trim-trailing;
-    say "<$stripped>";          # <  abc>
+    say "<$stripped>";          # OUTPUT: «<  abc>␤»
 
 =head2 routine lc
 
@@ -763,7 +763,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it case-folded to lower
 case.
 
-    say "ABC".lc;       # abc
+    say "ABC".lc;       # OUTPUT: «abc␤»
 
 =head2 routine uc
 
@@ -775,7 +775,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it case-folded to upper
 case (capital letters).
 
-    say "Abc".uc;       # ABC
+    say "Abc".uc;       # OUTPUT: «ABC␤»
 
 =head2 routine fc
 
@@ -789,7 +789,7 @@ returns the result a Unicode "case fold" operation suitable for doing caseless
 string comparisons. (In general, the returned string is unlikely to be useful
 for any purpose other than comparison.)
 
-    say "groß".fc;       # gross
+    say "groß".fc;       # OUTPUT: «gross␤»
 
 =head2 routine tc
 
@@ -801,7 +801,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it with the first letter
 case-folded to title case (or where not available, upper case).
 
-    say "abC".tc;       # AbC
+    say "abC".tc;       # OUTPUT: «AbC␤»
 
 =head2 routine tclc
 
@@ -814,7 +814,7 @@ Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and ret
 case-folded to title case (or where not available, upper case), and the rest
 of the string case-folded to lower case..
 
-    say 'abC'.tclc;     # Abc
+    say 'abC'.tclc;     # OUTPUT: «Abc␤»
 
 =head2 routine wordcase
 
@@ -828,7 +828,7 @@ smart-matches against C<$where> through the C<&filter>. With the default
 filter (first character to upper case, rest to lower) and matcher (which
 accepts everything), this title-cases each word:
 
-    say "perl 6 programming".wordcase;      # Perl 6 Programming
+    say "perl 6 programming".wordcase;      # OUTPUT: «Perl 6 Programming␤»
 
 With a matcher:
 
@@ -855,8 +855,8 @@ character in the result.)
 If C<$string> is longer than C<$pattern>, the case information from the last character of
 C<$pattern> is applied to the remaining characters of C<$string>.
 
-    say "perL 6".samecase("A__a__"); # Perl 6
-    say "pERL 6".samecase("Ab");     # Perl 6
+    say "perL 6".samecase("A__a__"); # OUTPUT: «Perl 6␤»
+    say "pERL 6".samecase("Ab");     # OUTPUT: «Perl 6␤»
 
 =head2 method uniprop
 
@@ -873,10 +873,10 @@ character. If no property is specified returns the
 L<General Category|https://en.wikipedia.org/wiki/Unicode_character_property#General_Category>.
 Returns a Bool for Boolean properties.
 
-    say 'a'.uniprop; # Ll
-    say '1'.uniprop; # Nd
-    say 'a'.uniprop('Alphabetic'); # True
-    say '1'.uniprop('Alphabetic'); # False
+    say 'a'.uniprop;               # OUTPUT: «Ll␤»
+    say '1'.uniprop;               # OUTPUT: «Nd␤»
+    say 'a'.uniprop('Alphabetic'); # OUTPUT: «True␤»
+    say '1'.uniprop('Alphabetic'); # OUTPUT: «False␤»
 
 =head2 method uniprops
 
@@ -904,13 +904,13 @@ L<uninames|#routine_uninames> for a routine that works with multiple codepoints.
 
     # Camelia in Unicode
     say ‘»ö«’.uniname;
-    # "RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK"
+    # OUTPUT: «"RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK"␤»
     say "Ḍ̇".uniname; # Note, doesn't show "COMBINING DOT ABOVE"
-    # "LATIN CAPITAL LETTER D WITH DOT BELOW"
+    # OUTPUT: «"LATIN CAPITAL LETTER D WITH DOT BELOW"␤»
 
     # Find the char with the longest Unicode name.
     say (0..0x1FFFF).sort(*.uniname.chars)[*-1].chr.uniname;
-    # «ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA INITIAL FORM␤»
+    # OUTPUT: ««ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA INITIAL FORM␤»␤»
 
 =head2 method uninames
 
@@ -922,13 +922,13 @@ Defined as:
 Returns of a Seq of Unicode names for the all the codepoints in the Str provided.
 
     say ‘»ö«’.uninames.perl;
-    # ("RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK", "LATIN SMALL LETTER O WITH DIAERESIS", "LEFT-POINTING DOUBLE ANGLE QUOTATION MARK").Seq
+    # OUTPUT: «("RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK", "LATIN SMALL LETTER O WITH DIAERESIS", "LEFT-POINTING DOUBLE ANGLE QUOTATION MARK").Seq␤»
 
 Note this example, which gets a Seq where each element is a Seq of all the
 codepoints in that character.
 
     say "Ḍ̇'oh".comb>>.uninames.perl;
-    # (("LATIN CAPITAL LETTER D WITH DOT BELOW", "COMBINING DOT ABOVE").Seq, ("APOSTROPHE",).Seq, ("LATIN SMALL LETTER O",).Seq, ("LATIN SMALL LETTER H",).Seq)
+    # OUTPUT: «(("LATIN CAPITAL LETTER D WITH DOT BELOW", "COMBINING DOT ABOVE").Seq, ("APOSTROPHE",).Seq, ("LATIN SMALL LETTER O",).Seq, ("LATIN SMALL LETTER H",).Seq)␤»
 
 =head2 method unimatch
 
@@ -941,9 +941,9 @@ Checks if the given integer codepoint or the first letter of the string given ha
 equal to the value you give. If you supply the Unicode property to be checked it will only return True
 if that property matches the given value.
 
-    say unimatch 'A', 'Latin'; # True
-    say unimatch 'A', 'Latin', 'Script'; # True
-    say unimatch 'A', 'Ll'; # True
+    say unimatch 'A', 'Latin';           # OUTPUT: «True␤»
+    say unimatch 'A', 'Latin', 'Script'; # OUTPUT: «True␤»
+    say unimatch 'A', 'Ll';              # OUTPUT: «True␤»
 
 =head2 routine chop
 
@@ -955,7 +955,7 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it with the last
 character removed.
 
-    say 'perl'.chop;                        # per
+    say 'perl'.chop;                        # OUTPUT: «per␤»
 
 =head2 routine chomp
 
@@ -967,8 +967,8 @@ Defined as:
 Coerces the invocant (or in sub form, its argument) to L<Str|/type/Str>, and returns it with the last
 character removed, if it is a logical newline.
 
-    say 'ab'.chomp.chars;                   # 2
-    say "a\n".chomp.chars;                  # 1
+    say 'ab'.chomp.chars;                   # OUTPUT: «2␤»
+    say "a\n".chomp.chars;                  # OUTPUT: «1␤»
 
 =head2 routine substr
 
@@ -981,20 +981,20 @@ Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and returns the string starting from offset C<$from>. If
 C<$chars> is supplied, at most C<$chars> characters are returned.
 
-    say 'zenith'.substr(2);         # nith
-    say 'zenith'.substr(0, 3);      # zen
+    say 'zenith'.substr(2);         # OUTPUT: «nith␤»
+    say 'zenith'.substr(0, 3);      # OUTPUT: «zen␤»
 
     # works on non-strings too:
-    say 20151224.substr(6);         # 24
+    say 20151224.substr(6);         # OUTPUT: «24␤»
 
     # sub form:
-    say substr "zenith", 0, 3;      # zen
+    say substr "zenith", 0, 3;      # OUTPUT: «zen␤»
 
 If the C<$from> parameter is a L<Callable|/type/Callable>, it is called with
 the number of chars in the string as argument. This allows easy indexing
 relative to the end:
 
-    say 20151224.substr(*-2);       # 24
+    say 20151224.substr(*-2);       # OUTPUT: «24␤»
 
 =head2 routine ords
 
@@ -1006,8 +1006,8 @@ Defined as:
 Coerces the invocant (or in the sub form, the first argument) to
 L<Str|/type/Str>, and returns a list of Unicode codepoints for each character.
 
-    say "Camelia".ords;              # 67 97 109 101 108 105 97
-    say ords 10;                     # 49 48
+    say "Camelia".ords;              # OUTPUT: «67 97 109 101 108 105 97␤»
+    say ords 10;                     # OUTPUT: «49 48␤»
 
 This is the list-returning version of L<ord>. The inverse operation in
 L<chrs>.
@@ -1023,7 +1023,7 @@ Coerces the invocant (or in the sub form, the argument list) to a list of
 integers, and returns the string created by interpreting each integer as a
 Unicode codepoint, and joining the characters.
 
-    say <67 97 109 101 108 105 97>.chrs;   # Camelia
+    say <67 97 109 101 108 105 97>.chrs;   # OUTPUT: «Camelia␤»
 
 This is the list-input version of L<chr>. The inverse operation is L<ords>.
 
@@ -1046,14 +1046,14 @@ If C<$delimiter> is a string, it is searched for literally and not treated
 as a regex. You can also provide multiple delimiters by specifying them as a
 list; mixing Cool and Regex objects is OK.
 
-    say split(';', "a;b;c").perl;          # ("a", "b", "c")
-    say split(';', "a;b;c", 2).perl;       # ("a", "b;c").Seq
+    say split(';', "a;b;c").perl;               # OUTPUT: «("a", "b", "c")␤»
+    say split(';', "a;b;c", 2).perl;            # OUTPUT: «("a", "b;c").Seq␤»
 
-    say split(';', "a;b;c,d").perl;        # ("a", "b", "c,d")
-    say split(/\;/, "a;b;c,d").perl;       # ("a", "b", "c,d")
-    say split(/<[;,]>/, "a;b;c,d").perl;   # ("a", "b", "c", "d")
+    say split(';', "a;b;c,d").perl;             # OUTPUT: «("a", "b", "c,d")␤»
+    say split(/\;/, "a;b;c,d").perl;            # OUTPUT: «("a", "b", "c,d")␤»
+    say split(/<[;,]>/, "a;b;c,d").perl;        # OUTPUT: «("a", "b", "c", "d")␤»
 
-    say split(['a', /b+/, 4], '1a2bb345').perl # ("1", "2", "3", "5")
+    say split(['a', /b+/, 4], '1a2bb345').perl; # OUTPUT: «("1", "2", "3", "5")␤»
 
 By default, split omits the matches, and returns a list of only those parts of
 the string that did not match. Specifying one of the C<:k, :v, :kv, :p> adverbs
@@ -1067,22 +1067,22 @@ as matcher. If multiple delimiters are specified, L<Match|/type/Match> objects
 will be generated for all of them, unless B<all> of the delimiters are
 L<Cool|/type/Cool>.
 
-    say 'abc'.split(/b/, :v);               # (a ｢b｣ c)
-    say 'abc'.split('b', :v);               # (a b c)
+    say 'abc'.split(/b/, :v);               # OUTPUT: «(a ｢b｣ c)␤»
+    say 'abc'.split('b', :v);               # OUTPUT: «(a b c)␤»
 
 C<:k> interleaves the keys, that is, the indexes:
 
-    say 'abc'.split(/b/, :k);               # (a 0 c)
+    say 'abc'.split(/b/, :k);               # OUTPUT: «(a 0 c)␤»
 
 C<:kv> adds both indexes and matches:
 
-    say 'abc'.split(/b/, :kv);               # (a 0 ｢b｣ c)
+    say 'abc'.split(/b/, :kv);               # OUTPUT: «(a 0 ｢b｣ c)␤»
 
 and C<:p> adds them as L<Pairs|/type/Pair>, using the same types for
 values as C<:v> does:
 
-    say 'abc'.split(/b/, :p);               # (a 0 => ｢b｣ c)
-    say 'abc'.split('b', :p);               # (a 0 => b c)
+    say 'abc'.split(/b/, :p);               # OUTPUT: «(a 0 => ｢b｣ c)␤»
+    say 'abc'.split('b', :p);               # OUTPUT: «(a 0 => b c)␤»
 
 You can only use one of the C<:k, :v, :kv, :p> adverbs in a single call
 to C<split>.
@@ -1090,8 +1090,8 @@ to C<split>.
 Note that empty chunks are not removed from the result list.
 For that behavior, use the `:skip-empty` named argument:
 
-    say ("f,,b,c,d".split: /","/             ).perl;  # ("f", "", "b", "c", "d")
-    say ("f,,b,c,d".split: /","/, :skip-empty).perl;  # ("f", "b", "c", "d")
+    say ("f,,b,c,d".split: /","/             ).perl;  # OUTPUT: «("f", "", "b", "c", "d")␤»
+    say ("f,,b,c,d".split: /","/, :skip-empty).perl;  # OUTPUT: «("f", "b", "c", "d")␤»
 
 See also: L<comb>.
 
@@ -1106,8 +1106,8 @@ Coerces the invocant (and in sub form, the argument) to L<Str|/type/Str>,
 decomposes it into lines (with the newline characters stripped), and returns
 the list of lines.
 
-    say lines("a\nb\n").join('|');          # a|b
-    say "some\nmore\nlines".lines.elems;    # 3
+    say lines("a\nb\n").join('|');          # OUTPUT: «a|b␤»
+    say "some\nmore\nlines".lines.elems;    # OUTPUT: «3␤»
 
 
 This method can be used as part of an C<IO::Path> to process a file
@@ -1139,12 +1139,12 @@ Defined as:
 Coerces the invocant to L<Str|/type/Str>, and returns a list of words that make
 up the string (and if C<$limit> is supplied, only the first C<$limit> words).
 
-    say 'The quick brown fox'.words.join('|');      # The|quick|brown|fox
-    say 'The quick brown fox'.words(2).join('|');   # The|quick
+    say 'The quick brown fox'.words.join('|');      # OUTPUT: «The|quick|brown|fox␤»
+    say 'The quick brown fox'.words(2).join('|');   # OUTPUT: «The|quick␤»
 
 Only whitespace counts as word boundaries
 
-    say "isn't, can't".words.join('|');             # isn't,|can't
+    say "isn't, can't".words.join('|');             # OUTPUT: «isn't,|can't␤»
 
 =head2 routine comb
 
@@ -1157,7 +1157,7 @@ Returns all (or if supplied, at most C<$limit>) matches of the invocant
 (method form) or the second argument (sub form) against the
 L<Regex|/type/Regex> as a list of strings.
 
-    say "6 or 12".comb(/\d+/).join(", ");           # 6, 12
+    say "6 or 12".comb(/\d+/).join(", ");           # OUTPUT: «6, 12␤»
 
 =head2 method contains
 
@@ -1166,8 +1166,8 @@ L<Regex|/type/Regex> as a list of strings.
 Returns C<True> if the invocant contains the C<$needle> at any position within
 the string. If $start is provided skip as many characters.
 
-    say "Hello, World".contains('hello');      # False
-    say "Hello, World".contains(',');          # True
+    say "Hello, World".contains('hello');      # OUTPUT: «False␤»
+    say "Hello, World".contains(',');          # OUTPUT: «True␤»
 
 =head2 routine index
 
@@ -1215,8 +1215,8 @@ Uses C<$format> to return a formatted representation of the invocant.
 
 For more information about formats strings, see L<sprintf|/routine/sprintf>.
 
-    say 11.fmt('This Int equals %03d');               # This Int equals 011
-    say '16'.fmt('Hexadecimal %x');                   # Hexadecimal 10
+    say 11.fmt('This Int equals %03d');               # OUTPUT: «This Int equals 011␤»
+    say '16'.fmt('Hexadecimal %x');                   # OUTPUT: «Hexadecimal 10␤»
 
 =head2 routine roots
 
@@ -1280,12 +1280,12 @@ overridden in any of several ways:
     use Test;
 
     # any of the above allows:
-    EVAL "say { 5 + 5 }";   # says 10
+    EVAL "say { 5 + 5 }";   # OUTPUT: «10␤»
 
 Symbols in the current lexical scope are visible to code in an C<EVAL>.
 
     my $answer = 42;
-    EVAL 'say $answer;';    # says 42
+    EVAL 'say $answer;';    # OUTPUT: «42␤»
 
 However, since the set of symbols in a lexical scope is immutable after compile
 time, an EVAL can never introduce symbols into the surrounding scope.
@@ -1298,21 +1298,21 @@ Furthermore, the C<EVAL> is evaluated in the current package:
     module M {
         EVAL 'our $answer = 42'
     }
-    say $M::answer;         # says 42
+    say $M::answer;         # OUTPUT: «42␤»
 
 And also the current language, meaning any added syntax is available:
 
     sub infix:<mean>(*@a) is assoc<list> {
         @a.sum / @a.elems
     }
-    EVAL 'say 2 mean 6 mean 4';     # says 4
+    EVAL 'say 2 mean 6 mean 4';     # OUTPUT: «4␤»
 
 An C<EVAL> statement evaluates to the result of the last statement:
 
     sub infix:<mean>(*@a) is assoc<list> {
         @a.sum / @a.elems
     }
-    say EVAL 'say 1; 2 mean 6 mean 4';         # says 1, then says 4
+    say EVAL 'say 1; 2 mean 6 mean 4';         # OUTPUT: «1␤4␤»
 
 C<EVAL> is also a gateway for executing code in other languages:
 

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -18,15 +18,15 @@ C<Date.today> creates
 an object the current day according to the system clock.
 
     my $d = Date.new(2015, 12, 24); # Christmas Eve!
-    say $d;                         # 2015-12-24
-    say $d.year;                    # 2015
-    say $d.month;                   # 12
-    say $d.day;                     # 24
-    say $d.day-of-week;             # 1  (that's Monday)
-    say $d.later(days => 20);       # 2016-01-13
+    say $d;                         # OUTPUT: «2015-12-24␤»
+    say $d.year;                    # OUTPUT: «2015␤»
+    say $d.month;                   # OUTPUT: «12␤»
+    say $d.day;                     # OUTPUT: «24␤»
+    say $d.day-of-week;             # OUTPUT: «1␤», that is Monday
+    say $d.later(days => 20);       # OUTPUT: «2016-01-13␤»
     my $n = Date.new('2015-12-31'); # New Year's Eve
-    say $n - $d;                    # 7 days between New Years/Christmas Eve
-    say $n + 1;                     # 2016-01-01
+    say $n - $d;                    # OUTPUT: «7␤», 7 days between New Years/Christmas Eve
+    say $n + 1;                     # OUTPUT: «2016-01-01␤»
 
 =head1 Methods
 
@@ -62,7 +62,7 @@ of days from epoch Nov. 17, 1858, i.e. the
 L<Modified Julian Day|https://en.wikipedia.org/wiki/Julian_day>.
 Optionally accepts a formatter as a named parameter.
 
-    say Date.new-from-daycount(49987);          # 1995-09-27
+    say Date.new-from-daycount(49987);          # OUTPUT: «1995-09-27␤»
 
 =head2 method clone
 
@@ -73,7 +73,7 @@ Defined as:
 Creates a new C<Date> object based on the invocant, but with the given
 arguments overriding the values from the invocant.
 
-    say Date.new('2015-11-24').clone(month => 12);    # 2015-12-24
+    say Date.new('2015-11-24').clone(month => 12);    # OUTPUT: «2015-12-24␤»
 
 =head2 method today
 
@@ -103,14 +103,14 @@ the C<later> method.
 Please note that the special ":2nd" named parameter syntax can be a compact
 and self-documenting way of specifying the delta
 
-    say Date.new('2015-12-24').later(:2years);  # 2017-12-24
+    say Date.new('2015-12-24').later(:2years);  # OUTPUT: «2017-12-24␤»
 
 Since addition of several different time units is not commutative, only one
 unit may be passed.
 
     my $d = Date.new('2015-02-27');
-    say $d.later(month => 1).later(:2days);  # 2015-03-29
-    say $d.later(days => 2).later(:1month);  # 2015-04-01
+    say $d.later(month => 1).later(:2days);  # OUTPUT: «2015-03-29␤»
+    say $d.later(days => 2).later(:1month);  # OUTPUT: «2015-04-01␤»
     say $d.later(days => 2).later(:month);   # same, as +True === 1
 
 Negative offsets are allowed, though L<#method earlier> is more idiomatic for
@@ -126,7 +126,7 @@ Returns a C<Date> object based on the current one, but with a date delta
 towards the past applied. See L<#method later> for usage.
 
     my $d = Date.new('2015-02-27');
-    say $d.earlier(month => 5).earlier(:2days);  # 2014-09-25
+    say $d.earlier(month => 5).earlier(:2days);  # OUTPUT: «2014-09-25␤»
 
 =head2 method truncated-to
 
@@ -138,9 +138,9 @@ Returns a C<Date> truncated to the first day of its year, month or week.
 For example
 
     my $c = Date.new('2012-12-24');
-    say $c.truncated-to('year');     # 2012-01-01
-    say $c.truncated-to('month');    # 2012-12-01
-    say $c.truncated-to('week');     # 2012-12-24  (because it's Monday already)
+    say $c.truncated-to('year');     # OUTPUT: «2012-01-01␤»
+    say $c.truncated-to('month');    # OUTPUT: «2012-12-01␤»
+    say $c.truncated-to('week');     # OUTPUT: «2012-12-24␤», because it's Monday already
 
 =head2 method succ
 
@@ -150,7 +150,7 @@ Defined as:
 
 Returns a C<Date> of the following day. "succ" is short for "successor".
 
-    say Date.new("2016-02-28").succ;   # 2016-02-29
+    say Date.new("2016-02-28").succ;   # OUTPUT: «2016-02-29␤»
 
 =head2 method pred
 
@@ -160,7 +160,7 @@ Defined as:
 
 Returns a C<Date> of the previous day. "pred" is short for "predecessor".
 
-    say Date.new("2016-01-01").pred;   # 2015-12-31
+    say Date.new("2016-01-01").pred;   # OUTPUT: «2015-12-31␤»
 
 =head2 method Str
 
@@ -173,10 +173,10 @@ L<the formatter|/type/Dateish#method_formatter>. If no formatter was
 specified, an (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>) date
 will be returned.
 
-    say Date.new('2015-12-24').Str;                     # 2015-12-24
+    say Date.new('2015-12-24').Str;                     # OUTPUT: «2015-12-24␤»
 
     my $fmt = { sprintf "%02d/%02d/%04d", .month, .day, .year };
-    say Date.new('2015-12-24', formatter => $fmt).Str;  # 12/24/2015
+    say Date.new('2015-12-24', formatter => $fmt).Str;  # OUTPUT: «12/24/2015␤»
 
 =head2 method gist
 
@@ -186,7 +186,7 @@ Defined as:
 
 Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>)
 
-    say Date.new('2015-12-24').gist;                    # 2015-12-24
+    say Date.new('2015-12-24').gist;                    # OUTPUT: «2015-12-24␤»
 
 =head2 method Date
 
@@ -196,8 +196,8 @@ Defined as:
 
 Returns the invocant.
 
-    say Date.new('2015-12-24').Date;  # 2015-12-24
-    say Date.Date;                    # (Date)
+    say Date.new('2015-12-24').Date;  # OUTPUT: «2015-12-24␤»
+    say Date.Date;                    # OUTPUT: «(Date)␤»
 
 =head2 method DateTime
 
@@ -208,8 +208,8 @@ Defined as:
 
 Converts the invocant to L«C<DateTime>|/type/DateTime»
 
-    say Date.new('2015-12-24').DateTime; # 2015-12-24T00:00:00Z
-    say Date.DateTime;                   # (DateTime)
+    say Date.new('2015-12-24').DateTime; # OUTPUT: «2015-12-24T00:00:00Z␤»
+    say Date.DateTime;                   # OUTPUT: «(DateTime)␤»
 
 =head1 Functions
 
@@ -234,12 +234,12 @@ seconds and C<sleep 5.2> sleeps for 5.2 seconds:
     my $before = now;
     sleep (5/2);
     my $after = now;
-    say $after-$before;  # 2.502411561
+    say $after-$before;  # OUTPUT: «2.502411561␤»
 
     $before = now;
     sleep 5.2;
     $after = now;
-    say $after-$before;  # 5.20156987
+    say $after-$before;  # OUTPUT: «5.20156987␤»
 
 =head2 sub sleep-timer
 
@@ -249,7 +249,7 @@ This function is just like C<sleep>, but returns the amount of time
 remaining to sleep as a C<Duration> (which will be 0 if the call was not
 interrupted).
 
-    say sleep-timer 3.14;  # 0
+    say sleep-timer 3.14;  # OUTPUT: «0␤»
 
 =head2 sub sleep-until
 
@@ -263,12 +263,12 @@ sleep until a time in the past.
 
 To sleep until 10 seconds into the future, one could write something like this:
 
-    say sleep-until now+10;   # True
+    say sleep-until now+10;   # OUTPUT: «True␤»
 
 Trying to sleep until a time in the past doesn't work:
 
     my $instant = now - 5;
-    say sleep-until $instant; # False
+    say sleep-until $instant; # OUTPUT: «False␤»
 
 However if we put the instant sufficiently far in the future, the sleep
 should run:
@@ -276,7 +276,7 @@ should run:
 =for code :skip-test
 my $instant = now + 30;
 # assuming the two commands are run within 30 seconds of one another...
-say sleep-until $instant; # True
+say sleep-until $instant; # OUTPUT: «True␤»
 
 To specify an exact instant in the future, first create a C<DateTime> at the
 appropriate point in time, and cast to an C<Instant>.
@@ -322,9 +322,9 @@ the number of days to subtract, or another L«C<Date>|/type/Date» object.
 Returns a new L«C<Date>|/type/Date» object or the number of days between the
 two dates, respectively.
 
-    say Date.new('2016-12-25') - Date.new('2016-12-24'); # 1
-    say Date.new('2015-12-25') - Date.new('2016-11-21'); # -332
-    say Date.new('2016-11-21') - 332;                    # 2015-12-25
+    say Date.new('2016-12-25') - Date.new('2016-12-24'); # OUTPUT: «1␤»
+    say Date.new('2015-12-25') - Date.new('2016-11-21'); # OUTPUT: «-332␤»
+    say Date.new('2016-11-21') - 332;                    # OUTPUT: «2015-12-25␤»
 
 =head2 sub infix:<+>
 
@@ -334,7 +334,7 @@ two dates, respectively.
 Takes an L«C<Int>|/type/Int» and adds that many days to the given
 L«C<Date>|/type/Date» object.
 
-    say Date.new('2015-12-25') + 332; # 2016-11-21
-    say 1 + Date.new('2015-12-25');   # 2015-12-26
+    say Date.new('2015-12-25') + 332; # OUTPUT: «2016-11-21␤»
+    say 1 + Date.new('2015-12-25');   # OUTPUT: «2015-12-26␤»
 
 =end pod

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -28,12 +28,12 @@ my $dt = DateTime.new(
     minute  => 1,
 );
 
-say $dt;                            # 2015-11-21T16:01:00Z
-say $dt.later(days => 20);          # 2015-12-11T16:01:00Z
-say $dt.truncated-to('hour');       # 2015-11-21T16:00:00Z
-say $dt.in-timezone(-8 * 3600);     # 2015-11-21T08:01:00-0800
+say $dt;                            # OUTPUT: «2015-11-21T16:01:00Z␤»
+say $dt.later(days => 20);          # OUTPUT: «2015-12-11T16:01:00Z␤»
+say $dt.truncated-to('hour');       # OUTPUT: «2015-11-21T16:00:00Z␤»
+say $dt.in-timezone(-8 * 3600);     # OUTPUT: «2015-11-21T08:01:00-0800␤»
 
-my $now = DateTime.now(formatter => { sprintf "%02d:%02d",.hour,.minute });
+my $now = DateTime.now(formatter => { sprintf "%02d:%02d", .hour, .minute });
 say $now;                           # 12:45 (or something like that)
 =end code
 
@@ -91,7 +91,8 @@ L<X::DateTime::TimezoneClash> is thrown.
     $datetime = DateTime.new(2015, 1, 1, # First January of 2015
                              1, 1, 1);   # Hour, minute, second with default timezone
     $datetime = DateTime.new(now);                       # Instant.
-    say $datetime = DateTime.new(1470853583);            # 2016-08-10T18:26:23Z from a Unix timestamp
+    # from a Unix timestamp
+    say $datetime = DateTime.new(1470853583);            # OUTPUT: «2016-08-10T18:26:23Z␤»
     $datetime = DateTime.new("2015-01-01T03:17:30+0500") # Formatted string
 
 =head2 method now
@@ -115,7 +116,7 @@ Creates a new C<DateTime> object based on the invocant, but with the given
 arguments overriding the values from the invocant.
 
     say DateTime.new('2015-12-24T12:23:00Z').clone(hour => 0);
-        # 2015-12-24T00:23:00Z
+    # OUTPUT: «2015-12-24T00:23:00Z␤»
 
 Note that this can lead to invalid dates in some circumstances:
 
@@ -142,7 +143,7 @@ Defined as:
 
 Returns the hour component.
 
-    say DateTime.new('2012-02-29T12:34:56Z').hour;      # 12
+    say DateTime.new('2012-02-29T12:34:56Z').hour;      # OUTPUT: «12␤»
 
 =head2 method minute
 
@@ -152,7 +153,7 @@ Defined as:
 
 Returns the minute component.
 
-    say DateTime.new('2012-02-29T12:34:56Z').minute;     # 34
+    say DateTime.new('2012-02-29T12:34:56Z').minute;     # OUTPUT: «34␤»
 
 =head2 method second
 
@@ -162,8 +163,8 @@ Defined as:
 
 Returns the second component, including potentially fractional seconds.
 
-    say DateTime.new('2012-02-29T12:34:56Z').second;     # 56
-    say DateTime.new('2012-02-29T12:34:56.789Z').second; # 56.789
+    say DateTime.new('2012-02-29T12:34:56Z').second;     # OUTPUT: «56␤»
+    say DateTime.new('2012-02-29T12:34:56.789Z').second; # OUTPUT: «56.789␤»
     say DateTime.new('2012-02-29T12:34:56,789Z').second; # comma also ok
 
 =head2 method whole-second
@@ -174,7 +175,7 @@ Defined as:
 
 Returns the second component, rounded down to an L<Int|/type/Int>.
 
-    say DateTime.new('2012-02-29T12:34:56.789Z').whole-second;      # 56
+    say DateTime.new('2012-02-29T12:34:56.789Z').whole-second;      # OUTPUT: «56␤»
 
 =head2 method timezone
 
@@ -184,7 +185,7 @@ Defined as:
 
 Returns the time zone in seconds as an offset from UTC.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').timezone;      # 7200
+    say DateTime.new('2015-12-24T12:23:00+0200').timezone;          # OUTPUT: «7200␤»
 
 =head2 method offset
 
@@ -195,7 +196,7 @@ Defined as:
 Returns the time zone in seconds as an offset from UTC. This is an alias for
 L<#method timezone>.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').offset;            # 7200
+    say DateTime.new('2015-12-24T12:23:00+0200').offset;            # OUTPUT: «7200␤»
 
 =head2 method offset-in-minutes
 
@@ -205,7 +206,7 @@ Defined as:
 
 Returns the time zone in minutes as an offset from UTC.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').offset-in-minutes; # 120
+    say DateTime.new('2015-12-24T12:23:00+0200').offset-in-minutes; # OUTPUT: «120␤»
 
 =head2 method offset-in-hours
 
@@ -215,7 +216,7 @@ Defined as:
 
 Returns the time zone in hours as an offset from UTC.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').offset-in-hours;   # 2
+    say DateTime.new('2015-12-24T12:23:00+0200').offset-in-hours;   # OUTPUT: «2␤»
 
 =head2 method Str
 
@@ -227,7 +228,7 @@ Returns a string representation of the invocant, as done by
 L<the formatter|#method formatter>.  If no formatter was specified, an
 ISO 8601 timestamp will be returned.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').Str; # 2015-12-24T12:23:00+02:00
+    say DateTime.new('2015-12-24T12:23:00+0200').Str; # OUTPUT: «2015-12-24T12:23:00+02:00␤»
 
 =head2 method Instant
 
@@ -237,7 +238,7 @@ Defined as:
 
 Returns an L<Instant|/type/Instant> object based on the invocant.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').Instant; # 2015-12-24T12:23:00+02:00
+    say DateTime.new('2015-12-24T12:23:00+0200').Instant; # OUTPUT: «2015-12-24T12:23:00+02:00␤»
 
 =head2 method posix
 
@@ -248,7 +249,7 @@ Defined as:
 Returns the date and time as a POSIX/UNIX timestamp (seconds since the Epoch,
 1st January 1970 UTC).
 
-    say DateTime.new('2015-12-24T12:23:00Z').posix;     # 1450959780
+    say DateTime.new('2015-12-24T12:23:00Z').posix;       # OUTPUT: «1450959780␤»
 
 =head2 method later
 
@@ -268,15 +269,14 @@ the C<later> method.
 Please note that the special ":2nd" named parameter syntax can be a compact
 and self-documenting way of specifying the delta
 
-    say DateTime.new('2015-12-24T12:23:00Z').later(:2years);
-        # 2017-12-24T12:23:00Z
+    say DateTime.new('2015-12-24T12:23:00Z').later(:2years); # OUTPUT: «2017-12-24T12:23:00Z␤»
 
 Since addition of several different time units is not commutative, only one
 unit may be passed.
 
     my $d = DateTime.new(date => Date.new('2015-02-27'));
-    say $d.later(month => 1).later(:2days);  # 2015-03-29T00:00:00Z
-    say $d.later(days => 2).later(:1month);  # 2015-04-01T00:00:00Z
+    say $d.later(month => 1).later(:2days);  # OUTPUT: «2015-03-29T00:00:00Z␤»
+    say $d.later(days => 2).later(:1month);  # OUTPUT: «2015-04-01T00:00:00Z␤»
     say $d.later(days => 2).later(:month);   # same, as +True === 1
 
 Negative offsets are allowed, though L<#method earlier> is more idiomatic for
@@ -292,7 +292,7 @@ Returns a DateTime object based on the current one, but with a time delta
 towards the past applied. See L<#method later> for usage.
 
     my $d = DateTime.new(date => Date.new('2015-02-27'));
-    say $d.earlier(month => 1).earlier(:2days);  # 2015-01-25T00:00:00Z
+    say $d.earlier(month => 1).earlier(:2days);  # OUTPUT: «2015-01-25T00:00:00Z␤»
 
 =head2 method truncated-to
 
@@ -304,12 +304,12 @@ Returns a copy of the invocant, with everything smaller than the specified
 unit truncated to the smallest possible value.
 
     my $d = DateTime.new("2012-02-29T12:34:56.946314Z");
-    say $d.truncated-to('second');      # 2012-02-29T12:34:56Z
-    say $d.truncated-to('minute');      # 2012-02-29T12:34:00Z
-    say $d.truncated-to('hour');        # 2012-02-29T12:00:00Z
-    say $d.truncated-to('day');         # 2012-02-29T00:00:00Z
-    say $d.truncated-to('month');       # 2012-02-01T00:00:00Z
-    say $d.truncated-to('year');        # 2012-01-01T00:00:00Z
+    say $d.truncated-to('second');      # OUTPUT: «2012-02-29T12:34:56Z␤»
+    say $d.truncated-to('minute');      # OUTPUT: «2012-02-29T12:34:00Z␤»
+    say $d.truncated-to('hour');        # OUTPUT: «2012-02-29T12:00:00Z␤»
+    say $d.truncated-to('day');         # OUTPUT: «2012-02-29T00:00:00Z␤»
+    say $d.truncated-to('month');       # OUTPUT: «2012-02-01T00:00:00Z␤»
+    say $d.truncated-to('year');        # OUTPUT: «2012-01-01T00:00:00Z␤»
 
 DateTimes with fractional seconds can be truncated to whole seconds with
 C<.truncated-to('second')>.
@@ -323,8 +323,8 @@ Defined as:
 
 Converts the invocant to L«C<Date>|/type/Date».
 
-    say DateTime.new("2012-02-29T12:34:56.946314Z").Date; # 2012-02-29
-    say DateTime.Date;                                    # (Date)
+    say DateTime.new("2012-02-29T12:34:56.946314Z").Date; # OUTPUT: «2012-02-29␤»
+    say DateTime.Date;                                    # OUTPUT: «(Date)␤»
 
 =head2 method DateTime
 
@@ -334,9 +334,8 @@ Defined as:
 
 Returns the invocant.
 
-    say DateTime.new("2012-02-29T12:34:56.946314Z")
-            .DateTime;      # 2012-02-29T12:34:56.946314Z
-    say DateTime.DateTime;  # (DateTime)
+    say DateTime.new("2012-02-29T12:34:56.946314Z").DateTime; # 2012-02-29T12:34:56.946314Z
+    say DateTime.DateTime;                                    # OUTPUT: «(DateTime)␤»
 
 =head2 method utc
 
@@ -346,7 +345,7 @@ Defined as:
 
 Returns a DateTime object for the same time, but in time zone UTC.
 
-    say DateTime.new('2015-12-24T12:23:00+0200').utc;  # 2015-12-24T10:23:00Z
+    say DateTime.new('2015-12-24T12:23:00+0200').utc;  # OUTPUT: «2015-12-24T10:23:00Z␤»
 
 =head2 method in-timezone
 
@@ -356,8 +355,7 @@ Defined as:
 
 Returns a DateTime object for the same time, but in the specified time zone.
 
-    say DateTime.new('2015-12-24T12:23:00Z').in-timezone(3600 + 1800);
-        # 2015-12-24T13:53:00+0130
+    say DateTime.new('2015-12-24T12:23:00Z').in-timezone(3600 + 1800); # OUTPUT: «2015-12-24T13:53:00+0130␤»
 
 =head2 method local
 
@@ -369,8 +367,7 @@ Returns a DateTime object for the same time, but in the local time zone
 (C<$*TZ>).
 
     my $*TZ = -3600;
-    say DateTime.new('2015-12-24T12:23:00+0200').local;
-            # 2015-12-24T09:23:00-0100
+    say DateTime.new('2015-12-24T12:23:00+0200').local; # OUTPUT: «2015-12-24T09:23:00-0100␤»
 
 =head2 sub infix:<->
 
@@ -383,11 +380,8 @@ C<DateTime> object or the C<Duration> between the two dates, respectively. When
 subtracting C<Duration>, timezone of the original C<DateTime> is preserved
 in the returned C<DateTime> object.
 
-    say perl DateTime.new(:2016year) - DateTime.new(:2015year):;
-    # Duration.new(31536001.0)
-
-    say DateTime.new(:2016year, :3600timezone) - Duration.new(31536001.0);
-    # 2015-01-01T00:00:00+01:00
+    say perl DateTime.new(:2016year) - DateTime.new(:2015year):;           # OUTPUT: «Duration.new(31536001.0)␤»
+    say DateTime.new(:2016year, :3600timezone) - Duration.new(31536001.0); # OUTPUT: «2015-01-01T00:00:00+01:00␤»
 
 =head2 sub infix:<+>
 
@@ -397,10 +391,7 @@ in the returned C<DateTime> object.
 Takes a L«C<DateTime>|/type/DateTime» and increases it by the given
 L«C<Duration>|/type/Duration», preserving the timezone.
 
-    say DateTime.new(:2015year) + Duration.new(31536001.0);
-    # 2016-01-01T00:00:00Z
-
-    say Duration.new(42) + DateTime.new(:2015year, :3600timezone);
-    # 2015-01-01T00:00:42+01:00
+    say DateTime.new(:2015year) + Duration.new(31536001.0);        # OUTPUT: «2016-01-01T00:00:00Z␤»
+    say Duration.new(42) + DateTime.new(:2015year, :3600timezone); # OUTPUT: «2015-01-01T00:00:42+01:00␤»
 
 =end pod

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -20,8 +20,8 @@ Defined as:
 
 Returns the year of the date.
 
-    say Date.new('2015-12-31').year; # 2015
-    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).year; # 2015
+    say Date.new('2015-12-31').year;                                  # OUTPUT: «2015␤»
+    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).year; # OUTPUT: «2015␤»
 
 =head2 method month
 
@@ -31,8 +31,8 @@ Defined as:
 
 Returns the month of the date (1..12).
 
-    say Date.new('2015-12-31').month; # 12
-    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).month; # 12
+    say Date.new('2015-12-31').month;                                  # OUTPUT: «12␤»
+    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).month; # OUTPUT: «12␤»
 
 =head2 method day
 
@@ -42,8 +42,8 @@ Defined as:
 
 Returns the day of the month of the date (1..31).
 
-    say Date.new('2015-12-31').day; # 31
-    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day; # 24
+    say Date.new('2015-12-31').day;                                  # OUTPUT: «31␤»
+    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day; # OUTPUT: «24␤»
 
 =head2 method formatter
 
@@ -61,11 +61,11 @@ L<DateTime method Str|/type/DateTime#method Str> with the
 invocant as its only argument.
 
     my $dt = Date.new('2015-12-31');  # (no formatter specified)
-    say $dt.formatter.WHAT;           # (Callable)
+    say $dt.formatter.WHAT;           # OUTPUT: «(Callable)␤»
     my $us-format = sub ($self) { sprintf "%02d/%02d/%04d", .month, .day, .year given $self; };
     $dt = Date.new('2015-12-31', formatter => $us-format);
-    say $dt.formatter.WHAT;           # (Sub)
-    say $dt;                          # 12/31/2015
+    say $dt.formatter.WHAT;           # OUTPUT: «(Sub)␤»
+    say $dt;                          # OUTPUT: «12/31/2015␤»
 
 =head2 method is-leap-year
 
@@ -75,8 +75,8 @@ Defined as:
 
 Returns C<True> if the year of the Dateish object is a leap year.
 
-    say DateTime.new(:year<2016>).is-leap-year; # True
-    say Date.new("1900-01-01").is-leap-year;    # False
+    say DateTime.new(:year<2016>).is-leap-year; # OUTPUT: «True␤»
+    say Date.new("1900-01-01").is-leap-year;    # OUTPUT: «False␤»
 
 =head2 method day-of-month
 
@@ -87,8 +87,8 @@ Defined as:
 Returns the day of the month of the date (1..31). Synonymous to the C<day>
 method.
 
-    say Date.new('2015-12-31').day-of-month; # 31
-    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day-of-month; # 24
+    say Date.new('2015-12-31').day-of-month;                                  # OUTPUT: «31␤»
+    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day-of-month; # OUTPUT: «24␤»
 
 =head2 method day-of-week
 
@@ -98,8 +98,8 @@ Defined as:
 
 Returns the day of the week, where 1 is Monday, 2 is Tuesday and Sunday is 7.
 
-    say Date.new('2015-12-31').day-of-week; # 4
-    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day-of-week; # 4
+    say Date.new('2015-12-31').day-of-week;                                  # OUTPUT: «4␤»
+    say DateTime.new(date => Date.new('2015-12-24'), hour => 1).day-of-week; # OUTPUT: «4␤»
 
 =head2 method day-of-year
 
@@ -109,8 +109,8 @@ Defined as:
 
 Returns the day of the year (1..366).
 
-    say Date.new('2015-12-31').day-of-year; # 365
-    say DateTime.new(date => Date.new('2015-03-24'), hour => 1).day-of-year; # 83
+    say Date.new('2015-12-31').day-of-year;                                  # OUTPUT: «365␤»
+    say DateTime.new(date => Date.new('2015-03-24'), hour => 1).day-of-year; # OUTPUT: «83␤»
 
 =head2 method days-in-month
 
@@ -120,8 +120,8 @@ Defined as:
 
 Returns the number of days in the month represented by the Dateish object:
 
-    say Date.new("2016-01-02").days-in-month;                # 31
-    say DateTime.new(:year<10000>, :month<2>).days-in-month; # 29
+    say Date.new("2016-01-02").days-in-month;                # OUTPUT: «31␤»
+    say DateTime.new(:year<10000>, :month<2>).days-in-month; # OUTPUT: «29␤»
 
 =head2 method week
 
@@ -133,9 +133,9 @@ Returns a list of two integers: the year, and the week number. This is because
 at the start or end of a year, the week may actually belong to the other year.
 
     my ($year, $week) = Date.new("2014-12-31").week;
-    say $year;      # 2015
-    say $week;      # 1
-    say Date.new('2015-01-31').week;        # (2015 5)
+    say $year;                       # OUTPUT: «2015␤»
+    say $week;                       # OUTPUT: «1␤»
+    say Date.new('2015-01-31').week; # OUTPUT: «(2015 5)␤»
 
 =head2 method week-number
 
@@ -186,8 +186,8 @@ Defined as:
 
 Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>)
 
-    say Date.new("2015-11-15").yyyy-mm-dd;   # 2015-11-15
-    say DateTime.new(1470853583).yyyy-mm-dd; # 2016-08-10
+    say Date.new("2015-11-15").yyyy-mm-dd;   # OUTPUT: «2015-11-15␤»
+    say DateTime.new(1470853583).yyyy-mm-dd; # OUTPUT: «2016-08-10␤»
 
 =head2 method daycount
 
@@ -202,7 +202,7 @@ which is used routinely by e.g. astronomers, geodesists, scientists
 and others. The MJD convention is designed to facilitate simplified
 chronological calculations.
 
-    say Date.new('1995-09-27').daycount;    # 49987
+    say Date.new('1995-09-27').daycount;    # OUTPUT: «49987␤»
 
 =head2 method IO
 
@@ -213,8 +213,8 @@ Defined as:
 Returns an L<IO::Path|/type/IO::Path> object representing the stringified
 value of the Dateish object:
 
-    Date.today.IO.say;   # "2016-10-03".IO
-    DateTime.now.IO.say; # "2016-10-03T11:14:47.977994-04:00".IO
+    Date.today.IO.say;   # OUTPUT: «"2016-10-03".IO␤»
+    DateTime.now.IO.say; # OUTPUT: «"2016-10-03T11:14:47.977994-04:00".IO␤»
 
 B<PORTABILITY NOTE:> some operating systems (e.g. Windows) do not permit
 colons (C<:>) in filenames, which would be present in C<IO::Path> created from a

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -36,7 +36,7 @@ an exception itself.
 
     try die "Something bad happened";
     if ($!) {
-        say $!.message; # Something bad happened.
+        say $!.message; # OUTPUT: «Something bad happened.␤»
     }
 
 =head2 method backtrace
@@ -61,9 +61,9 @@ Defined as:
 
 Throws the exception.
 
-    my $exception = X::AdHoc.new; # Totally fine
-    try $exception.throw;             # Throws
-    if ($!) { #`( some handling ) };                   # Suppress the exception in a
+    my $exception = X::AdHoc.new;    # Totally fine
+    try $exception.throw;            # Throws
+    if ($!) { #`( some handling ) }; # Suppress the exception
 
 =head2 method resume
 

--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -32,7 +32,7 @@ Defined as:
 
 Returns C<True> for handled failures, C<False> otherwise.
 
-    sub f() { fail }; my $v = f; say $v.handled; # False
+    sub f() { fail }; my $v = f; say $v.handled; # OUTPUT: «False␤»
 
 =head2 method exception
 
@@ -55,8 +55,8 @@ Defined as:
 Returns C<False>, and marks the failure as handled.
 
     sub f() { fail }; my $v = f; say $v.handled; $v.Bool; say $v.handled;
-    # False
-    # True
+    # OUTPUT: «False␤
+    # True␤»
 
 =head2 method defined
 
@@ -67,6 +67,6 @@ Defined as:
 Returns C<False> (failures are officially undefined), and marks
 the failure as handled.
 
-    sub f() { fail }; my $v = f; say $v.defined; # False
+    sub f() { fail }; my $v = f; say $v.defined; # OUTPUT: «False␤»
 
 =end pod

--- a/doc/Type/Grammar.pod6
+++ b/doc/Type/Grammar.pod6
@@ -16,10 +16,10 @@ superclass) becomes a subclass of I<Grammar>.
         token a { a }
         token b { b }
     }
-    say Thingy ~~ Grammar;      # True
+    say Thingy ~~ Grammar;      # OUTPUT: «True␤»
     my $match = Thingy.parse('ab');
-    say so $match;              # True
-    say ~$match<a>;             # a
+    say so $match;              # OUTPUT: «True␤»
+    say ~$match<a>;             # OUTPUT: «a␤»
 
 More L<documentation on grammars|/language/grammars> is available.
 
@@ -119,8 +119,8 @@ if the grammar failed to match.
         token as { a+ };
     }
     my $match = A.subparse('aaab', :rule<as>);
-    say ~$match;        # aaa
-    say $match.to;      # 3
+    say ~$match;        # OUTPUT: «aaa␤»
+    say $match.to;      # OUTPUT: «3␤»
 
 =head2 method parsefile
 

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -51,20 +51,20 @@ If a L<Pair> is encountered where a value is expected, it is used as a
 hash value:
 
     my %h = 'a', 'b' => 'c';
-    say %h<a>.WHAT;             # (Pair)
-    say %h<a>.key;              # b
+    say %h<a>.WHAT;             # OUTPUT: «(Pair)␤»
+    say %h<a>.key;              # OUTPUT: «b␤»
 
 If the same key appears more than once, the value associated with its last
 occurrence is stored in the hash:
 
     my %h = a => 1, a => 2;
-    say %h<a>;                  # 2
+    say %h<a>;                  # OUTPUT: «2␤»
 
 To assign to a variable without the C<%> sigil, you may use curly braces:
 
     my $h = { a => 1, b => 2 }; # *See Note*
-    say $h.WHAT;                # Hash
-    say $h<a>;                  # 1
+    say $h.WHAT;                # OUTPUT: «Hash␤»
+    say $h<a>;                  # OUTPUT: «1␤»
 
 B<NOTE:> If one or more values reference the topic variable, C<$_>, the
 right-hand side of the assignment will be interpreted as a L<Block|/type/Block>,
@@ -80,7 +80,7 @@ not a Hash:
 
     my @names = map {
         my $query = { name => "$_<firstName> $_<lastName>" };
-        say $query.WHAT;       # Block
+        say $query.WHAT;       # OUTPUT: «Block␤»
         say $query<name>;      # fails
         CATCH { default { put .^name, ': ', .Str } };
         # OUTPUT: «X::AdHoc: Type Block does not support associative indexing.␤»
@@ -94,7 +94,7 @@ Instead, you should either:
 
 =for code :skip-test
 my  $query = %( name => "$_<firstName> $_<lastName>" );
-say $query.WHAT;         # Hash
+say $query.WHAT;         # OUTPUT: «Hash␤»
 say $query<name>;        # Andy Adams, Beth Burke, etc.
 =end item
 
@@ -103,7 +103,7 @@ say $query<name>;        # Andy Adams, Beth Burke, etc.
 
 =for code :skip-test
 my  %query = name => "$_<firstName> $_<lastName>";   # No braces required
-say %query.WHAT;         # Hash
+say %query.WHAT;         # OUTPUT: «Hash␤»
 say %query<name>;        # Andy Adams, Beth Burke, etc.
 =end item
 
@@ -118,7 +118,7 @@ the topic variable:
     sub lookup-user (Hash $h) { #`(Do something...) $h }
     my @names = map -> $person {
         my $query = { name => "$person<firstName> $person<lastName>" };
-        say $query.WHAT;     # Hash
+        say $query.WHAT;     # OUTPUT: «Hash␤»
         say $query<name>;    # Andy Adams, Beth Burke, etc.
 
        lookup-user($query);
@@ -141,8 +141,8 @@ most idiomatic and unambiguous solution:
 
 You can assign to multiple keys at the same time with a slice.
 
-    my %h; %h<a b c> = 2 xx *; %h.perl.say;  # {:a(2), :b(2), :c(2)}
-    my %h; %h<a b c> = ^3;     %h.perl.say;  # {:a(0), :b(1), :c(2)}
+    my %h; %h<a b c> = 2 xx *; %h.perl.say;  # OUTPUT: «{:a(2), :b(2), :c(2)}␤»
+    my %h; %h<a b c> = ^3;     %h.perl.say;  # OUTPUT: «{:a(0), :b(1), :c(2)}␤»
 
 =head2 Non-string keys
 
@@ -269,10 +269,10 @@ C<.keys> is undefined and one anonymous list is never L<===> to another.
     sleep 1;
     my $second-instant = now;
     %intervals{ $second-instant } = "Logging this Instant for spurious raisins.";
-    say ($first-instant, $second-instant) ~~ %intervals.keys;       # False
-    say ($first-instant, $second-instant) ~~ %intervals.keys.sort;  # True
-    say ($first-instant, $second-instant) === %intervals.keys.sort; # False
-    say $first-instant === %intervals.keys.sort[0];                 # True
+    say ($first-instant, $second-instant) ~~ %intervals.keys;       # OUTPUT: «False␤»
+    say ($first-instant, $second-instant) ~~ %intervals.keys.sort;  # OUTPUT: «True␤»
+    say ($first-instant, $second-instant) === %intervals.keys.sort; # OUTPUT: «False␤»
+    say $first-instant === %intervals.keys.sort[0];                 # OUTPUT: «True␤»
 
 Since C<Instant> defines its own comparison methods, in our example a sort according to
 L<cmp> will always provide the earliest instant object as the first element in the L<List>
@@ -345,12 +345,12 @@ In simple classification mode, each mapper's value is any non-Iterable and
 represents a key to classify C<@list>'s item under:
 
     say % .classify-list: { $_ %% 2 ?? 'even' !! 'odd' }, ^10;
-    # OUTPUT: {even => [0 2 4 6 8], odd => [1 3 5 7 9]}
+    # OUTPUT: «{even => [0 2 4 6 8], odd => [1 3 5 7 9]}␤»
 
     my @mapper = <zero one two three four five>;
     my %hash = foo => 'bar';
     say %hash.classify-list: @mapper, 1, 2, 3, 4, 4;
-    # OUTPUT: {foo => bar, four => [4 4], one => [1], three => [3], two => [2]}
+    # OUTPUT: «{foo => bar, four => [4 4], one => [1], three => [3], two => [2]}␤»
 
 The mapper's value is used as the key of the L«C<Hash>|/type/Hash» to
 which the C<@list>'s item will be L«C<push>ed|/routine/push». See
@@ -537,7 +537,7 @@ index:
 
     my %wc = 'hash' => 323, 'pair' => 322, 'pipe' => 323;
     (my %inv).push: %wc.invert.unique;
-    say %inv;                           # {322 => pair, 323 => [pipe hash]}
+    say %inv;                           # OUTPUT: «{322 => pair, 323 => [pipe hash]}␤»
 
 Note that such a initialization could also be written as
 
@@ -560,9 +560,9 @@ arguments|/type/Signature#Positional_vs._Named> to C<.append>.
     %h.append('b', 2, 'c', 3);
     %h.append({d => 4});
     say %h;
-    # OUTPUT«{a => 1, b => 2, c => 3, d => 4}␤»
+    # OUTPUT: «{a => 1, b => 2, c => 3, d => 4}␤»
     %h.append('a', 2);
-    # OUTPUT«{{a => [1 2], b => 2, c => 3, d => 4}␤»
+    # OUTPUT: «{{a => [1 2], b => 2, c => 3, d => 4}␤»
 
 =head2 method default
 
@@ -577,12 +577,12 @@ L<is default|/routine/is default> trait the method returns the type object
 C<(Any)>.
 
     my %h1 = 'apples' => 3, 'oranges' => 7;
-    say %h1.default;                                       # (Any)
-    say %h1{'bananas'};                                    # (Any)
+    say %h1.default;                                       # OUTPUT: «(Any)␤»
+    say %h1{'bananas'};                                    # OUTPUT: «(Any)␤»
 
     my %h2 is default(1) = 'apples' => 3, 'oranges' => 7;
-    say %h2.default;                                       # 1
-    say %h2{'apples'} + %h2{'bananas'};                    # 4
+    say %h2.default;                                       # OUTPUT: «1␤»
+    say %h2{'apples'} + %h2{'bananas'};                    # OUTPUT: «4␤»
 
 =head2 method keyof
 
@@ -596,9 +596,9 @@ while for L<object hashes|/type/Hash#Object_hashes_and_type_constraints>
 the type used in the declaration of the C<Hash> is returned.
 
     my %h1 = 'apples' => 3, 'oranges' => 7;  # (no key type specified)
-    say %h1.keyof;                           # (Str(Any))
+    say %h1.keyof;                           # OUTPUT: «(Str(Any))␤»
 
-    my %h2{Str} = 'oranges' => 7;            # (keys must be of type Str
+    my %h2{Str} = 'oranges' => 7;            # (keys must be of type Str)
     say %h2.keyof;                           # (Str)
     %h2{3} = 'apples';                       # throws exception
     CATCH { default { put .^name, ': ', .Str } };
@@ -615,10 +615,10 @@ i.e. if no type constraint is given during declaration, the method
 returns C<(Mu)>.
 
     my %h1 = 'apples' => 3, 'oranges' => 7;  # (no type constraint specified)
-    say %h1.of;                              # (Mu)
+    say %h1.of;                              # OUTPUT: «(Mu)␤»
 
     my Int %h2 = 'oranges' => 7;             # (values must be of type Int)
-    say %h2.of;                              # (Int)
+    say %h2.of;                              # OUTPUT: «(Int)␤»
 
 =head1 Subscript Adverbs
 
@@ -629,8 +629,8 @@ Some methods are implemented as adverbs on subscripts.
 The adverb C<:exists> returns C<Bool::True> if a key exists in the Hash. If more then one key is supplied it returns a C<List> of C<Bool>.
 
     my %h = a => 1, b => 2;
-    say %h<a>:exists;   # True
-    say %h<a b>:exists; # (True True)
+    say %h<a>:exists;   # OUTPUT: «True␤»
+    say %h<a b>:exists; # OUTPUT: «(True True)␤»
 
 =head2 C<:delete>
 
@@ -646,25 +646,25 @@ Use C<:delete> to remove a C<Pair> from the C<Hash>.
 The adverb C<:p> returns a C<Pair> or a List of C<Pair> instead of just the value.
 
     my %h = a => 1, b => 2;
-    say %h<a>:p;    # a => 1
-    say %h<a b>:p;  # (a => 1 b=> 2)
+    say %h<a>:p;    # OUTPUT: «a => 1␤»
+    say %h<a b>:p;  # OUTPUT: «(a => 1 b=> 2)␤»
 
 =head2 C<:v> and C<:k>
 
 The adverbs C<:v> and C<:k> return the key or value or a list their of.
 
     my %h = a => 1, b => 2;
-    say %h<a>:k;    # a
-    say %h<a b>:k;  # (a b)
+    say %h<a>:k;    # OUTPUT: «a␤»
+    say %h<a b>:k;  # OUTPUT: «(a b)␤»
 
 You can also use the adverbs without knowing anything about the hash by using
 empty angle brackets in which case all the keys and values will be listed:
 
     my %h1 = a => 1;
     my %h2 = a => 1, b => 2;
-    say %h1<>:k; # (a)
-    say %h1<>:v; # (1)
-    say %h2<>:k; # (a b)
-    say %h2<>:v; # (1 2)
+    say %h1<>:k; # OUTPUT: «(a)␤»
+    say %h1<>:v; # OUTPUT: «(1)␤»
+    say %h2<>:k; # OUTPUT: «(a b)␤»
+    say %h2<>:v; # OUTPUT: «(1 2)␤»
 
 =end pod

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -71,12 +71,12 @@ printing.  Hence the following C<say> statements for the respective
 containers are equivalent:
 
     my @array = qw{1 2 3 4};
-    say @array;       # [1 2 3 4]
-    say @array.gist;  # [1 2 3 4]
+    say @array;       # OUTPUT: «[1 2 3 4]␤»
+    say @array.gist;  # OUTPUT: «[1 2 3 4]␤»
 
     my %hash = "a" => 1, "b" => 2, "c" => 3;
-    say %hash;        # {a => 1, b => 2, c => 3}
-    say %hash.gist;   # {a => 1, b => 2, c => 3}
+    say %hash;        # OUTPUT: «{a => 1, b => 2, c => 3}␤»
+    say %hash.gist;   # OUTPUT: «{a => 1, b => 2, c => 3}␤»
 
 =head2 sub note
 

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -224,7 +224,7 @@ after the final argument.
 
 =for code :skip-test
 my $fh = open 'path/to/file', :w;
-$fh.say(Complex.new(3, 4));        # 3+4i\n
+$fh.say(Complex.new(3, 4));        # RESULT: «3+4i\n»
 $fh.close;
 
 =head2 method read

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -55,7 +55,7 @@ Returns the absolute path as a string.
 Returns the basename part of the path object. That is, it returns the name of
 the file relative to its directory.
 
-    say IO::Path.new("/etc/passwd").basename;   # passwd
+    say IO::Path.new("/etc/passwd").basename;      # OUTPUT: «passwd␤»
 
 =head2 method extension
 
@@ -63,7 +63,7 @@ the file relative to its directory.
 
 Returns the extension (if any) of the path object.
 
-    say IO::Path.new("docs/README.pod").extension;   # pod
+    say IO::Path.new("docs/README.pod").extension; # OUTPUT: «pod␤»
 
 =head2 method dirname
 
@@ -72,7 +72,7 @@ Returns the extension (if any) of the path object.
 Returns the directory name portion of the path object. That is, it returns
 the path excluding the volume and the base name.
 
-    say IO::Path.new("/etc/passwd").dirname;    # /etc
+    say IO::Path.new("/etc/passwd").dirname;       # OUTPUT: «/etc␤»
 
 =head2 method volume
 
@@ -81,7 +81,7 @@ the path excluding the volume and the base name.
 Returns the volume portion of the path object. On Unix system, this is always
 the empty string.
 
-    say IO::Path::Win32.new("C:\\Windows\\registry.ini").volume;    # C:
+    say IO::Path::Win32.new("C:\\Windows\\registry.ini").volume;    # OUTPUT: «C:␤»
 
 =head2 method parts
 
@@ -90,8 +90,8 @@ the empty string.
 Returns a hash with the keys C<dirname>, C<path> and C<volume>, and as
 values the return values of the methods with the same names.
 
-    say IO::Path.new("/etc/passwd").parts.perl
-    # ("dirname" => "/etc", "volume" => "", "basename" => "passwd").hash
+    say IO::Path.new("/etc/passwd").parts.perl;
+    # OUTPUT: «{:basename("passwd"), :directory("/etc"), :dirname("/etc"), :volume("")}␤»
 
 =head2 method path
 
@@ -106,8 +106,8 @@ Returns the full path as a string.
 Returns the complete text that was used to create the path as a string, whether
 it was given as a single string or as named arguments.
 
-    say IO::Path.new(basename => "foo", dirname => "/bar").Str;  # /bar/foo
-    say IO::Path.new("/bar/foo").Str;                            # /bar/foo
+    say IO::Path.new(basename => "foo", dirname => "/bar").Str;  # OUTPUT: «/bar/foo␤»
+    say IO::Path.new("/bar/foo").Str;                            # OUTPUT: «/bar/foo␤»
 
 =head2 method open
 
@@ -154,7 +154,7 @@ Returns a new C<Str> object relative to the C<$base> path.
 Removes the last portion of the path and returns the result as a new C<IO::Path>.
 
     my $io = IO::Path.new( "/etc/passwd" );
-    say $io.parent;                          # "/etc".IO
+    say $io.parent;                          # OUTPUT: «"/etc".IO␤»
 
 =head2 method child
 
@@ -164,7 +164,7 @@ Appends C<$childname> to the end of the path, adding path separators where
 needed and returns the result as a new C<IO::Path>.
 
     my $io = IO::Path.new( "/bin" );
-    say $io.child('netstat');                # "/bin/netstat".IO
+    say $io.child('netstat');                # OUTPUT: «"/bin/netstat".IO␤»
 
 =head2 method resolve
 
@@ -492,8 +492,8 @@ Returns the L<IO::Spec|/type/IO::Spec> object that was (implicitly) specified at
 creation time.
 
     my $io = IO::Path.new("/bin/bash");
-    say $io.SPEC;                            # (Unix)
-    say $io.SPEC.dir-sep;                    # /
+    say $io.SPEC;                            # OUTPUT: «(Unix)␤»
+    say $io.SPEC.dir-sep;                    # OUTPUT: «/␤»
 
 =head1 File test operators
 
@@ -556,13 +556,13 @@ Return an L<Instant> object representing the timestamp when the file was
 last modified.
 
 =for code :skip-test
-say "path/to/file".IO.modified;   #  e.g. Instant:1424089165
+say "path/to/file".IO.modified;               #  e.g. Instant:1424089165
 
 To obtain a human-readable form of the timestamp, call C<DateTime> method
 on the returned C<Instant>, to convert it into a L<DateTime> object:
 
 =for code :skip-test
-say "path/to/file".IO.modified.DateTime;  # e.g. 2015-02-16T12:18:50Z
+say "path/to/file".IO.modified.DateTime;      # e.g. 2015-02-16T12:18:50Z
 
 =head2 method accessed
 
@@ -570,19 +570,19 @@ Return an L<Instant> object representing the timestamp when the file was
 last accessed.
 
 =for code :skip-test
-say "path/to/file".IO.accessed;   #  e.g. Instant:1424353577
+say "path/to/file".IO.accessed;               # e.g. Instant:1424353577
 
 To obtain a human-readable form of the timestamp, use a L<DateTime> object:
 
 =for code :skip-test
-say DateTime.new("path/to/file".IO.accessed);  # e.g. 2015-02-19T13:45:42Z
+say DateTime.new("path/to/file".IO.accessed); # e.g. 2015-02-19T13:45:42Z
 
 or more readably:
 
 =for code :skip-test
 my $access_instant = "path/to/file".IO.accessed;
 my $access_time = DateTime.new($access_instant);
-say $access_time;         # e.g. 2015-02-19T13:45:42Z
+say $access_time;                             # e.g. 2015-02-19T13:45:42Z
 
 =head2 method changed
 
@@ -590,7 +590,7 @@ Return an L<Instant> object representing the timestamp when the inode was
 last changed.
 
 =for code :skip-test
-"path/to/file".IO.changed;        #  e.g. Instant:1424089165
+"path/to/file".IO.changed;                    # e.g. Instant:1424089165
 
 To obtain a human-readable form of the timestamp, use a L<DateTime> object:
 
@@ -602,7 +602,7 @@ or more readably:
 =for code :skip-test
 my $change_instant = "path/to/file".IO.changed;
 my $change_time = DateTime.new($change_instant);
-say $change_time;         # e.g. 2015-02-16T12:18:50Z
+say $change_time;                             # e.g. 2015-02-16T12:18:50Z
 
 =head1 File permissions retrieval
 

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -60,8 +60,8 @@ Converts the POSIX timestamp C<$posix> to an Instant.
 If C<$prefer-leap-second> is C<True>, the return value will be
 the first of the two possible seconds in the case of a leap second.
 
-    say DateTime.new(Instant.from-posix(915148800, True));  # 1998-12-31T23:59:60Z
-    say DateTime.new(Instant.from-posix(915148800));        # 1999-01-01T00:00:00Z
+    say DateTime.new(Instant.from-posix(915148800, True));  # OUTPUT: «1998-12-31T23:59:60Z␤»
+    say DateTime.new(Instant.from-posix(915148800));        # OUTPUT: «1999-01-01T00:00:00Z␤»
 
 =head2 method to-posix
 
@@ -73,8 +73,8 @@ It is the inverse of L<#method from-posix>, except that the second return
 value is C<True> if *and only if* this Instant is in a leap
 second.
 
-    say DateTime.new("1999-01-01T00:00:00Z").Instant.to-posix; # (915148800 False)
-    say DateTime.new('1998-12-31T23:59:60Z').Instant.to-posix; # (915148800 True)
+    say DateTime.new("1999-01-01T00:00:00Z").Instant.to-posix; # OUTPUT: «(915148800 False)␤»
+    say DateTime.new('1998-12-31T23:59:60Z').Instant.to-posix; # OUTPUT: «(915148800 True)␤»
 
 =head2 method Date
 
@@ -86,7 +86,7 @@ Returns a L<Date|/type/Date> object set to the date of the invocant.
 
     # the results given will vary from system to system
     my $i = "/etc/passwd".IO.modified;
-    say $i;                                       # Instant:1451489025.878018
-    say $i.Date;                                  # 2015-12-30
+    say $i;                                       # OUTPUT: «Instant:1451489025.878018␤»
+    say $i.Date;                                  # OUTPUT: «2015-12-30␤»
 
 =end pod

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -17,7 +17,7 @@ There are two main syntax forms for C<Int> literals
 For your convenience common radix forms come with a prefix shortcut.
 
     say so :2<11111111> == 0b11111111 == :8<377> == 0o377 == 255 == 0d255 == :16<ff> == 0xff;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 All forms allow underscores between any two digits which can serve as visual
 separators, but don't carry any meaning:
@@ -70,8 +70,8 @@ Returns the given C<Int> raised to the C<$y> power within modulus C<$mod>,
 that is gives the result of C<($x ** $y) mod $mod>. The subroutine form
 can accept non-C<Int> arguments, which will be coerced to C<Int>.
 
-    say expmod(4, 2, 5);    # 1
-    say 7.expmod(2, 5);     # 4
+    say expmod(4, 2, 5);    # OUTPUT: «1␤»
+    say 7.expmod(2, 5);     # OUTPUT: «4␤»
 
 =head2 method polymod
 
@@ -95,15 +95,15 @@ the method is called on a non-C<Int> number.
                 + 4 * 60       # minutes
                 + 5;           # seconds
 
-    say $seconds.polymod(60, 60);              # (5 4 27)
-    say $seconds.polymod(60, 60, 24);          # (5 4 3 1)
+    say $seconds.polymod(60, 60);                # OUTPUT: «(5 4 27)␤»
+    say $seconds.polymod(60, 60, 24);            # OUTPUT: «(5 4 3 1)␤»
 
-    say 120.polymod:      1, 10, 10², 10³, 10⁴;  # (0 0 12 0 0 0)
-    say 120.polymod: lazy 1, 10, 10², 10³, 10⁴;  # (0 0 12)
-    say 120.polymod:      1, 10, 10² … ∞;        # (0 0 12)
+    say 120.polymod:      1, 10, 10², 10³, 10⁴;  # OUTPUT: «(0 0 12 0 0 0)␤»
+    say 120.polymod: lazy 1, 10, 10², 10³, 10⁴;  # OUTPUT: «(0 0 12)␤»
+    say 120.polymod:      1, 10, 10² … ∞;        # OUTPUT: «(0 0 12)␤»
 
-    say ⅔.polymod(⅓);                          # (0 2)
-    say 5.Rat.polymod(.3, .2);                 # (0.2 0 80)
+    say ⅔.polymod(⅓);                            # OUTPUT: «(0 2)␤»
+    say 5.Rat.polymod(.3, .2);                   # OUTPUT: «(0.2 0 80)␤»
 
 To illustrate how the C<Int>, non-lazy version of polymod works, consider
 this code that implements it:
@@ -120,7 +120,7 @@ this code that implements it:
     }
     @pieces.push: $seconds;
 
-    say @pieces; # [5 4 3 2]
+    say @pieces; # OUTPUT: «[5 4 3 2]␤»
 
 For a more detailed discussion, see
 L<this blog post|http://perl6.party/post/Perl6-.polymod-break-up-a-number-into-denominations>
@@ -137,8 +137,8 @@ prime based on a probabilistic Miller-Rabin test.
 
 Returns C<False> if this C<Int> is known not to be a prime.
 
-    say 2.is-prime;         # True
-    say is-prime(9);        # False
+    say 2.is-prime;         # OUTPUT: «True␤»
+    say is-prime(9);        # OUTPUT: «False␤»
 
 =head2 routine lsb
 
@@ -151,11 +151,11 @@ Returns L<Nil|/type/Nil> if the number is 0. Otherwise returns the zero-based
 index from the right of the least significant (rightmost) 1 in the binary
 representation of the number.
 
-    say 0b01011.lsb;        # 0
-    say 0b01010.lsb;        # 1
-    say 0b10100.lsb;        # 2
-    say 0b01000.lsb;        # 3
-    say 0b10000.lsb;        # 4
+    say 0b01011.lsb;        # OUTPUT: «0␤»
+    say 0b01010.lsb;        # OUTPUT: «1␤»
+    say 0b10100.lsb;        # OUTPUT: «2␤»
+    say 0b01000.lsb;        # OUTPUT: «3␤»
+    say 0b10000.lsb;        # OUTPUT: «4␤»
 
 =head2 routine msb
 
@@ -168,11 +168,11 @@ Returns L<Nil|/type/Nil> if the number is 0. Otherwise returns the zero-based
 index from the right of the most significant (leftmost) 1 in the binary
 representation of the number.
 
-    say 0b00001.msb;        # 0
-    say 0b00011.msb;        # 1
-    say 0b00101.msb;        # 2
-    say 0b01010.msb;        # 3
-    say 0b10011.msb;        # 4
+    say 0b00001.msb;        # OUTPUT: «0␤»
+    say 0b00011.msb;        # OUTPUT: «1␤»
+    say 0b00101.msb;        # OUTPUT: «2␤»
+    say 0b01010.msb;        # OUTPUT: «3␤»
+    say 0b10011.msb;        # OUTPUT: «4␤»
 
 =head2 routine unival
 
@@ -184,9 +184,9 @@ Defined as:
 Returns the number represented by the Unicode codepoint with the given integer
 number, or L<NaN|/type/Num#NaN> if it does not represent a number.
 
-    say ord("¾").unival;    # 0.75
-    say 190.unival;         # 0.75
-    say unival(65);         # NaN
+    say ord("¾").unival;    # OUTPUT: «0.75␤»
+    say 190.unival;         # OUTPUT: «0.75␤»
+    say unival(65);         # OUTPUT: «NaN␤»
 
 =head1 Operators
 

--- a/doc/Type/IntStr.pod6
+++ b/doc/Type/IntStr.pod6
@@ -11,7 +11,7 @@ allow for the representation of a value as both a string and a numeric type, typ
 they will be created for you when the context is "stringy" but they can be determined
 to be numbers, such as in some L<quoting constructs|/language/quoting>:
 
-    my $f = <42>; say $f.WHAT; # (IntStr)
+    my $f = <42>; say $f.WHAT; # OUTPUT: «(IntStr)␤»
 
 As a subclass of both L«C<Int>|/type/Int» and L«C<Str>|/type/Str», an C<IntStr>
 will be accepted where either is expected. However, C<IntStr> does not share
@@ -32,8 +32,8 @@ The constructor requires both the C<Int> and the C<Str> value, when constructing
 directly the values can be whatever is required:
 
     my $f = IntStr.new(42, "forty two");
-    say +$f; # -> 42
-    say ~$f; # -> "forty two"
+    say +$f; # OUTPUT: «42␤»
+    say ~$f; # OUTPUT: «"forty two"␤»
 
 =head2 method Numeric
 
@@ -65,8 +65,8 @@ coerce to a C<Int> or C<Str> value first:
 
     my $f = IntStr.new(42, "smaller");
     my $g = IntStr.new(43, "larger");
-    say $f cmp $g;          # Less
-    say $f.Str cmp $g.Str;  # More
+    say $f cmp $g;          # OUTPUT: «Less␤»
+    say $f.Str cmp $g.Str;  # OUTPUT: «More␤»
 
 =end pod
 

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -20,7 +20,7 @@ Its important aspect is a method stub for C<iterator>.
     };
 
     my @a does DNA = 'GAATCC';
-    .say for @a; # OUTPUT«G␤G␤A␤T␤C␤C␤»
+    .say for @a; # OUTPUT: «G␤G␤A␤T␤C␤C␤»
 
 =head1 Methods
 
@@ -48,8 +48,8 @@ returns.
 
 For example
 
-    say (<a b>, 'c').elems;         # 2
-    say (<a b>, 'c').flat.elems;    # 3
+    say (<a b>, 'c').elems;         # OUTPUT: «2␤»
+    say (<a b>, 'c').flat.elems;    # OUTPUT: «3␤»
 
 because C<< <a b> >> is a L<List|/type/List> and thus iterable, so
 C<< (<a b>, 'c').flat >> returns C<('a', 'b', 'c')>, which has three elems.
@@ -57,7 +57,7 @@ C<< (<a b>, 'c').flat >> returns C<('a', 'b', 'c')>, which has three elems.
 Note that the flattening is recursive, so C<((("a", "b"), "c"), "d").flat>
 returns C<("a", "b", "c", "d")>, but it does not flatten itemized sublists:
 
-    say ($('a', 'b'), 'c').perl;    # ($("a", "b"), "c")
+    say ($('a', 'b'), 'c').perl;    # OUTPUT: «($("a", "b"), "c")␤»
 
 =head2 method lazy
 
@@ -67,8 +67,8 @@ Defined as:
 
 Returns a lazy iterable wrapping the invocant.
 
-    say (1 ... 1000).is-lazy;      # False
-    say (1 ... 1000).lazy.is-lazy; # True
+    say (1 ... 1000).is-lazy;      # OUTPUT: «False␤»
+    say (1 ... 1000).lazy.is-lazy; # OUTPUT: «True␤»
 
 =head2 method hyper
 

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -41,9 +41,9 @@ The C<pull-one> method is supposed to return the next value if available, or
 the sentinel value C<IterationEnd> if no more elements are available.
 
     my $i = (1 .. 3).iterator;
-    say $i.pull-one; # 1
-    say $i.pull-one; # 2
-    say $i.pull-one; # 3
+    say $i.pull-one; # OUTPUT: «1␤»
+    say $i.pull-one; # OUTPUT: «2␤»
+    say $i.pull-one; # OUTPUT: «3␤»
     dd $i.pull-one;  # IterationEnd
 
 =head2 method push-exactly
@@ -60,7 +60,7 @@ returns the sentinel value C<IterationEnd>. Otherwise it returns
 C<$count>.
 
     my @array;
-    say (1 .. Inf).iterator.push-exactly(@array, 3); # 3
+    say (1 .. Inf).iterator.push-exactly(@array, 3); # OUTPUT: «3␤»
     say @array; # [1 2 3]
 
 =head2 method push-at-least
@@ -81,7 +81,7 @@ iterators without side effects (such as L<Range|/type/Range> iterators) can
 produce more elements to achieve better performance.
 
     my @array;
-    say (1 .. Inf).iterator.push-at-least(@array, 10); # 10
+    say (1 .. Inf).iterator.push-at-least(@array, 10); # OUTPUT: «10␤»
     say @array; # [1 2 3 4 5 6 7 8 9 10]
 
 =head2 method push-all
@@ -122,8 +122,8 @@ otherwise.
 Built-in operations that know that they can produce infinitely many values
 return C<True> here, for example C<(1..6).roll(*)>.
 
-    say (1 .. 100).is-lazy; # False
-    say (1 .. Inf).is-lazy; # True
+    say (1 .. 100).is-lazy; # OUTPUT: «False␤»
+    say (1 .. Inf).is-lazy; # OUTPUT: «True␤»
 
 =head2 method sink-all
 

--- a/doc/Type/Junction.pod6
+++ b/doc/Type/Junction.pod6
@@ -61,7 +61,7 @@ Usage examples:
         so $x %% none(2..$x.sqrt);
     }
     my @primes_ending_in_1 = grep &is_prime & / 1$ /, 2..100;
-    say @primes_ending_in_1;        # [11 31 41 61 71]
+    say @primes_ending_in_1;        # OUTPUT: «[11 31 41 61 71]␤»
 
     my @exclude = <~ .git>;
     for dir(".") { say .Str if .Str.ends-with(none @exclude) }
@@ -75,7 +75,7 @@ produce an empty list:
 To express "all, but at least one", you can use C<@a && all(@a)>
 
     my @a = ();
-    say so @a && all(@a);   # False
+    say so @a && all(@a);   # OUTPUT: «False␤»
 
 Negated operators are special-cased when it comes to autothreading.
 C<$a !op $b> is rewritten internally as C<!($a op $b)>. The outer

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -18,7 +18,7 @@ for @users -> $u {
     }
     say "None of {$u}'s pets barks";
 }
-say USERS.^name;        # Label
+say USERS.^name;        # OUTPUT: «Label␤»
 =end code
 
 Those label are objects of type C<Label>.

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -54,15 +54,15 @@ The same flattening behavior applies all objects that do the
 L<Iterable|/type/Iterable> role, notable L<hashes|/type/Hash>:
 
     my %h = a => 1, b => 2;
-    my @b = %h;   say @b.elems;     # 2
-    my @c = %h, ; say @c.elems;     # 1
-    my @d = $%h;  say @d.elems;     # 1
+    my @b = %h;   say @b.elems;     # OUTPUT: «2␤»
+    my @c = %h, ; say @c.elems;     # OUTPUT: «1␤»
+    my @d = $%h;  say @d.elems;     # OUTPUT: «1␤»
 
 Slurpy parameters (C<*@a>) flatten non-itemized sublists:
 
     sub fe(*@flat) { @flat.elems }
-    say fe(<a b>, <d e>);           # 4
-    say fe(<a b>, <d e>.item);      # 3
+    say fe(<a b>, <d e>);           # OUTPUT: «4␤»
+    say fe(<a b>, <d e>.item);      # OUTPUT: «3␤»
 
 X<|(),empty list>
 The empty list is created with C<()>. Smartmatching against the empty list will
@@ -77,11 +77,10 @@ check for the absence of elements.
 Coercion to Bool also indicates if the List got any elements.
 
     my @a;
-    say [@a.elems, @a.Bool, ?@a];
+    say [@a.elems, @a.Bool, ?@a]; # OUTPUT: «[0 False False]␤»
     @a.push: 42;
-    say [@a.elems, @a.Bool, ?@a];
-    say 'empty' unless @a;
-    # OUTPUT«[0 False False]␤[1 True True]␤»
+    say [@a.elems, @a.Bool, ?@a]; # OUTPUT: «[1 True True]␤»
+    say 'empty' unless @a;        # OUTPUT: «()␤»
 
 =head1 Methods
 
@@ -94,7 +93,7 @@ Defined as:
 
 Returns the number of elements in the list.
 
-    say (1,2,3,4).elems; # 4
+    say (1,2,3,4).elems; # OUTPUT: «4␤»
 
 =head2 routine end
 
@@ -105,7 +104,7 @@ Defined as:
 
 Returns the index of the last element.
 
-    say (1,2,3,4).end; # 3
+    say (1,2,3,4).end; # OUTPUT: «3␤»
 
 =head2 routine keys
 
@@ -116,7 +115,7 @@ Defined as:
 
 Returns a sequence of indexes into the list (e.g., 0..(@list.elems-1)).
 
-    say (1,2,3,4).keys; # 0..3
+    say (1,2,3,4).keys; # OUTPUT: «0..3␤»
 
 =head2 routine values
 
@@ -127,8 +126,8 @@ Defined as:
 
 Returns a sequence of the list elements, in order.
 
-    say (1,2,3,4).WHAT;        # (List)
-    say (1,2,3,4).values.WHAT; # (Seq)
+    say (1,2,3,4).WHAT;        # OUTPUT: «(List)␤»
+    say (1,2,3,4).values.WHAT; # OUTPUT: «(Seq)␤»
 
 =head2 routine kv
 
@@ -162,7 +161,7 @@ Defined as:
 Returns a L<Seq|/type/Seq> of pairs, with the values as keys and the indexes as
 values, i.e. the direct opposite to L<pairs|/type/List#routine_pairs>.
 
-    say <a b c>.antipairs;  # (a => 0 b => 1 c => 2)
+    say <a b c>.antipairs;  # OUTPUT: «(a => 0 b => 1 c => 2)␤»
 
 =head2 routine join
 
@@ -176,11 +175,11 @@ C<$separator> and concatenates everything into a single string.
 
 Example:
 
-    join ', ', <a b c>;             # a, b, c
+    join ', ', <a b c>;             # RESULT: «a, b, c»
 
 Note that the method form does not flatten sublists:
 
-    say (1, <a b c>).join('|');     # 1|a b c
+    say (1, <a b c>).join('|');     # OUTPUT: «1|a b c␤»
 
 =head2 routine map
 
@@ -193,14 +192,14 @@ Invokes C<&code> for each element and gathers the return values in a sequence
     and returns it. This happens lazily, i.e. C<&code> is only invoked when the
 return values are accessed.Examples:
 
-    say ('hello', 1, 22/7, 42, 'world').map: { .WHAT.perl } # (Str Int Rat Int Str)
-    say map *.Str.chars, 'hello', 1, 22/7, 42, 'world';     # (5 1 8 2 5)
+    say ('hello', 1, 22/7, 42, 'world').map: { .WHAT.perl } # OUTPUT: «(Str Int Rat Int Str)␤»
+    say map *.Str.chars, 'hello', 1, 22/7, 42, 'world';     # OUTPUT: «(5 1 8 2 5)␤»
 
 C<map> inspects the arity of the code object, and tries to pass as many
 arguments to it as expected:
 
     sub b($a, $b) { "$a before $b" };
-    say <a b x y>.map(&b).join(', ');   # a before b, x before y
+    say <a b x y>.map(&b).join(', ');   # OUTPUT: «a before b, x before y␤»
 
 iterates the list two items at a time.
 
@@ -229,7 +228,7 @@ the context of that C<Routine>.
         say 'oi‽' # dead code
     };
     s
-    # OUTPUT«hi␤»
+    # RESULT: «hi»
 
 =head2 sub flat
 
@@ -241,7 +240,7 @@ Constructs a list which contains any arguments provided in the order
 provided, and returns the result of calling the C<.flat> method (L<inherited
 from C<Any>|/type/Any#method_flat>) on that list:
 
-    say flat 1, (2, (3, 4), $(5, 6)); # (1 2 3 4 (5 6))
+    say flat 1, (2, (3, 4), $(5, 6)); # OUTPUT: «(1 2 3 4 (5 6))␤»
 
 =head2 method flatmap
 
@@ -255,7 +254,7 @@ these invocations in a result list.
 
 Unlike C<map> it flattens non-itemized lists and arrays, so
 
-    say ((1, 2), <a b>).flatmap(&uc).join('|');     # 1 2|A B
+    say ((1, 2), <a b>).flatmap(&uc).join('|');     # OUTPUT: «1 2|A B␤»
 
 invokes L<uc|/type/Str#routine_uc> four times.
 
@@ -272,8 +271,8 @@ list.
 
 Examples:
 
-    say ('hello', 1, 22/7, 42, 'world').grep: Int;              # (1 42)
-    say grep { .Str.chars > 3 }, 'hello', 1, 22/7, 42, 'world'; # (hello 3.142857 world)
+    say ('hello', 1, 22/7, 42, 'world').grep: Int;              # OUTPUT: «(1 42)␤»
+    say grep { .Str.chars > 3 }, 'hello', 1, 22/7, 42, 'world'; # OUTPUT: «(hello 3.142857 world)␤»
 
 The optional named parameters C<:k>, C<:kv>, C<:p>, C<:v> provide the same
 functionality as on slices:
@@ -297,9 +296,12 @@ at all).
 
 Examples:
 
-    say ('hello', 1, 22/7, 42, 'world').grep: Int, :k; # (1 3)
-    say grep { .Str.chars > 3 }, :kv, 'hello', 1, 22/7, 42, 'world'; # (0 hello 2 3.142857 4 world)
-    say grep { .Str.chars > 3 }, :p, 'hello', 1, 22/7, 42, 'world'; # (0 => hello 2 => 3.142857 4 => world)
+    say ('hello', 1, 22/7, 42, 'world').grep: Int, :k;
+    # OUTPUT: «(1 3)␤»
+    say grep { .Str.chars > 3 }, :kv, 'hello', 1, 22/7, 42, 'world';
+    # OUTPUT: «(0 hello 2 3.142857 4 world)␤»
+    say grep { .Str.chars > 3 }, :p, 'hello', 1, 22/7, 42, 'world';
+    # OUTPUT: «(0 => hello 2 => 3.142857 4 => world)␤»
 
 =head2 routine first
 
@@ -315,9 +317,9 @@ from the start.
 
 Examples:
 
-    say (1, 22/7, 42, 300).first: * > 5;                  # 42
-    say (1, 22/7, 42, 300).first: * > 5, :end;            # 300
-    say ('hello', 1, 22/7, 42, 'world').first: Complex;   # Nil
+    say (1, 22/7, 42, 300).first: * > 5;                  # OUTPUT: «42␤»
+    say (1, 22/7, 42, 300).first: * > 5, :end;            # OUTPUT: «300␤»
+    say ('hello', 1, 22/7, 42, 'world').first: Complex;   # OUTPUT: «Nil␤»
 
 The optional named parameters C<:k>, C<:kv>, C<:p> provide the same
 functionality as on slices:
@@ -338,9 +340,9 @@ Return the index and the matched element as a C<Pair>.
 
 Examples:
 
-    say (1, 22/7, 42, 300).first: * > 5, :k;        # 2
-    say (1, 22/7, 42, 300).first: * > 5, :p;        # 2 => 42
-    say (1, 22/7, 42, 300).first: * > 5, :kv, :end; # (3 300)
+    say (1, 22/7, 42, 300).first: * > 5, :k;        # OUTPUT: «2␤»
+    say (1, 22/7, 42, 300).first: * > 5, :p;        # OUTPUT: «2 => 42␤»
+    say (1, 22/7, 42, 300).first: * > 5, :kv, :end; # OUTPUT: «(3 300)␤»
 
 In method form, the C<$matcher> can be omitted, in which case the first
 available item (or last if C<:end> is set) will be returned. See also
@@ -357,10 +359,10 @@ NUMBER <= 0.  Defaults to the first element seen if no NUMBER specified.
 
 Examples:
 
-    say ^10 .head(5);      # (0 1 2 3 4)
-    say ^Inf .head(5);     # (0 1 2 3 4)
-    say ^10 .head;         # (0)
-    say ^Inf .head;         # (0)
+    say ^10 .head(5);      # OUTPUT: «(0 1 2 3 4)␤»
+    say ^Inf .head(5);     # OUTPUT: «(0 1 2 3 4)␤»
+    say ^10 .head;         # OUTPUT: «(0)␤»
+    say ^Inf .head;        # OUTPUT: «(0)␤»
 
 =head2 method tail
 
@@ -375,10 +377,10 @@ Throws an exception if the list is lazy.
 Examples:
 
 =for code :skip-test
-say ^10 .tail(5)      # (5 6 7 8 9)
-say ^Inf .tail(5)     # Cannot tail a lazy list
-say ^10 .tail         # (9)
-say ^Inf .tail        # Cannot tail a lazy list
+say ^10 .tail(5);      # OUTPUT: «(5 6 7 8 9)␤»
+say ^Inf .tail(5);     # Cannot tail a lazy list
+say ^10 .tail;         # OUTPUT: «(9)␤»
+say ^Inf .tail;        # Cannot tail a lazy list
 
 =head2 routine categorize
 
@@ -404,8 +406,8 @@ Example:
         $i %% 2 ?? 'even' !! 'odd',
         $i.is-prime ?? 'prime' !! 'not prime'
     }
-    say categorize &mapper, (1, 7, 6, 3, 2);   # {even => [6 2], not prime => [1 6],
-                                               #  odd => [1 7 3], prime => [7 3 2]}
+    say categorize &mapper, (1, 7, 6, 3, 2);   # OUTPUT: «{even => [6 2], not prime => [1 6],
+                                               #          odd => [1 7 3], prime => [7 3 2]}␤»
 
 =head2 routine classify
 
@@ -424,9 +426,9 @@ of the associated key.
 Example:
 
     say classify { $_ %% 2 ?? 'even' !! 'odd' }, (1, 7, 6, 3, 2);
-        # {even => [6 2], odd => [1 7 3]}
+    # OUTPUT: «{even => [6 2], odd => [1 7 3]}␤»
     say ('hello', 1, 22/7, 42, 'world').classify: { .Str.chars };
-        # {1 => [1], 2 => [42], 5 => [hello world], 8 => [3.142857]}
+    # OUTPUT: «{1 => [1], 2 => [42], 5 => [hello world], 8 => [3.142857]}␤»
 
 =head2 method Bool
 
@@ -437,8 +439,8 @@ Defined as:
 Returns C<True> if the list has at least one element, and C<False>
 for the empty list.
 
-    say ().Bool;  # False
-    say (1).Bool; # True
+    say ().Bool;  # OUTPUT: «False␤»
+    say (1).Bool; # OUTPUT: «True␤»
 
 =head2 method Str
 
@@ -449,7 +451,7 @@ Defined as:
 Stringifies the elements of the list and joins them with spaces
 (same as C<.join(' ')>).
 
-    say (1,2,3,4,5).Str; # 1 2 3 4 5
+    say (1,2,3,4,5).Str; # OUTPUT: «1 2 3 4 5␤»
 
 =head2 method Int
 
@@ -459,7 +461,7 @@ Defined as:
 
 Returns the number of elements in the list (same as C<.elems>).
 
-    say (1,2,3,4,5).Int; # 5
+    say (1,2,3,4,5).Int; # OUTPUT: «5␤»
 
 =head2 method Numeric
 
@@ -469,7 +471,7 @@ Defined as:
 
 Returns the number of elements in the list (same as C<.elems>).
 
-    say (1,2,3,4,5).Numeric; # 5
+    say (1,2,3,4,5).Numeric; # OUTPUT: «5␤»
 
 =head2 method Capture
 
@@ -486,8 +488,8 @@ argument, getting index C<1> etc.
 
     my $list = (7, 5, a => 2, b => 17);
     my $capture = $list.Capture;
-    say $capture.keys;                                # (0 1 a b)
-    my-sub(|$capture);                                # 7, 5, 2, 17
+    say $capture.keys;                                # OUTPUT: «(0 1 a b)␤»
+    my-sub(|$capture);                                # RESULT: «7, 5, 2, 17»
 
     sub my-sub($first, $second, :$a, :$b) {
         say "$first, $second, $a, $b"
@@ -497,10 +499,10 @@ A more advanced example demonstrating the returned C<Capture> being matched
 against a L<Signature|/type/Signature>.
 
     my $list = (7, 5, a => 2, b => 17);
-    say so $list.Capture ~~ :($ where * == 7,$,:$a,:$b); # True
+    say so $list.Capture ~~ :($ where * == 7,$,:$a,:$b); # OUTPUT: «True␤»
 
     $list = (8, 5, a => 2, b => 17);
-    say so $list.Capture ~~ :($ where * == 7,$,:$a,:$b); # False
+    say so $list.Capture ~~ :($ where * == 7,$,:$a,:$b); # OUTPUT: «False␤»
 
 =head2 routine pick
 
@@ -520,9 +522,9 @@ Nil if the list is empty
 
 Examples:
 
-    say <a b c d e>.pick;           # b
-    say <a b c d e>.pick: 3;        # (c a e)
-    say  <a b c d e>.pick: *;       # (e d a b c)
+    say <a b c d e>.pick;           # OUTPUT: «b␤»
+    say <a b c d e>.pick: 3;        # OUTPUT: «(c a e)␤»
+    say  <a b c d e>.pick: *;       # OUTPUT: «(e d a b c)␤»
 
 =head2 routine roll
 
@@ -542,12 +544,12 @@ Nil if the list is empty
 
 Examples:
 
-    say <a b c d e>.roll;       # b
-    say <a b c d e>.roll: 3;    # (c c e)
-    say roll 8, <a b c d e>;    # (b a e d a e b c)
+    say <a b c d e>.roll;       # 1 random letter
+    say <a b c d e>.roll: 3;    # 3 random letters
+    say roll 8, <a b c d e>;    # 8 random letters
 
     my $random-digits := (^10).roll(*);
-    say $random-digits[^15];    # (3 8 7 6 0 1 3 2 0 8 8 5 8 0 5)
+    say $random-digits[^15];    # 15 random digits
 
 =head2 routine eager
 
@@ -558,7 +560,7 @@ Defined as:
 
 Evaluates all elements in the list eagerly, and returns them as a list.
 
-    say (1,2,3,4,5).eager; # 1 2 3 4 5
+    say (1,2,3,4,5).eager; # OUTPUT: «1 2 3 4 5␤»
 
 =head2 routine reverse
 
@@ -574,8 +576,8 @@ to reverse the characters in a string, use L<flip>.
 
 Examples:
 
-    say <hello world!>.reverse;     # (world! hello)
-    say reverse ^10;                # (9 8 7 6 5 4 3 2 1 0)
+    say <hello world!>.reverse;     # OUTPUT: «(world! hello)␤»
+    say reverse ^10;                # OUTPUT: «(9 8 7 6 5 4 3 2 1 0)␤»
 
 =head2 routine rotate
 
@@ -613,9 +615,9 @@ cached, so that C<&by> is only called once per list element.
 
 Examples:
 
-    say (3, -4, 7, -1, 2, 0).sort;                  # (-4 -1 0 2 3 7)
-    say (3, -4, 7, -1, 2, 0).sort: *.abs;           # (0 -1 2 3 -4 7)
-    say (3, -4, 7, -1, 2, 0).sort: { $^b leg $^a }; # (7 3 2 0 -4 -1)
+    say (3, -4, 7, -1, 2, 0).sort;                  # OUTPUT: «(-4 -1 0 2 3 7)␤»
+    say (3, -4, 7, -1, 2, 0).sort: *.abs;           # OUTPUT: «(0 -1 2 3 -4 7)␤»
+    say (3, -4, 7, -1, 2, 0).sort: { $^b leg $^a }; # OUTPUT: «(7 3 2 0 -4 -1)␤»
 
 =head2 routine unique
 
@@ -633,8 +635,8 @@ even as duplicates are removed.
 
 Examples:
 
-    say <a a b b b c c>.unique;   # (a b c)
-    say <a b b c c b a>.unique;   # (a b c)
+    say <a a b b b c c>.unique;   # OUTPUT: «(a b c)␤»
+    say <a b b c c b a>.unique;   # OUTPUT: «(a b c)␤»
 
 (Use L<C<squish>> instead if you know the input is sorted such that identical
 objects are adjacent.)
@@ -645,7 +647,7 @@ but it's still the original values that make it to the result list:
 
 Example:
 
-    say <a A B b c b C>.unique(:as(&lc))          # (a B c)
+    say <a A B b c b C>.unique(:as(&lc))          # OUTPUT: «(a B c)␤»
 
 One can also specify the comparator with the optional C<:with> parameter.  For
 instance if one wants a list of unique hashes, one could use the C<eqv>
@@ -654,7 +656,7 @@ comparator.
 Example:
 
     my @list = {a => 42}, {b => 13}, {a => 42};
-    say @list.unique(:with(&[eqv]))               # ({a => 42} {b => 13})
+    say @list.unique(:with(&[eqv]))               # OUTPUT: «({a => 42} {b => 13})␤»
 
 =head2 routine repeated
 
@@ -670,12 +672,12 @@ as they're seen for the second time (or more).
 
 Examples:
 
-    say <a a b b b c c>.repeated;                   # (a b b c)
-    say <a b b c c b a>.repeated;                   # (b c b a)
-    say <a A B b c b C>.repeated(:as(&lc));         # (A b b C)
+    say <a a b b b c c>.repeated;                   # OUTPUT: «(a b b c)␤»
+    say <a b b c c b a>.repeated;                   # OUTPUT: «(b c b a)␤»
+    say <a A B b c b C>.repeated(:as(&lc));         # OUTPUT: «(A b b C)␤»
 
     my @list = {a => 42}, {b => 13}, {a => 42};
-    say @list.repeated(:with(&[eqv]))               # ({a => 42})
+    say @list.repeated(:with(&[eqv]))               # OUTPUT: «({a => 42})␤»
 
 =head2 routine squish
 
@@ -694,8 +696,8 @@ are removed.
 
 Examples:
 
-    say <a a b b b c c>.squish; # (a b c)
-    say <a b b c c b a>.squish; # (a b c b a)
+    say <a a b b b c c>.squish; # OUTPUT: «(a b c)␤»
+    say <a b b c c b a>.squish; # OUTPUT: «(a b c b a)␤»
 
 The optional C<:as> parameter, just like with L<C<unique>>, allows values to be
 temporarily transformed before comparison.
@@ -727,14 +729,14 @@ C<(VAL1, VAL2, VAL3).reduce(&[OP])> is the same as C<VAL1 OP VAL2 OP VAL3> even
 for operators which aren't left-associative:
 
     # Raise 2 to the 81st power, because 3 to the 4th power is 81
-    [2,3,4].reduce(&[**]).lsb.say;        # 81
-    (2**(3**4)).lsb.say;                  # 81
-    (2**3**4).lsb.say;                    # 81
+    [2,3,4].reduce(&[**]).lsb.say;        # OUTPUT: «81␤»
+    (2**(3**4)).lsb.say;                  # OUTPUT: «81␤»
+    (2**3**4).lsb.say;                    # OUTPUT: «81␤»
 
     # Subtract 4 from -1, because 2 minus 3 is -1
-    [2,3,4].reduce(&[-]).say;             # -5
-    ((2-3)-4).say;                        # -5
-    (2-3-4).say;                          # -5
+    [2,3,4].reduce(&[-]).say;             # OUTPUT: «-5␤»
+    ((2-3)-4).say;                        # OUTPUT: «-5␤»
+    (2-3-4).say;                          # OUTPUT: «-5␤»
 
 Since reducing with an infix operator is a common thing to do, the C<[ ]>
 meta-operator provides a syntactic shortcut:
@@ -789,14 +791,14 @@ C<(VAL1, VAL2, VAL3).produce(&[OP])> is the same as C<VAL1 OP VAL2 OP VAL3> even
 for operators which aren't left-associative:
 
     # Raise 2 to the 81st power, because 3 to the 4th power is 81
-    [2,3,4].produce(&[**]).say;        # (4 81 2417851639229258349412352)
-    say produce &[**], (2,3,4);        # (4 81 2417851639229258349412352)
-    say [\**] (2,3,4);                 # (4 81 2417851639229258349412352)
+    [2,3,4].produce(&[**]).say;        # OUTPUT: «(4 81 2417851639229258349412352)␤»
+    say produce &[**], (2,3,4);        # OUTPUT: «(4 81 2417851639229258349412352)␤»
+    say [\**] (2,3,4);                 # OUTPUT: «(4 81 2417851639229258349412352)␤»
 
     # Subtract 4 from -1, because 2 minus 3 is -1
-    [2,3,4].produce(&[-]).say;         # (2 -1 -5)
-    say produce &[-], (2,3,4);         # (2 -1 -5)
-    say [\-] (2,3,4);                  # (2 -1 -5)
+    [2,3,4].produce(&[-]).say;         # OUTPUT: «(2 -1 -5)␤»
+    say produce &[-], (2,3,4);         # OUTPUT: «(2 -1 -5)␤»
+    say [\-] (2,3,4);                  # OUTPUT: «(2 -1 -5)␤»
 
 A triangle meta-operator C<[\ ]> provides a syntactic shortcut for
 producing with an infix operator:
@@ -823,7 +825,7 @@ triangular list of of lists, you can use a "triangular comma":
 Since C<produce> is an implicit loop, it responds to C<next>, C<last> and
 C<redo> statements inside C<&with>:
 
-    say (2,3,4,5).produce: { last if $^a > 7; $^a + $^b }; # says (2 5 9)
+    say (2,3,4,5).produce: { last if $^a > 7; $^a + $^b }; # OUTPUT: «(2 5 9)␤»
 
 =head2 routine combinations
 
@@ -837,9 +839,9 @@ The C<Int> variant returns all C<$of>-combinations of the invocant list.
 For example
 
     say .join('|') for <a b c>.combinations(2);
-    # a|b
-    # a|c
-    # b|c
+    # OUTPUT: «a|b␤
+    # a|c␤
+    # b|c␤»
 
 because all the 2-combinations of C<'a', 'b', 'c'> are
 C<['a', 'b'], ['a', 'c'], ['b', 'c']>.
@@ -848,10 +850,10 @@ The C<Range> variant combines all the individual combinations into a single
 list, so
 
     say .join('|') for <a b c>.combinations(2..3);
-    # a|b
-    # a|c
-    # b|c
-    # a|b|c
+    # OUTPUT: «a|b
+    # a|c␤
+    # b|c␤
+    # a|b|c␤»
 
 because that's the list of all 2- and 3-combinations.
 
@@ -859,12 +861,12 @@ The subroutine form C<combinations($n, $k)> is equivalent to
 C<(^$n).combinations($k)>, so
 
     .say for combinations(4, 2)
-    # 0 1
-    # 0 2
-    # 0 3
-    # 1 2
-    # 1 3
-    # 2 3
+    # OUTPUT: «0 1
+    # 0 2␤
+    # 0 3␤
+    # 1 2␤
+    # 1 3␤
+    # 2 3␤»
 
 If C<$k> is negative or is larger than there are items in the given list, an
 empty list will be returned. If C<$k> is zero, a 1-item list containing an empty
@@ -883,12 +885,12 @@ Defined as:
 Returns all possible permutations of a list as a sequence of lists. So
 
     say .join('|') for <a b c>.permutations
-    # a|b|c
-    # a|c|b
-    # b|a|c
-    # b|c|a
-    # c|a|b
-    # c|b|a
+    # OUTPUT: «a|b|c␤
+    # a|c|b␤
+    # b|a|c␤
+    # b|c|a␤
+    # c|a|b␤
+    # c|b|a␤»
 
 C<permutations> treats all list elements as distinguishable, so
 C<(1, 1, 2).permutations> still returns a list of 6 elements, even though
@@ -898,12 +900,12 @@ The subroutine form C<permutations($n)> is equivalent to
 C<(^$n).permutations>, so
 
     .say for permutations 3;
-    # 0 1 2
-    # 0 2 1
-    # 1 0 2
-    # 1 2 0
-    # 2 0 1
-    # 2 1 0
+    # OUTPUT: «0 1 2␤
+    # 0 2 1␤
+    # 1 0 2␤
+    # 1 2 0␤
+    # 2 0 1␤
+    # 2 1 0␤»
 
 =head2 method rotor
 
@@ -919,26 +921,26 @@ invocant list is split into sublists with as many elements as the integer
 specifies. If C<:$partial> is True, the final chunk is included even if it
 doesn't satisfy the length requirement:
 
-    say ('a'..'h').rotor(3).join('|');              # a b c|d e f
-    say ('a'..'h').rotor(3, :partial).join('|');    # a b c|d e f|g h
+    say ('a'..'h').rotor(3).join('|');              # OUTPUT: «a b c|d e f␤»
+    say ('a'..'h').rotor(3, :partial).join('|');    # OUTPUT: «a b c|d e f|g h␤»
 
 If the element of C<@cycle> is a L<Pair|/type/Pair> instead, the key of the
 pair specifies the length of the return sublist, and the value the gap between
 sublists; negative gaps produce overlap:
 
-    say ('a'..'h').rotor(2 => 1).join('|');         # a b|d e|g h
-    say ('a'..'h').rotor(3 => -1).join('|');        # a b c|c d e|e f g
+    say ('a'..'h').rotor(2 => 1).join('|');         # OUTPUT: «a b|d e|g h␤»
+    say ('a'..'h').rotor(3 => -1).join('|');        # OUTPUT: «a b c|c d e|e f g␤»
 
 If C<@cycle> contains more than element, C<rotor> cycles through it to find
 the number of elements for each sublist:
 
-    say ('a'..'h').rotor(2, 3).join('|');           # a b|c d e|f g
-    say ('a'..'h').rotor(1 => 1, 3).join('|');      # a|c d e|f
+    say ('a'..'h').rotor(2, 3).join('|');           # OUTPUT: «a b|c d e|f g␤»
+    say ('a'..'h').rotor(1 => 1, 3).join('|');      # OUTPUT: «a|c d e|f␤»
 
 Combining multiple cycles and C<:partial> also works:
 
     say ('a'..'h').rotor(1 => 1, 3 => -1, :partial).join('|');
-                                                    # a|c d e|e|g h
+    # OUTPUT: «a|c d e|e|g h␤»
 
 See L<this blog post for more elaboration on rotor|http://perl6.party/post/Perl-6-.rotor-The-King-of-List-Manipulation>.
 
@@ -952,7 +954,7 @@ from the first iterable, the second is from the second given iterable, etc.
 Every item will be paired with every other item in all the other lists.
 
     say cross(<a b c>, <d e f>).map(*.join).join(",")
-    # ad,ae,af,bd,be,bf,cd,ce,cf
+    # OUTPUT: «ad,ae,af,bd,be,bf,cd,ce,cf␤»
 
 The C<cross> routine has an infix synonym as well, named C<X>.
 
@@ -963,7 +965,7 @@ If the optional C<with> parameter is passed, it is used as a reduction operation
 to apply to each of the cross product items.
 
     say cross([1, 2, 3], [4, 5, 6], :with(&infix:<*>)).join(",");
-    # 4,5,6,8,10,12,12,15,18
+    # OUTPUT: «4,5,6,8,10,12,12,15,18␤»
 
 The C<X> operator can be combined with another operator as a meta-operator to perform a reduction as well:
 
@@ -984,20 +986,21 @@ together, so that elements are grouped according to their input list index, in
 the order that the lists are provided.
 
     say zip(<a b c>, <d e f>, <g h i>);
-    # ((a d g) (b e h) (c f i))
+    # OUTPUT: «((a d g) (b e h) (c f i))␤»
 
 C<zip> has an infix synonym, the C<Z> operator.
 
     say <a b c> Z <d e f> Z <g h i>;                   # same output
 
+
 C<zip> can provide input to a for loop :
 
     for <a b c> Z <d e f> Z <g h i> -> [$x,$y,$z] {say ($x,$y,$z).join(",")}
-    # a,d,g
-    # b,e,h
-    # c,f,i
+    # OUTPUT: «a,d,g␤
+    # b,e,h␤
+    # c,f,i␤»
 
-, or more succinctly :
+, or more succinctly:
 
     say .join(",") for zip <a b c>, <d e f>, <g h i>;  # same output
 
@@ -1016,9 +1019,9 @@ example, the following multiplies corresponding elements together to return a
 single list of products.
 
     .say for zip <1 2 3>, [1, 2, 3], (1, 2, 3), :with(&infix:<*>);
-    # 1
-    # 8
-    # 27
+    # OUTPUT: «1␤
+    # 8␤
+    # 27␤»
 
 The C<Z> form can also be used to perform reduction by implicitly setting the
 C<with> parameter with a meta-operator :
@@ -1037,23 +1040,23 @@ that of L<zip|/type/List#routine_zip>, except when the input lists have an
 unequal number of elements.
 
     say roundrobin <a b c>, <d e f>, <g h i>;
-    # ((a d g) (b e h) (c f i))
+    # OUTPUT: «((a d g) (b e h) (c f i))␤»
 
     say .join(",") for roundrobin([1, 2], [2, 3], [3, 4]);
-    # 1,2,3
-    # 2,3,4
+    # OUTPUT: «1,2,3␤
+    # 2,3,4␤»
 
 C<roundrobin> does not terminate once one or more of the input lists become
 exhausted, but proceeds until all elements from all lists have been processed.
 
     say roundrobin <a b c>, <d e f m n o p>, <g h i j>;
-    # ((a d g) (b e h) (c f i) (m j) (n) (o) (p))
+    # OUTPUT: «((a d g) (b e h) (c f i) (m j) (n) (o) (p))␤»
 
     say .join(",") for roundrobin([1, 2], [2, 3, 57, 77], [3, 4, 102]);
-    # 1,2,3
-    # 2,3,4
-    # 57,102
-    # 77
+    # OUTPUT: «1,2,3␤
+    # 2,3,4␤
+    # 57,102␤
+    # 77␤»
 
 Therefore no data values are lost due in the 'zipping' operation. A record of
 which input list provided which element cannot be gleaned from the resulting
@@ -1072,9 +1075,9 @@ Defined as:
 Returns the sum of all elements in the list or 0 if the list is empty.
 Throws an exception if an element can not be coerced into Numeric.
 
-    say (1, 3, pi).sum;       # 7.14159265358979
-    say (1, "0xff").sum;      # 256
-    say sum(0b1111, 5);       # 20
+    say (1, 3, pi).sum;       # OUTPUT: «7.14159265358979␤»
+    say (1, "0xff").sum;      # OUTPUT: «256␤»
+    say sum(0b1111, 5);       # OUTPUT: «20␤»
 
 =head2 method fmt
 
@@ -1088,7 +1091,7 @@ to C<$format> and where each element is separated by C<$separator>.
 For more information about formats strings, see L<sprintf|/routine/sprintf>.
 
     my @a = 8..11;
-    say @a.fmt('%03d', ',');  # 008,009,010,011
+    say @a.fmt('%03d', ',');  # OUTPUT: «008,009,010,011␤»
 
 =head2 method from
 
@@ -1096,15 +1099,15 @@ Assumes the list contains L«C<Match> objects|/type/Match» and returns the
 value of C<.from> called on the first element of the list.
 
     'abcdefg' ~~ /(c)(d)/;
-    say $/.list.from;         # 2
+    say $/.list.from;         # OUTPUT: «2␤»
 
     "abc123def" ~~ m:g/\d/;
-    say $/.list.from;         # 3
+    say $/.list.from;         # OUTPUT: «3␤»
 
 =head2 method to
 
     "abc123def" ~~ m:g/\d/;
-    say $/.to; # 6
+    say $/.to; # OUTPUT: «6␤»
 
 Assumes the C<List> contains L«C<Match> objects|/type/Match», such as the
 C<$/> variable being a C<List>, when using C<:g> modifier in regexes. Returns the

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -17,7 +17,7 @@ I<critical section>).
             $l.protect({ $x++ });
         }
     }
-    say $x;         # 10
+    say $x;         # OUTPUT: «10␤»
 
 Locks are re-entrant, that is, a thread that holds the lock can lock it again
 without blocking.

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -38,10 +38,10 @@ parentheses around all the arguments.
     my %h = Map.new('a', 1, 'b', 2);
 
     # WRONG: :b(2) interpreted as named argument
-    say Map.new('a', 1, :b(2) ).keys; # (a)
+    say Map.new('a', 1, :b(2) ).keys; # OUTPUT: «(a)␤»
 
     # RIGHT: :b(2) interpreted as part of Map's contents
-    say Map.new( ('a', 1, :b(2)) ).keys; # (a b)
+    say Map.new( ('a', 1, :b(2)) ).keys; # OUTPUT: «(a b)␤»
 
 =head2 method elems
 
@@ -52,7 +52,7 @@ Defined as:
 Returns the number of pairs stored in the Map.
 
     my %map = Map.new('a', 1, 'b', 2);
-    say %map.elems; # 2
+    say %map.elems; # OUTPUT: «2␤»
 
 =head2 method ACCEPTS
 
@@ -81,7 +81,7 @@ To retrieve a value from the Map by key, use the C<{ }> postcircumfix
 operator:
 
     my $map = Map.new('a', 1, 'b', 2);
-    say $map{'a'}; # 1
+    say $map{'a'}; # OUTPUT: «1␤»
 
 To check whether a given key is stored in a Map, modify the access
 with the C<:exists> adverb:
@@ -101,7 +101,7 @@ Defined as:
 Returns a list of all keys in the Map.
 
     my $m = Map.new('a' => (2, 3), 'b' => 17);
-    say $m.keys; # (a b)
+    say $m.keys; # OUTPUT: «(a b)␤»
 
 =head2 method values
 
@@ -112,7 +112,7 @@ Defined as:
 Returns a list of all values in the Map.
 
     my $m = Map.new('a' => (2, 3), 'b' => 17);
-    say $m.values; # ((2 3) 17)
+    say $m.values; # OUTPUT: «((2 3) 17)␤»
 
 =head2 method pairs
 
@@ -123,7 +123,7 @@ Defined as:
 Returns a list of all pairs in the Map.
 
     my $m = Map.new('a' => (2, 3), 'b' => 17);
-    say $m.pairs; # (a => (2 3) b => 17)
+    say $m.pairs; # OUTPUT: «(a => (2 3) b => 17)␤»
 
 =head2 method antipairs
 
@@ -137,7 +137,7 @@ L<pairs|#method_pairs>. Unlike the L<invert|#method_invert> method, there is
 no attempt to expand list values into multiple pairs.
 
     my $m = Map.new('a' => (2, 3), 'b' => 17);
-    say $m.antipairs;                                  # ((2 3) => a 17 => b)
+    say $m.antipairs;                                  # OUTPUT: «((2 3) => a 17 => b)␤»
 
 =head2 method invert
 
@@ -151,7 +151,7 @@ and L<antipairs|#method_antipairs> is that C<invert> expands list values into
 multiple pairs.
 
     my $m = Map.new('a' => (2, 3), 'b' => 17);
-    say $m.invert;                                    # (2 => a 3 => a 17 => b)
+    say $m.invert;                                    # OUTPUT: «(2 => a 3 => a 17 => b)␤»
 
 =head2 method kv
 
@@ -172,7 +172,7 @@ Defined as:
 Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
     my $m = Map.new('a' => 2, 'b' => 17);
-    say $m.Int;                                       # 2
+    say $m.Int;                                       # OUTPUT: «2␤»
 
 =head2 method Numeric
 
@@ -183,7 +183,7 @@ Defined as:
 Returns the number of pairs stored in the C<Map> (same as C<.elems>).
 
     my $m = Map.new('a' => 2, 'b' => 17);
-    say $m.Numeric;                                   # 2
+    say $m.Numeric;                                   # OUTPUT: «2␤»
 
 =head2 method Bool
 
@@ -194,7 +194,7 @@ Defined as:
 Returns C<True> if the invocant contains at least one key/value pair.
 
     my $m = Map.new('a' => 2, 'b' => 17);
-    say $m.Bool;                                      # True
+    say $m.Bool;                                      # OUTPUT: «True␤»
 
 =head2 method Capture
 
@@ -208,7 +208,7 @@ The returned C<Capture> will not contain any positional arguments.
 
     my $map = Map.new('a' => 2, 'b' => 17);
     my $capture = $map.Capture;
-    my-sub(|$capture);                                # 2, 17
+    my-sub(|$capture);                                # RESULT: «2, 17»
 
     sub my-sub(:$a, :$b) {
         say "$a, $b"

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -48,9 +48,8 @@ Defined as:
 Returns C<True> on successful and C<False> on unsuccessful matches. Please note
 that any zero-width match can also be successful.
 
-    say 'abc' ~~ /^/;
-    say $/.from, ' ',  $/.to, ' ', ?$/
-    # OUTPUT«｢｣␤0 0 True␤»
+    say 'abc' ~~ /^/;                   # OUTPUT: «｢｣␤»
+    say $/.from, ' ',  $/.to, ' ', ?$/; # OUTPUT: «0 0 True␤»
 
 =head2 method Str
 
@@ -61,7 +60,7 @@ Defined as:
 Returns the matched text.
 
     "abc123def" ~~ /\d+/;
-    say $/.Str;               # 123
+    say $/.Str;               # OUTPUT: «123␤»
 
 =head2 method caps
 
@@ -95,11 +94,11 @@ Defined as:
 Returns the part of the original string leading up to the match.
 
     'abcdefg' ~~ /cd/;
-    say $/.prematch;          # ab
+    say $/.prematch;          # OUTPUT: «ab␤»
 
     # will return a list of three match objects
     "abc123def" ~~ m:g/\d/;
-    say $/.[1].prematch;      # abc1
+    say $/.[1].prematch;      # OUTPUT: «abc1␤»
 
 =head2 method postmatch
 
@@ -110,11 +109,11 @@ Defined as:
 Returns the part of the original string following the match.
 
     'abcdefg' ~~ /cd/;
-    say $/.postmatch;         # efg
+    say $/.postmatch;         # OUTPUT: «efg␤»
 
     # will return a list of three match objects
     "abc123def" ~~ m:g/\d/;
-    say $/.[1].postmatch;     # 3def
+    say $/.[1].postmatch;     # OUTPUT: «3def␤»
 
 =head2 method make
 

--- a/doc/Type/Metamodel/C3MRO.pod6
+++ b/doc/Type/Metamodel/C3MRO.pod6
@@ -25,8 +25,7 @@ class Child2 is CommonAncestor { }
 class GrandChild2 is Child2 { }
 class Weird is Child1 is GrandChild2 { };
 
-say Weird.^mro;
-    # (Weird) (Child1) (GrandChild2) (Child2) (CommonAncestor) (Any) (Mu)
+say Weird.^mro; # OUTPUT: «(Weird) (Child1) (GrandChild2) (Child2) (CommonAncestor) (Any) (Mu)␤»
 =end code
 
 C3 is the default resolution order for classes and grammars in Perl 6.
@@ -48,7 +47,7 @@ Computes the method resolution order.
 
 Returns a list of types in the method resolution order.
 
-    say Int.^mro    # ((Int) (Cool) (Any) (Mu))
+    say Int.^mro;   # OUTPUT: «((Int) (Cool) (Any) (Mu))␤»
 
 Returns a list of types in the method resolution order, even those that are
 marked C<is hidden>.

--- a/doc/Type/Metamodel/ClassHOW.pod6
+++ b/doc/Type/Metamodel/ClassHOW.pod6
@@ -31,8 +31,8 @@
 
 C<Metamodel::ClassHOW> is the meta class behind the C<class> keyword.
 
-    say so Int.HOW ~~ Metamodel::ClassHOW;      # True
-    say Int.^methods(:all).pick.name;       # random Int method name
+    say so Int.HOW ~~ Metamodel::ClassHOW;    # OUTPUT: «True␤»
+    say Int.^methods(:all).pick.name;         # OUTPUT: «random Int method name␤»
 
 =head1 Methods
 
@@ -67,9 +67,9 @@ with this name.
 
     class A      { method x($a) {} };
     class B is A { method x()   {} };
-    say B.^can('x').elems;              # 2
+    say B.^can('x').elems;              # OUTPUT: «2␤»
     for B.^can('x') {
-        say .arity;                     # 1, 2
+        say .arity;                     # OUTPUT: «1, 2␤»
     }
 
 In this example, class C<B> has two possible methods available with name C<x>
@@ -86,8 +86,7 @@ Returns the first matching L<Method|/type/Method> with the provided name or
 Nil. It is faster than C<.^can> but does not provide a full list of all
 candidates.
 
-    say Str.^lookup('Int').perl
-    # OUTPUT«method Int (Str:D $: *%_) { #`(Method|39910024) ... }␤»
+    say Str.^lookup('Int').perl; # OUTPUT: «method Int (Str:D $: *%_) { #`(Method|39910024) ... }␤»
 
 =head2 method compose
 

--- a/doc/Type/Metamodel/MethodContainer.pod6
+++ b/doc/Type/Metamodel/MethodContainer.pod6
@@ -14,7 +14,7 @@ the API around storing and introspecting them.
     # don't do that, because it changes type Int globally.
     # just for demonstration purposes.
     Int.^add_method('double', method ($x:) { 2 * $x });
-    say 21.double;
+    say 21.double; # OUTPUT: «42␤»
 
 =head1 Methods
 

--- a/doc/Type/Metamodel/MultipleInheritance.pod6
+++ b/doc/Type/Metamodel/MultipleInheritance.pod6
@@ -48,9 +48,10 @@ a nested list is returned.
     class B is C1 is C2 { };
     class A is B { };
 
-    say A.^parents(:all).perl;          # (B, C1, C2, D, Any, Mu)
+    say A.^parents(:all).perl;
+    # OUTPUT: «(B, C1, C2, D, Any, Mu)␤»
     say A.^parents(:all, :tree).perl;
-        # [B, ([C1, [D, [Any, [Mu]]]], [C2, [D, [Any, [Mu]]]])]
+    # OUTPUT: «[B, ([C1, [D, [Any, [Mu]]]], [C2, [D, [Any, [Mu]]]])]␤»
 
 =head2 method hides
 

--- a/doc/Type/Metamodel/Naming.pod6
+++ b/doc/Type/Metamodel/Naming.pod6
@@ -17,7 +17,7 @@ roles and enums.
 
 Returns the name of the meta object, if any.
 
-    say 42.^name;       # Int
+    say 42.^name;       # OUTPUT: «Int␤»
 
 =head2 method set_name
 

--- a/doc/Type/Method.pod6
+++ b/doc/Type/Method.pod6
@@ -19,7 +19,7 @@ use the declarators C<my> and C<method>:
     "greeting".$m("hello");         # greeting: 'hello'
 
     <a b c>.&(my method (List:D:){dd self; self}).say;
-    # OUTPUT«("a", "b", "c")␤(a b c)␤»
+    # OUTPUT: «("a", "b", "c")␤(a b c)␤»
 
 The invocant of a method defaults to C<self>. A type constraint including a
 type-smiley can be used and is honored both for methods defined in a class and
@@ -30,7 +30,7 @@ for free floating methods. Call the latter with C<.&> on an object.
     }
     my $i = 1;
     $i.&m(<a>);
-    # OUTPUT«Int␤»
+    # OUTPUT: «Int␤»
 
 Methods will ignore extra named arguments where other types of C<Routine> will
 throw at runtime. Extra arguments will be forwarded by C<nextsame> and friends.
@@ -43,6 +43,6 @@ throw at runtime. Extra arguments will be forwarded by C<nextsame> and friends.
         method m(:$a) { say "1 named"; nextsame }
     }
     B.m( :1a, :2b );
-    # OUTPUT«1 named␤2 named␤»
+    # OUTPUT: «1 named␤2 named␤»
 
 =end pod

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -21,10 +21,10 @@ element, with a combined weight.
 my $recipe = (butter => 0.22, sugar => 0.1,
               flour => 0.275, sugar => 0.02).Mix;
 
-say $recipe.elems;      # 3
-say $recipe.keys.sort;  # butter flour sugar
-say $recipe.pairs.sort; # "butter" => 0.22 "flour" => 0.275 "sugar" => 0.12
-say $recipe.total;      # 0.615
+say $recipe.elems;      # OUTPUT: «3␤»
+say $recipe.keys.sort;  # OUTPUT: «butter flour sugar␤»
+say $recipe.pairs.sort; # OUTPUT: «"butter" => 0.22 "flour" => 0.275 "sugar" => 0.12␤»
+say $recipe.total;      # OUTPUT: «0.615␤»
 =end code
 
 C<Mix>es can be treated as object hashes using the C<{ }> postcircumfix
@@ -33,9 +33,9 @@ elements of the mix, and C<0> for keys that aren't:
 
     my $recipe = (butter => 0.22, sugar => 0.1,
                   flour => 0.275, sugar => 0.02).Mix;
-    say $recipe<butter>;     # 0.22
-    say $recipe<sugar>;      # 0.12
-    say $recipe<chocolate>;  # 0
+    say $recipe<butter>;     # OUTPUT: «0.22␤»
+    say $recipe<sugar>;      # OUTPUT: «0.12␤»
+    say $recipe<chocolate>;  # OUTPUT: «0␤»
 
 =head1 Creating C<Mix> objects
 
@@ -45,8 +45,8 @@ type, become elements of the mix - with a weight of C<1> for each time the
 parameter occurred:
 
     my $n = mix "a", "a", "b" => 0, "c" => 3.14;
-    say $n.keys.map(&WHAT);  # ((Str) (Pair) (Pair))
-    say $n.pairs;            # (a => 2 (c => 3.14) => 1 (b => 0) => 1)
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Pair) (Pair))␤»
+    say $n.pairs;            # OUTPUT: «(a => 2 (c => 3.14) => 1 (b => 0) => 1)␤»
 
 Alternatively, the C<.Mix> coercer (or its functional form, C<Mix()>) can be
 called on an existing object to coerce it to a C<Mix>. Its semantics depend on
@@ -56,8 +56,8 @@ Hash-like objects or Pair items, only the keys become elements of the mix, and
 the (cumulative) values become the associated numeric weights:
 
     my $n = ("a", "a", "b" => 0, "c" => 3.14).Mix;
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
-    say $n.pairs;            # (a => 2 c => 3.14)
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
+    say $n.pairs;            # OUTPUT: «(a => 2 c => 3.14)␤»
 
 =head1 Operators
 

--- a/doc/Type/MixHash.pod6
+++ b/doc/Type/MixHash.pod6
@@ -18,10 +18,10 @@ same element, with a combined weight.
 my $recipe = (butter => 0.22, sugar => 0.1,
               flour => 0.275, sugar => 0.02).MixHash;
 
-say $recipe.elems;      # 3
-say $recipe.keys.sort;  # butter flour sugar
-say $recipe.pairs.sort; # "butter" => 0.22 "flour" => 0.275 "sugar" => 0.12
-say $recipe.total;      # 0.615
+say $recipe.elems;      # OUTPUT: «3␤»
+say $recipe.keys.sort;  # OUTPUT: «butter flour sugar␤»
+say $recipe.pairs.sort; # OUTPUT: «"butter" => 0.22 "flour" => 0.275 "sugar" => 0.12␤»
+say $recipe.total;      # OUTPUT: «0.615␤»
 =end code
 
 C<MixHash>es can be treated as object hashes using the C<{ }> postcircumfix
@@ -35,13 +35,13 @@ already exist:
 my $recipe = (butter => 0.22, sugar => 0.1,
               flour => 0.275, sugar => 0.02).MixHash;
 
-say $recipe<butter>;     # 0.22
-say $recipe<sugar>;      # 0.12
-say $recipe<chocolate>;  # 0
+say $recipe<butter>;     # OUTPUT: «0.22␤»
+say $recipe<sugar>;      # OUTPUT: «0.12␤»
+say $recipe<chocolate>;  # OUTPUT: «0␤»
 
 $recipe<butter> = 0;
 $recipe<chocolate> = 0.30;
-say $recipe.pairs;       # "sugar" => 0.12 "flour" => 0.275 "chocolate" => 0.3
+say $recipe.pairs;       # OUTPUT: «"sugar" => 0.12 "flour" => 0.275 "chocolate" => 0.3␤»
 =end code
 
 
@@ -52,8 +52,8 @@ regardless of their type, become elements of the mix - with a weight of C<1> for
 each time the parameter occurred:
 
     my $n = MixHash.new: "a", "a", "b" => 0, "c" => 3.14;
-    say $n.keys.map(&WHAT);  # ((Str) (Pair) (Pair))
-    say $n.pairs;            # (a => 2 (c => 3.14) => 1 (b => 0) => 1)
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Pair) (Pair))␤»
+    say $n.pairs;            # OUTPUT: «(a => 2 (c => 3.14) => 1 (b => 0) => 1)␤»
 
 Alternatively, the C<.MixHash> coercer (or its functional form, C<MixHash()>)
 can be called on an existing object to coerce it to a C<MixHash>. Its semantics
@@ -63,8 +63,8 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the mix, and the (cumulative) values become the associated numeric weights:
 
     my $n = ("a", "a", "b" => 0, "c" => 3.14).MixHash;
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
-    say $n.pairs;            # (a => 2 c => 3.14)
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
+    say $n.pairs;            # OUTPUT: «(a => 2 c => 3.14)␤»
 
 =head1 Operators
 

--- a/doc/Type/Mixy.pod6
+++ b/doc/Type/Mixy.pod6
@@ -18,8 +18,8 @@ C<Mixy> are L<Real>s rather than L<Int>s.
 
 Returns the sum of all the weights
 
-    mix('a', 'b', 'c', 'a', 'a', 'd').total == 6; # True
-    {a => 5.6, b => 2.4}.Mix.total == 8; # True
+    mix('a', 'b', 'c', 'a', 'a', 'd').total == 6; # RESULT: «True»
+    {a => 5.6, b => 2.4}.Mix.total == 8;          # RESULT: «True»
 
 =head2 method roll
 

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -23,14 +23,14 @@ L<Any|/type/Any>.
 
 Returns C<False> on the type object, and C<True> otherwise.
 
-    say Int.defined;                # False
-    say 42.defined;                 # True
+    say Int.defined;                # OUTPUT: «False␤»
+    say 42.defined;                 # OUTPUT: «True␤»
 
 Very few types (like L<Failure|/type/Failure>) override C<defined> to return
 C<False> even for instances:
 
     sub fails() { fail 'oh noe' };
-    say fails().defined;            # False
+    say fails().defined;            # OUTPUT: «False␤»
 
 =head2 routine isa
 
@@ -40,13 +40,13 @@ C<False> even for instances:
 Returns C<True> if the invocant is an instance of class C<$type>, a subset type or a derived class (through inheritance) of C<$type>.
 
     my $i = 17;
-    say $i.isa("Int");   # True
-    say $i.isa(Any);     # True
+    say $i.isa("Int");   # OUTPUT: «True␤»
+    say $i.isa(Any);     # OUTPUT: «True␤»
 
 A more idiomatic way to do this is to use the smartmatch operator L<~~|/routine/~~> instead.
 
     my $s = "String";
-    say $s ~~ Str;       # True
+    say $s ~~ Str;       # OUTPUT: «True␤»
 
 =head2 routine does
 
@@ -62,9 +62,9 @@ Returns C<True> if and only if the invocant conforms to type C<$type>.
 Using the smart match operator L<~~|/routine/~~> is a more idiomatic alternative.
 
     my $d = Date.new('2016-06-03');
-    say $d ~~ Dateish;                # True
-    say $d ~~ Any;                    # True
-    say $d ~~ DateTime;               # False
+    say $d ~~ Dateish;                # OUTPUT: «True␤»
+    say $d ~~ Any;                    # OUTPUT: «True␤»
+    say $d ~~ DateTime;               # OUTPUT: «False␤»
 
 =head2 routine Bool
 
@@ -76,16 +76,16 @@ Returns C<False> on the type object, and C<True> otherwise.
 Many built-in types override this to be C<False> for empty collections, the
 empty L<string|/type/Str> or numerical zeros
 
-    say Mu.Bool;                    # False
-    say Mu.new.Bool;                # True
-    say [1, 2, 3].Bool;             # True
-    say [].Bool;                    # False
-    say { 'hash' => 'full' }.Bool;  # True
-    say {}.Bool;                    # False
-    say "".Bool;                    # False
-    say 0.Bool;                     # False
-    say 1.Bool;                     # True
-    say "0".Bool;                   # True
+    say Mu.Bool;                    # OUTPUT: «False␤»
+    say Mu.new.Bool;                # OUTPUT: «True␤»
+    say [1, 2, 3].Bool;             # OUTPUT: «True␤»
+    say [].Bool;                    # OUTPUT: «False␤»
+    say { 'hash' => 'full' }.Bool;  # OUTPUT: «True␤»
+    say {}.Bool;                    # OUTPUT: «False␤»
+    say "".Bool;                    # OUTPUT: «False␤»
+    say 0.Bool;                     # OUTPUT: «False␤»
+    say 1.Bool;                     # OUTPUT: «True␤»
+    say "0".Bool;                   # OUTPUT: «True␤»
 
 =head2 method Str
 
@@ -94,7 +94,7 @@ empty L<string|/type/Str> or numerical zeros
 Returns a string representation of the invocant, intended to be machine
 readable. Method C<Str> warns on type objects, and produces the empty string.
 
-    say Mu.Str;                     #!> use of uninitialized value of type Mu in string context
+    say Mu.Str;                     # Use of uninitialized value of type Mu in string context.
 
 =head2 routine gist
 
@@ -113,8 +113,8 @@ more specific that may truncate output.
 C<gist> is the method that L<say> calls implicitly, so C<say $something> and
 C<say $something.gist> generally produce the same output.
 
-    say Mu.gist;        # (Mu)
-    say Mu.new.gist;    # Mu.new
+    say Mu.gist;        # OUTPUT: «(Mu)␤»
+    say Mu.new.gist;    # OUTPUT: «Mu.new␤»
 
 =head2 routine perl
 
@@ -132,9 +132,9 @@ write a Perl expression that produces a particular value
 
 Forces the invocant to be evaluated in item context and returns the value of it.
 
-    say [1,2,3].item.perl;         # $[1, 2, 3]
-    say { apple => 10 }.item.perl; # ${:apple(10)}
-    say "abc".item.perl;           # "abc"
+    say [1,2,3].item.perl;         # OUTPUT: «$[1, 2, 3]␤»
+    say { apple => 10 }.item.perl; # OUTPUT: «${:apple(10)}␤»
+    say "abc".item.perl;           # OUTPUT: «"abc"␤»
 
 =head2 method clone
 
@@ -154,8 +154,8 @@ class Point2D {
 
 my $p = Point2D.new(x => 2, y => 3);
 
-say $p;                     # Point(2, 3)
-say $p.clone(y => -5);      # Point(2, -5)
+say $p;                     # OUTPUT: «Point(2, 3)␤»
+say $p.clone(y => -5);      # OUTPUT: «Point(2, -5)␤»
 =end code
 
 =head2 method new
@@ -204,7 +204,7 @@ subclassing harder).
 Allocates a new object of the same type as the invocant, without
 initializing any attributes.
 
-    say Mu.CREATE.defined;  # True
+    say Mu.CREATE.defined;  # OUTPUT: «True␤»
 
 =head2 method print
 
@@ -213,7 +213,7 @@ initializing any attributes.
 Prints value to C<$*OUT> after stringification using C<.Str> method without
 adding a newline at end.
 
-    "abc\n".print;          # abc␤
+    "abc\n".print;          # RESULT: «abc␤»
 
 =head2 method put
 
@@ -222,7 +222,7 @@ adding a newline at end.
 Prints value to C<$*OUT>, adding a newline at end, and if necessary,
 stringifying non-C<Str> object using the C<.Str> method.
 
-    "abc".put;              # abc␤
+    "abc".put;              # RESULT: «abc␤»
 
 =head2 method say
 
@@ -231,7 +231,7 @@ stringifying non-C<Str> object using the C<.Str> method.
 Prints value to C<$*OUT> after stringification using C<.gist> method with
 newline at end. To produce machine readable output use C<.put>.
 
-    say 42;                 # 42␤
+    say 42;                 # OUTPUT: «42␤»
 
 =head2 method ACCEPTS
 
@@ -243,9 +243,9 @@ operator and given/when invokes on the right-hand side (the matcher).
 The C<Mu:U> multi performs a type check. Returns C<True> if C<$other> conforms to the invocant
 (which is always a type object or failure).
 
-    say 42 ~~ Mu;           # True
-    say 42 ~~ Int;          # True
-    say 42 ~~ Str;          # False
+    say 42 ~~ Mu;           # OUTPUT: «True␤»
+    say 42 ~~ Int;          # OUTPUT: «True␤»
+    say 42 ~~ Str;          # OUTPUT: «False␤»
 
 Note that there is no multi for defined invocants; this is to allow
 autothreading of L<junctions|/type/Junction>, which happens as a fallback
@@ -259,7 +259,7 @@ Returns an object of type L<ObjAt> which uniquely identifies the object.
 Value types override this method which makes sure that two equivalent objects
 return the same return value from C<WHICH>.
 
-    say 42.WHICH eq 42.WHICH;       # True
+    say 42.WHICH eq 42.WHICH;       # OUTPUT: «True␤»
 
 =head2 method WHERE
 
@@ -353,7 +353,7 @@ Returns the invocant in the enclosing L<gather|/language/control#gather/take> bl
     }
 
     say insert ':', <a b c>;
-    # OUTPUT«(a : b : c)␤»
+    # OUTPUT: «(a : b : c)␤»
 
 =head2 routine take
 
@@ -366,7 +366,7 @@ Takes the given item and passes it to the enclosing C<gather> block.
     my $max-lotto-numbers = 49;
     gather for ^$num-selected-numbers {
         take (1 .. $max-lotto-numbers).pick(1);
-    }.say;    #-> 32 22 1 17 32 9  (for example)
+    }.say;    # six random values
 
 =head2 routine take-rw
 
@@ -378,7 +378,7 @@ Returns the given item to the enclosing C<gather> block, without introducing a n
     sub f(@list){ gather for @list { take-rw $_ } };
     for f(@a) { $_++ };
     say @a;
-    # OUTPUT«[2 3 4]␤»
+    # OUTPUT: «[2 3 4]␤»
 
 =head2 method so
 
@@ -392,7 +392,7 @@ that is B<so>, then do this thing".  For instance,
     my $verbose-selected = any(@args) eq '-v' | '-V';
     if $verbose-selected.so {
         say "Verbose option detected in arguments";
-    } #-> Verbose option detected in arguments
+    } # OUTPUT: «Verbose option detected in arguments␤»
 
 =head2 method not
 
@@ -405,7 +405,7 @@ Thus it is the opposite of C<so>.
     my $verbose-selected = any(@args) eq '-v' | '-V';
     if $verbose-selected.not {
         say "Verbose option not present in arguments";
-    } #-> Verbose option not present in arguments
+    } # OUTPUT: «Verbose option not present in arguments␤»
 
 Since there is also a prefix version of C<not>, the above code reads better
 like so:
@@ -414,7 +414,7 @@ like so:
     my $verbose-selected = any(@args) eq '-v' | '-V';
     if not $verbose-selected {
         say "Verbose option not present in arguments";
-    } #-> Verbose option not present in arguments
+    } # OUTPUT: «Verbose option not present in arguments␤»
 
 =end pod
 

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -14,7 +14,7 @@ so smartmatching C<Nil> will also match C<Failure>.)
 
 The class C<Nil> is the same exact thing as its only possible value, C<Nil>.
 
-    say Nil === Nil.new         # True
+    say Nil === Nil.new;        # OUTPUT: «True␤»
 
 Along with C<Failure>, C<Nil> and its sub classes may always be returned from a
 routine even when the routine specifies a particular return type. It may also
@@ -22,16 +22,16 @@ be returned regardless of the definedness of the return type, however, C<Nil>
 is considered undefined for all other purposes.
 
     sub a( --> Int:D ) { return Nil }
-    a().say;                    # Nil
+    a().say;                    # OUTPUT: «Nil␤»
 
 C<Nil> is what is returned from empty routines or closure, or routines
 that use a bare C<return> statement.
 
-    sub a { }; a().say;         # Nil
-    sub b { return }; b().say;  # Nil
-    say (if 1 { });             # Nil
-    { ; }().say;                # Nil
-    say EVAL "";                # Nil
+    sub a { }; a().say;         # OUTPUT: «Nil␤»
+    sub b { return }; b().say;  # OUTPUT: «Nil␤»
+    say (if 1 { });             # OUTPUT: «Nil␤»
+    { ; }().say;                # OUTPUT: «Nil␤»
+    say EVAL "";                # OUTPUT: «Nil␤»
 
 In a list, C<Nil> takes the space of one value.  Iterating a C<Nil>
 behaves like iteration of any non-iterable value, producing a sequence
@@ -39,16 +39,16 @@ of one C<Nil>. (When you need the other meaning, the special value
 L<Empty|/type/Slip#Empty> is available to take no spaces when inserted into
 list, and to return no values when iterated.)
 
-    (1, Nil, 3).elems.say;      # 3
-    (for Nil { $_ }).perl.say;  # (Nil,)
+    (1, Nil, 3).elems.say;      # OUTPUT: «3␤»
+    (for Nil { $_ }).perl.say;  # OUTPUT: «(Nil,)␤»
 
 Any method call on C<Nil> other than those specifically listed below,
 and consequently, any subscripting operation, will succeed and return
 C<Nil>.
 
-    say Nil.ITotallyJustMadeThisUp;  # Nil
-    say (Nil)[100];                  # Nil
-    say (Nil){100};                  # Nil
+    say Nil.ITotallyJustMadeThisUp;  # OUTPUT: «Nil␤»
+    say (Nil)[100];                  # OUTPUT: «Nil␤»
+    say (Nil){100};                  # OUTPUT: «Nil␤»
 
 X<|Nil assignment>
 When assigned to a L<container|/language/containers>, the C<Nil> value (but not any subclass of
@@ -63,15 +63,15 @@ type container will fail with a runtime error.
 
     my Int $x = 42;
     $x = Nil;
-    $x.say;                     # (Int)
+    $x.say;                     # OUTPUT: «(Int)␤»
 
-    sub f( --> Int:D ){ Nil }; # this definedness constraint is ignored
-    my Int:D $i = f; # this definedness constraint is not ignored, so throws
+    sub f( --> Int:D ){ Nil };  # this definedness constraint is ignored
+    my Int:D $i = f;            # this definedness constraint is not ignored, so throws
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $y; expected Int but got Any (Any)»
 
     sub g( --> Int:D ){ fail "oops" }; # this definedness constraint is ignored
-    my Any:D $h = g; # failure object matches Any:D, so is assigned
+    my Any:D $h = g;                   # failure object matches Any:D, so is assigned
 
 but
 
@@ -91,8 +91,8 @@ Because an untyped variable is type C<Any>, assigning a C<Nil> to one
 will result in an L<(Any)|/type/Any> type object.
 
     my $x = Nil;
-    $x.say;          # (Any)
-    my Int $y = $x;  # error
+    $x.say;          # OUTPUT: «(Any)␤»
+    my Int $y = $x;  # will throw an exception
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $y; expected Int but got Any (Any)␤»
 
@@ -101,7 +101,7 @@ when said variable appears on the RHS, you can type the container as C<Nil>.
 
     my Nil $x;
     my Str $s = $x;
-    $s.say;          # (Str)
+    $s.say;          # OUTPUT: «(Str)␤»
 
 There is an important exception to this transforms-into-type-object rule:
 assigning C<Nil> to a variable which has a default will restore that default.
@@ -109,7 +109,7 @@ assigning C<Nil> to a variable which has a default will restore that default.
     my Int $x is default(42) = -1;
     my $y = 1;
     for $x, $y -> $val is rw { $val = Nil unless $val > 0 }
-    $x.say;          # 42
+    $x.say;          # OUTPUT: «42␤»
 
 =head1 Methods
 

--- a/doc/Type/NumStr.pod6
+++ b/doc/Type/NumStr.pod6
@@ -11,7 +11,7 @@ allow for the representation of a value as both a string and a numeric type, typ
 they will be created for you when the context is "stringy" but they can be determined
 to be numbers, such as in some L<quoting constructs|/language/quoting>:
 
-    my $f = <42.1e0>; say $f.WHAT; # (NumStr)
+    my $f = <42.1e0>; say $f.WHAT; # OUTPUT: «(NumStr)␤»
 
 As a subclass of both L«C<Num>|/type/Num» and L«C<Str>|/type/Str», a C<NumStr>
 will be accepted where either is expected. However, C<NumStr> does not share
@@ -32,8 +32,8 @@ The constructor requires both the C<Num> and the C<Str> value, when constructing
 directly the values can be whatever is required:
 
     my $f = NumStr.new(42.1e0, "forty two and a bit");
-    say +$f; # -> 42.1
-    say ~$f; # -> "forty two and a bit"
+    say +$f; # OUTPUT: «42.1␤»
+    say ~$f; # OUTPUT: «"forty two and a bit"␤»
 
 =head2 method Numeric
 
@@ -65,8 +65,8 @@ coerce to a C<Num> or C<Str> value first:
 
     my $f = NumStr.new(42.1e0, "smaller");
     my $g = NumStr.new(43.1e0, "larger");
-    say $f cmp $g;          # Less
-    say $f.Str cmp $g.Str;  # More
+    say $f cmp $g;          # OUTPUT: «Less␤»
+    say $f.Str cmp $g.Str;  # OUTPUT: «More␤»
 
 =end pod
 

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -62,8 +62,8 @@ as accurately as is possible. Fail with C<X::Numeric::Real> otherwise.
 Returns the number converted to the narrowest type that can hold it without
 loss of precision.
 
-    say (4.0 + 0i).narrow.perl;     # 4
-    say (4.0 + 0i).narrow.^name;    # Int
+    say (4.0 + 0i).narrow.perl;     # OUTPUT: «4␤»
+    say (4.0 + 0i).narrow.^name;    # OUTPUT: «Int␤»
 
 =head2 method ACCEPTS
 

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -43,8 +43,8 @@ Defined as:
 Returns a new C<Pair> object with key and value exchanged.
 
     my $p = (6 => 'Perl').antipair;
-    say $p.key;         # Perl
-    say $p.value;       # 6
+    say $p.key;         # OUTPUT: «Perl␤»
+    say $p.value;       # OUTPUT: «6␤»
 
 =head2 method key
 
@@ -55,7 +55,7 @@ Defined as:
 Returns the I<key> part of the C<Pair>.
 
     my $p = (Perl => 6);
-    say $p.key; # Perl
+    say $p.key; # OUTPUT: «Perl␤»
 
 =head2 method value
 
@@ -66,7 +66,7 @@ Defined as:
 Returns the I<value> part of the C<Pair>.
 
     my $p = (Perl => 6);
-    say $p.value; # 6
+    say $p.value; # OUTPUT: «6␤»
 
 =head2 infix cmp
 
@@ -120,8 +120,8 @@ Defined as:
 Returns a list of one C<Pair>, namely this one.
 
     my $p = (Perl => 6);
-    say $p.pairs.WHAT; # (List)
-    say $p.pairs[0];   # (Pair)
+    say $p.pairs.WHAT; # OUTPUT: «(List)␤»
+    say $p.pairs[0];   # OUTPUT: «(Pair)␤»
 
 =head2 method antipairs
 
@@ -133,9 +133,9 @@ Returns a L<List|/type/List> containing the L<antipair|/type/Pair#method_antipai
 of the invocant.
 
     my $p = (6 => 'Perl').antipairs;
-    say $p.WHAT;                                      # (List)
-    say $p.first;                                     # Perl => 6
-    say $p.first.WHAT;                                # (Pair)
+    say $p.WHAT;                                      # OUTPUT: «(List)␤»
+    say $p.first;                                     # OUTPUT: «Perl => 6␤»
+    say $p.first.WHAT;                                # OUTPUT: «(Pair)␤»
 
 =head2 method invert
 
@@ -150,16 +150,16 @@ of C<Pair>s is returned since C<invert> expands iterable values into multiple
 pairs.
 
     my Pair $p1 = (6 => 'Perl');
-    say $p1.invert;                                   # Perl => 6
-    say $p1.invert.WHAT;                              # (Pair)
+    say $p1.invert;                                   # OUTPUT: «Perl => 6␤»
+    say $p1.invert.WHAT;                              # OUTPUT: «(Pair)␤»
 
     my Pair $p2 = ('Perl' => (5, 6));
-    say $p2.invert;                                   # (5 => Perl 6 => Perl)
-    say $p2.invert.WHAT;                              # (List)
+    say $p2.invert;                                   # OUTPUT: «(5 => Perl 6 => Perl)␤»
+    say $p2.invert.WHAT;                              # OUTPUT: «(List)␤»
 
     my Pair $p3 = ('Perl' => { cool => 'language'});
-    say $p3.invert;                                   # {cool => language => Perl}
-    say $p3.invert.WHAT;                              # (Hash)
+    say $p3.invert;                                   # OUTPUT: «{cool => language => Perl}␤»
+    say $p3.invert.WHAT;                              # OUTPUT: «(Hash)␤»
 
 =head2 method keys
 
@@ -170,7 +170,7 @@ Defined as:
 Returns a L<List|/type/List> containing the L<key|/type/Pair#method_key>
 of the invocant.
 
-    say ('Perl' => 6).keys;                           # (Perl)
+    say ('Perl' => 6).keys;                           # OUTPUT: «(Perl)␤»
 
 =head2 method values
 
@@ -181,7 +181,7 @@ Defined as:
 Returns a L<List|/type/List> containing the L<value|/type/Pair#method_value>
 of the invocant.
 
-    say ('Perl' => 6).values;                         # (6)
+    say ('Perl' => 6).values;                         # OUTPUT: «(6)␤»
 
 =head2 method freeze
 
@@ -194,8 +194,8 @@ Makes the I<value> of the C<Pair> read-only, by removing it from its L<Scalar co
     my $str = "apple";
     my $p = Pair.new('key', $str);
     $p.value = "orange";              # this works as expected
-    $p.say;                           # key => orange
-    $p.freeze.say;                    # orange
+    $p.say;                           # OUTPUT: «key => orange␤»
+    $p.freeze.say;                    # OUTPUT: «orange␤»
     $p.value = "a new apple";         # Fails
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::Assignment::RO: Cannot modify an immutable Str␤»

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -13,7 +13,7 @@ and call C<.params> on it to obtain a list of the Parameters.
 
     my $sig   = :(Str $x);
     my $param = $sig.params[0];
-    say $param.type;              # Str()
+    say $param.type;              # OUTPUT: «Str()␤»
 
 See L<Signature> for more information, and also for an explanation
 on what most of the concepts related to parameters mean.
@@ -77,8 +77,8 @@ Defined as:
 Returns C<True> if it's a L<named parameter|/type/Signature#Positional_vs._Named>.
 
     my Signature $sig = :(Str $x, Bool :$is-named);
-    say $sig.params[0].named;                          # False
-    say $sig.params[1].named;                          # True
+    say $sig.params[0].named;                          # OUTPUT: «False␤»
+    say $sig.params[1].named;                          # OUTPUT: «True␤»
 
 =head2 method named_names
 
@@ -166,8 +166,8 @@ Returns C<True> for parameters that capture the rest of the argument list into
 a single L<Capture|/type/Capture> object.
 
     sub how_many_extra_positionals($!, |capture) { capture.elems.say }
-    how_many_extra_positionals(0, 1, 2, 3);                        #-> 3
-    say &how_many_extra_positionals.signature.params[1].capture;   #-> True
+    how_many_extra_positionals(0, 1, 2, 3);                        # RESULT: «3»
+    say &how_many_extra_positionals.signature.params[1].capture;   # OUTPUT: «True␤»
 
 Like raw parameters, Capture parameters do not force any context on the
 values bound to them, which is why their sigils are only used in
@@ -225,9 +225,9 @@ parameter.  Type captures define a type name within the attached code,
 which is an alias to the type gleaned from the argument during a call.
 
     sub a(::T ::U $x) { T.say }
-    a(8);                                       #-> Int
-    say &a.signature.params[0].type_captures;   #-> T U
-    sub b($x) { $x.WHAT.say } # does the same thing, but uglier.
+    a(8);                                       # OUTPUT: «Int␤»
+    say &a.signature.params[0].type_captures;   # OUTPUT: «T U␤»
+    sub b($x) { $x.WHAT.say }                   # does the same thing, but uglier.
 
 The type used may change from call to call.  Once they are defined,
 type captures can be used wherever you would use a type, even later

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -10,13 +10,13 @@ This role provides an interface by which an L<Iterable|/type/Iterable> can
 be coerced into a L<Positional|/type/Positional>, so that you can for example
 write:
 
-    sub fifths(@a) {       # @a is constraint to Positional
+    sub fifths(@a) {        # @a is constraint to Positional
         @a[4];
     }
     my $seq := gather {     # a Seq, which is not Positional
         take $_ for 1..*;
     }
-    say fifths($seq);       # 5
+    say fifths($seq);       # OUTPUT: «5␤»
 
 The invocation of C<fifths> in the example above would ordinarily give a type
 error, because C<$seq> is of type L<Seq|/type/Seq>, which doesn't do the

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -12,7 +12,7 @@ the exit code. It is typically created through the C<run> subroutine:
 
     my $proc = run 'echo', 'Hallo world', :out;
     my $captured-output = $proc.out.slurp-rest;
-    say "Output was $captured-output.perl()";       # Output was "Hallo world\n"
+    say "Output was $captured-output.perl()";       # OUTPUT: «Output was "Hallo world\n"␤»
 
 Piping several commands is easy too. To achieve the equivalent of the pipe
 C<echo "Hello, world" | cat -n> in Perl 6, and capture the output from the
@@ -29,9 +29,8 @@ to C<True>, which will make the pipe available via C<.in> method on the C<Proc>:
     $p.in.say: "Hello,\nworld!";
     $p.in.close;
     say $p.out.slurp-rest;
-    # OUTPUT:
-    #    1  Hello,
-    #    2  world!
+    # OUTPUT: «1  Hello,␤
+    #          2  world!␤»
 
 =head1 Methods
 

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -14,9 +14,9 @@ combining promises, and waiting for results.
 
     my $p = Promise.start({ sleep 2; 42});
     $p.then({ say .result });   # will print 42 once the block finished
-    say $p.status;              # Planned
+    say $p.status;              # OUTPUT: «Planned␤»
     $p.result;                  # waits for the computation to finish
-    say $p.status;              # Kept
+    say $p.status;              # OUTPUT: «Kept␤»
 
 There are two typical scenarios for using promises. The first is to use a
 factory method (C<start>, C<in>, C<anyof>, C<allof>) on the type object; those
@@ -181,8 +181,8 @@ taken. See method C<vow> for more information.
     my $p = Promise.new;
 
     $p.break('sorry');
-    say $p.status;          # Broken
-    say $p.cause;           # sorry
+    say $p.status;          # OUTPUT: «Broken␤»
+    say $p.cause;           # OUTPUT: «sorry␤»
 
 =head2 method result
 
@@ -237,7 +237,7 @@ exception of type C<X::Promise::Vowed>.
     my $p   = Promise.new;
     my $vow = $p.vow;
     $vow.keep($p);
-    say $p.status;          # Kept
+    say $p.status;          # OUTPUT: «Kept␤»
 
 =head2 method Supply
 

--- a/doc/Type/Proxy.pod6
+++ b/doc/Type/Proxy.pod6
@@ -23,7 +23,7 @@ something like this:
     }
     my $doubled := double();
     $doubled = 4;
-    say $doubled;       # 8
+    say $doubled;       # OUTPUT: «8␤»
 
 =head1 Methods
 

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -33,11 +33,11 @@ the start point, and then the generated elements.
 Ranges always go from small to larger elements; if the start point is bigger
 than the end point, the range is considered empty.
 
-    for 1..5 { .say };       # five iterations
-    ('a' ^..^ 'f').list;     # 'b', 'c', 'd', 'e'
-    5 ~~ ^5;                 # False
-    4.5 ~~ 0..^5;            # True
-    (1.1..5).list;           # (1.1, 2.1, 3.1, 4.1)
+    for 1..5 { .say };       # OUTPUT: «1␤2␤3␤4␤5␤»
+    ('a' ^..^ 'f').list;     # RESULT: «'b', 'c', 'd', 'e'»
+    5 ~~ ^5;                 # RESULT: «False»
+    4.5 ~~ 0..^5;            # RESULT: «True»
+    (1.1..5).list;           # RESULT: «(1.1, 2.1, 3.1, 4.1)»
 
 Use the L<...|/language/operators#infix_...> sequence operator to produce lists of elements that
 go from larger to smaller values, or to use offsets other than
@@ -57,11 +57,10 @@ binding, @-sigiled containers or a slip to get what you mean.
 
     my @numbers =  <4 8 15 16 23 42>;
     my $range := 0..2;
-    .say for @numbers[$range];
-    # OUTPUT«4␤8␤15␤»
+    .say for @numbers[$range]; # OUTPUT: «4␤8␤15␤»
     my @range = 0..2;
-    .say for @numbers[@range];
-    # OUTPUT«4␤8␤15␤»
+    .say for @numbers[@range]; # OUTPUT: «4␤8␤15␤»
+
 
 =head1 Methods
 
@@ -71,8 +70,8 @@ binding, @-sigiled containers or a slip to get what you mean.
 
 Returns the start point of the range.
 
-    say (1..5).min;                                   # 1
-    say (1^..^5).min;                                 # 1
+    say (1..5).min;                                   # OUTPUT: «1␤»
+    say (1^..^5).min;                                 # OUTPUT: «1␤»
 
 =head2 method excludes-min
 
@@ -81,8 +80,8 @@ Returns the start point of the range.
 Returns C<True> if the start point is excluded from the range, and C<False>
 otherwise.
 
-    say (1..5).excludes-min;                          # False
-    say (1^..^5).excludes-min;                        # True
+    say (1..5).excludes-min;                          # OUTPUT: «False␤»
+    say (1^..^5).excludes-min;                        # OUTPUT: «True␤»
 
 =head2 method max
 
@@ -90,8 +89,8 @@ otherwise.
 
 Returns the end point of the range.
 
-    say (1..5).max;                                   # 5
-    say (1^..^5).max;                                 # 5
+    say (1..5).max;                                   # OUTPUT: «5␤»
+    say (1^..^5).max;                                 # OUTPUT: «5␤»
 
 =head2 method excludes-max
 
@@ -100,8 +99,8 @@ Returns the end point of the range.
 Returns C<True> if the end point is excluded from the range, and C<False>
 otherwise.
 
-    say (1..5).excludes-max;                          # False
-    say (1^..^5).excludes-max;                        # True
+    say (1..5).excludes-max;                          # OUTPUT: «False␤»
+    say (1^..^5).excludes-max;                        # OUTPUT: «True␤»
 
 =head2 method bounds
 
@@ -109,8 +108,8 @@ otherwise.
 
 Returns a list consisting of the start and end point.
 
-    say (1..5).bounds;                                # (1 5)
-    say (1^..^5).bounds;                              # (1 5)
+    say (1..5).bounds;                                # OUTPUT: «(1 5)␤»
+    say (1^..^5).bounds;                              # OUTPUT: «(1 5)␤»
 
 =head2 method infinite
 
@@ -118,8 +117,8 @@ Returns a list consisting of the start and end point.
 
 Returns C<True> if either end point was declared with C<Inf> or C<*>.
 
-    say (1..5).infinite;                              # False
-    say (1..*).infinite;                              # True
+    say (1..5).infinite;                              # OUTPUT: «False␤»
+    say (1..*).infinite;                              # OUTPUT: «True␤»
 
 =head2 method is-int
 
@@ -127,9 +126,9 @@ Returns C<True> if either end point was declared with C<Inf> or C<*>.
 
 Returns C<True> if both end points are C<Int> values.
 
-    say ('a'..'d').is-int;                            # False
-    say (1..^5).is-int;                               # True
-    say (1.1..5.5).is-int;                            # False
+    say ('a'..'d').is-int;                            # OUTPUT: «False␤»
+    say (1..^5).is-int;                               # OUTPUT: «True␤»
+    say (1.1..5.5).is-int;                            # OUTPUT: «False␤»
 
 =head2 method int-bounds
 
@@ -155,14 +154,14 @@ the start and end point of the range unless either of L<excludes-min> or
 L<excludes-max> are C<True> in which case a L<Failure|/type/Failure> is returned.
 
     my $r1 = (1..5); my $r2 = (1^..5);
-    say $r1.is-int, ', ', $r2.is-int;                 # True, True
-    say $r1.excludes-min, ', ', $r2.excludes-min;     # False, True
-    say $r1.minmax, ', ', $r2.minmax;                 # (1 5), (2 5)
+    say $r1.is-int, ', ', $r2.is-int;                 # OUTPUT: «True, True␤»
+    say $r1.excludes-min, ', ', $r2.excludes-min;     # OUTPUT: «False, True␤»
+    say $r1.minmax, ', ', $r2.minmax;                 # OUTPUT: «(1 5), (2 5)␤»
 
     my $r3 = (1.1..5.2); my $r4 = (1.1..^5.2);
-    say $r3.is-int, ', ', $r4.is-int;                 # False, False
-    say $r3.excludes-max, ', ', $r4.excludes-max;     # False, True
-    say $r3.minmax;                                   # (1.1 5.2)
+    say $r3.is-int, ', ', $r4.is-int;                 # OUTPUT: «False, False␤»
+    say $r3.excludes-max, ', ', $r4.excludes-max;     # OUTPUT: «False, True␤»
+    say $r3.minmax;                                   # OUTPUT: «(1.1 5.2)␤»
     say $r4.minmax;
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::AdHoc: Cannot return minmax on Range with excluded ends␤»
@@ -175,8 +174,8 @@ Returns the number of elements in the range, e.g. when being iterated over,
 or when used as a C<List>.  Returns Inf if either end point was specified
 as C<Inf> or C<*>.
 
-    say (1..5).elems;                                 # 5
-    say (1^..^5).elems;                               # 3
+    say (1..5).elems;                                 # OUTPUT: «5␤»
+    say (1^..^5).elems;                               # OUTPUT: «3␤»
 
 =head2 method list
 
@@ -184,8 +183,8 @@ as C<Inf> or C<*>.
 
 Generates the list of elements that the range represents.
 
-    say (1..5).list;                                  # (1 2 3 4 5)
-    say (1^..^5).list;                                # (2 3 4)
+    say (1..5).list;                                  # OUTPUT: «(1 2 3 4 5)␤»
+    say (1^..^5).list;                                # OUTPUT: «(2 3 4)␤»
 
 =head2 method flat
 
@@ -225,8 +224,8 @@ Returns a L<Seq> where all elements that the C<Range> represents have been
 reversed. Note that reversing an infinite C<Range> won't produce any meaningful
 results.
 
-    say (1^..5).reverse;                              # (5 4 3 2)
-    say ('a'..'d').reverse;                           # (d c b a)
-    say (1..Inf).reverse;                             # (Inf Inf Inf ...)
+    say (1^..5).reverse;                              # OUTPUT: «(5 4 3 2)␤»
+    say ('a'..'d').reverse;                           # OUTPUT: «(d c b a)␤»
+    say (1..Inf).reverse;                             # OUTPUT: «(Inf Inf Inf ...)␤»
 
 =end pod

--- a/doc/Type/Rat.pod6
+++ b/doc/Type/Rat.pod6
@@ -28,8 +28,8 @@ the denominator quickly:
         $x = ($x + $n / $x) / 2 for ^$iterations;
         return $x;
     }
-    say approx-sqrt(2, 5).WHAT;     # (Rat)
-    say approx-sqrt(2, 10).WHAT;    # (Num)
+    say approx-sqrt(2, 5).WHAT;     # OUTPUT: «(Rat)␤»
+    say approx-sqrt(2, 10).WHAT;    # OUTPUT: «(Num)␤»
 
 If you want arbitrary precision arithmetic with rational numbers, use the
 L<FatRat|/type/FatRat> type instead.
@@ -49,7 +49,7 @@ the form "C<< <3/5> >>", without internal spaces, and including the
 angles that keep the C</> from being treated as a normal division
 operator.
 
-    say (1/3).perl;                # <1/3>
-    say (2/4).perl;                # 0.5
+    say (1/3).perl;                # OUTPUT: «<1/3>␤»
+    say (2/4).perl;                # OUTPUT: «0.5␤»
 
 =end pod

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -11,7 +11,7 @@ allow for the representation of a value as both a string and a numeric type, typ
 they will be created for you when the context is "stringy" but they can be determined
 to be numbers, such as in some L<quoting constructs|/language/quoting>:
 
-    my $f = <42.1>; say $f.WHAT; # (RatStr)
+    my $f = <42.1>; say $f.WHAT; # OUTPUT: «(RatStr)␤»
 
 As a subclass of both L«C<Rat>|/type/Rat» and L«C<Str>|/type/Str», a C<RatStr>
 will be accepted where either is expected. However, C<RatStr> does not share
@@ -32,8 +32,8 @@ The constructor requires both the C<Rat> and the C<Str> value, when constructing
 directly the values can be whatever is required:
 
     my $f = RatStr.new(42.1, "forty two and a bit");
-    say +$f; # -> 42.1
-    say ~$f; # -> "forty two and a bit"
+    say +$f; # OUTPUT: «42.1␤»
+    say ~$f; # OUTPUT: «"forty two and a bit"␤»
 
 =head2 method Numeric
 
@@ -65,8 +65,8 @@ coerce to the C<Rat> or C<Str> values first:
 
     my $f = RatStr.new(42.1, "smaller");
     my $g = RatStr.new(43.1, "larger");
-    say $f cmp $g;          # Less
-    say $f.Str cmp $g.Str;  # More
+    say $f cmp $g;          # OUTPUT: «Less␤»
+    say $f.Str cmp $g.Str;  # OUTPUT: «More␤»
 
 =end pod
 

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -64,15 +64,15 @@ Returns a list of two strings that, when concatenated, represent the number in
 base C<$base>. The second element is the one that repeats. For example:
 
     my ($non-rep, $repeating) = (19/3).base-repeating(10);
-    say $non-rep;                               # 6.
-    say $repeating;                             # 3
-    printf '%s(%s)', $non-rep, $repeating;      # 6.(3)
+    say $non-rep;                               # OUTPUT: «6.␤»
+    say $repeating;                             # OUTPUT: «3␤»
+    printf '%s(%s)', $non-rep, $repeating;      # OUTPUT: «6.(3)»
 
 19/3 is 6.333333... with the 3 repeating indefinitely.
 
 If no repetition occurs, the second string is empty:
 
-    say (5/2).base-repeating(10).perl;          # ("2.5", "")
+    say (5/2).base-repeating(10).perl;          # OUTPUT: «("2.5", "")␤»
 
 The precision for determining the repeating group is limited to 1000
 characters, above that, the second string is C<???>.

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -82,9 +82,9 @@ digits).
 
 The final digit produced is always rounded.
 
-    say pi.base(10, 3);      # 3.142
-    say (1/128).base(10, *); # 0.0078125
-    say (1/100).base(10, *); # 0.01
+    say pi.base(10, 3);      # OUTPUT: «3.142␤»
+    say (1/128).base(10, *); # OUTPUT: «0.0078125␤»
+    say (1/100).base(10, *); # OUTPUT: «0.01␤»
 =begin code :skip-test
     say (1/3)  .base(10, *); # WRONG: endlessly repeating fractional part
 =end code

--- a/doc/Type/Regex.pod6
+++ b/doc/Type/Regex.pod6
@@ -23,17 +23,16 @@ definition in curly braces. Since any regex does C<Callable> introspection requi
 referencing via C<&>-sigil.
 
     my regex R { \N };
-    say &R.WHAT;
-    # OUTPUT: «(Regex)␤»
+    say &R.WHAT; # OUTPUT: «(Regex)␤»
 
 To match a string against a regex, you can use the smart match operator:
 
     my $match = 'abc' ~~ rx/ ^ab /;
-    say $match.Bool;                # True
-    say $match.orig;                # abc
-    say $match.Str;                 # ab
-    say $match.from;                # 0
-    say $match.to;                  # 2
+    say $match.Bool;                # OUTPUT: «True␤»
+    say $match.orig;                # OUTPUT: «abc␤»
+    say $match.Str;                 # OUTPUT: «ab␤»
+    say $match.from;                # OUTPUT: «0␤»
+    say $match.to;                  # OUTPUT: «2␤»
 
 Or you can evaluate the regex in boolean context, in which case it matches
 against the C<$_> variable

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -52,7 +52,7 @@ given L<Capture|/type/Capture>, ordered by narrowest candidate first. For
 methods, the first element of the Capture needs to be the invocant:
 
     .signature.say for "foo".^can("comb")[0].cando: \(Cool, "o");
-    # (Cool $: Str $matcher, $limit = Inf, *%_)
+    # OUTPUT: «(Cool $: Str $matcher, $limit = Inf, *%_)␤»
 
 =head2 method wrap
 
@@ -79,8 +79,8 @@ Restores the original routine after it has been wrapped with L<wrap>.
 
 Returns C<True> if the routine is a stub
 
-    say (sub f() { ... }).yada;      # True
-    say (sub g() { 1;  }).yada;      # False
+    say (sub f() { ... }).yada;      # OUTPUT: «True␤»
+    say (sub g() { 1;  }).yada;      # OUTPUT: «False␤»
 
 =head2 trait is cached
 

--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -31,22 +31,22 @@ tell if this has been done by examining the introspective pseudo-method
 C<.VAR>:
 
     my $a = 1;
-    $a.WHAT.say;     # (Int)
-    $a.VAR.WHAT.say; # (Scalar)
+    $a.WHAT.say;     # OUTPUT: «(Int)␤»
+    $a.VAR.WHAT.say; # OUTPUT: «(Scalar)␤»
     my $b := 1;
-    $b.WHAT.say;     # (Int)
-    $b.VAR.WHAT.say; # (Int)
+    $b.WHAT.say;     # OUTPUT: «(Int)␤»
+    $b.VAR.WHAT.say; # OUTPUT: «(Int)␤»
 
 This same thing happens when values are assigned to an element of
 an C<Array>, however, C<List>s directly contain their values:
 
     my @a = 1, 2, 3;
-    @a[0].WHAT.say;            # (Int)
-    @a[0].VAR.WHAT.say;        # (Scalar)
-    [1, 2, 3][0].WHAT.say;     # (Int)
-    [1, 2, 3][0].VAR.WHAT.say; # (Scalar)
-    (1, 2, 3)[0].WHAT.say;     # (Int)
-    (1, 2, 3)[0].VAR.WHAT.say; # (Int)
+    @a[0].WHAT.say;            # OUTPUT: «(Int)␤»
+    @a[0].VAR.WHAT.say;        # OUTPUT: «(Scalar)␤»
+    [1, 2, 3][0].WHAT.say;     # OUTPUT: «(Int)␤»
+    [1, 2, 3][0].VAR.WHAT.say; # OUTPUT: «(Scalar)␤»
+    (1, 2, 3)[0].WHAT.say;     # OUTPUT: «(Int)␤»
+    (1, 2, 3)[0].VAR.WHAT.say; # OUTPUT: «(Int)␤»
 
 Array elements may be bound directly to values using C<:=> as well,
 however this is to be discouraged as it may lead to confusion.
@@ -54,8 +54,8 @@ Doing so will break exact round-tripping of C<.perl> output – since
 C<Array>s are assumed to place C<Scalar>s around each element,
 C<Scalar>s are not denoted with C<$> in the output of C<Array.perl>.
 
-    [1, $(2, 3)].perl.say;     # [1, (2, 3)]
-    (1, $(2, 3)).perl.say;     # (1, $(2, 3))
+    [1, $(2, 3)].perl.say;     # OUTPUT: «[1, (2, 3)]␤»
+    (1, $(2, 3)).perl.say;     # OUTPUT: «(1, $(2, 3))␤»
 
 Binding a Scalar to a C<$>-sigiled variable replaces the existing
 C<Scalar> in that variable, if any, with the given C<Scalar>.
@@ -66,7 +66,7 @@ alter the value of both variables by altering only one of them:
     my $a = 1;
     my $b := $a;
     $b = 2;
-    $a.say;       # 2
+    $a.say;       # OUTPUT: «2␤»
 
 X<|\ (sigilless scalar)>
 SSA-style constants bind directly to their value with no
@@ -76,14 +76,14 @@ to them, at which point, they behave entirely like C<$>-sigiled
 variables.
 
     my \c = 1;
-    c.WHAT.say;              # (Int)
-    c.VAR.WHAT.say;          # (Int)
+    c.WHAT.say;              # OUTPUT: «(Int)␤»
+    c.VAR.WHAT.say;          # OUTPUT: «(Int)␤»
     my $a = 1;
     my \d = $a;              # just "my \d = $ = 1" works, too
-    d.WHAT.say;              # (Int)
-    d.VAR.WHAT.say;          # (Scalar)
+    d.WHAT.say;              # OUTPUT: «(Int)␤»
+    d.VAR.WHAT.say;          # OUTPUT: «(Scalar)␤»
     d = 2;                   # ok
-    c = 2;
+    c = 2;                   # fails
     CATCH { default { put .^name, ': ', .Str } };
     # OUTPUT: «X::Assignment::RO: Cannot modify an immutable Int␤»
 

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -16,8 +16,8 @@ compare positively with the L<===> operator):
 =begin code
 my $fruits = set <peach apple orange apple apple>;
 
-say $fruits.elems;      # 3
-say $fruits.keys.sort;  # apple orange peach
+say $fruits.elems;      # OUTPUT: «3␤»
+say $fruits.keys.sort;  # OUTPUT: «apple orange peach␤»
 =end code
 
 C<Set>s can be treated as object hashes using the C<{ }> postcircumfix operator,
@@ -25,8 +25,8 @@ which returns the value C<True> for keys that are elements of the set, and
 C<False> for keys that aren't:
 
     my $fruits = set <peach apple orange apple apple>;
-    say $fruits<apple>;  # True
-    say $fruits<kiwi>;   # False
+    say $fruits<apple>;  # OUTPUT: «True␤»
+    say $fruits<kiwi>;   # OUTPUT: «False␤»
 
 =head1 Creating C<Set> objects
 
@@ -35,8 +35,8 @@ which it is a shorthand). Any positional parameters, regardless of their type,
 become elements of the set:
 
     my $n = set "zero" => 0, "one" => 1, "two" => 2;
-    say $n.keys.perl;        # (:two(2), :zero(0), :one(1)).Seq
-    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
+    say $n.keys.perl;        # OUTPUT: «(:two(2), :zero(0), :one(1)).Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Pair) (Pair) (Pair))␤»
 
 Alternatively, the C<.Set> coercer (or its functional form, C<Set()>) can be
 called on an existing object to coerce it to a C<Set>. Its semantics depend on
@@ -46,15 +46,15 @@ Hash-like objects or Pair items, only the keys become elements of the set - and
 keys mapped to values which boolify to C<False> are skipped:
 
     my $n = ("zero" => 0, "one" => 1, "two" => 2).Set;
-    say $n.keys.perl;        # ("one", "two").Seq
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.keys.perl;        # OUTPUT: «("one", "two").Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
 
 Furthermore, you can get a C<Set> by using set operators (see next section) on
 objects of other types such as L<List>, which will internally call C<.Set>
 on them before performing the operation. Be aware of the tight precedence of
 those operators though, which may require you to use parentheses around arguments:
 
-    say (1..5) (^) 4;  # set(1, 2, 3, 5)
+    say (1..5) (^) 4;  # OUTPUT: «set(1, 2, 3, 5)␤»
 
 =head1 Operators
 
@@ -65,14 +65,14 @@ example:
 =begin code
 my ($a, $b) = set(1, 2, 3), set(2, 4);
 
-say $a (<) $b;  # False
-say $a (&) $b;  # set(2)
-say $a (^) $b;  # set(1, 3, 4)
+say $a (<) $b;  # OUTPUT: «False␤»
+say $a (&) $b;  # OUTPUT: «set(2)␤»
+say $a (^) $b;  # OUTPUT: «set(1, 3, 4)␤»
 
 # Unicode versions:
-say $a ⊂ $b;  # False
-say $a ∩ $b;  # set(2)
-say $a ⊖ $b;  # set(1, 3, 4)
+say $a ⊂ $b;  # OUTPUT: «False␤»
+say $a ∩ $b;  # OUTPUT: «set(2)␤»
+say $a ⊖ $b;  # OUTPUT: «set(1, 3, 4)␤»
 =end code
 
 See L<Set/Bag Operators|/language/setbagmix#Set/Bag_Operators> for a complete

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -16,8 +16,8 @@ compare positively with the L<===> operator):
 =begin code
 my $fruits = <peach apple orange apple apple>.SetHash;
 
-say $fruits.elems;      # 3
-say $fruits.keys.sort;  # apple orange peach
+say $fruits.elems;      # OUTPUT: «3␤»
+say $fruits.keys.sort;  # OUTPUT: «apple orange peach␤»
 =end code
 
 C<SetHash>es can be treated as object hashes using the C<{ }> postcircumfix
@@ -28,11 +28,11 @@ or C<False>, respectively, can be used to add or remove a set element:
 =begin code
 my $fruits = <peach apple orange apple apple>.SetHash;
 
-say $fruits<apple>;     # True
-say $fruits<kiwi>;      # False
+say $fruits<apple>;     # OUTPUT: «True␤»
+say $fruits<kiwi>;      # OUTPUT: «False␤»
 
 $fruits<apple kiwi> = False, True;
-say $fruits.keys.sort;  # kiwi orange peach
+say $fruits.keys.sort;  # OUTPUT: «kiwi orange peach␤»
 =end code
 
 =head1 Creating C<SetHash> objects
@@ -41,8 +41,8 @@ C<SetHash>es can be composed using C<SetHash.new>. Any positional parameters,
 regardless of their type, become elements of the set:
 
     my $n = SetHash.new: "zero" => 0, "one" => 1, "two" => 2;
-    say $n.keys.perl;        # (:two(2), :zero(0), :one(1)).Seq
-    say $n.keys.map(&WHAT);  # ((Pair) (Pair) (Pair))
+    say $n.keys.perl;        # OUTPUT: «(:two(2), :zero(0), :one(1)).Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Pair) (Pair) (Pair))␤»
 
 Alternatively, the C<.SetHash> coercer (or its functional form, C<SetHash()>)
 can be called on an existing object to coerce it to a C<SetHash>. Its semantics
@@ -52,8 +52,8 @@ although for Hash-like objects or Pair items, only the keys become elements of
 the set - and keys mapped to values which boolify to C<False> are skipped:
 
     my $n = ("zero" => 0, "one" => 1, "two" => 2).SetHash;
-    say $n.keys.perl;        # ("one", "two").Seq
-    say $n.keys.map(&WHAT);  # ((Str) (Str))
+    say $n.keys.perl;        # OUTPUT: «("one", "two").Seq␤»
+    say $n.keys.map(&WHAT);  # OUTPUT: «((Str) (Str))␤»
 
 =head1 Operators
 
@@ -64,16 +64,16 @@ For example:
 =begin code
 my ($a, $b) = SetHash.new(1, 2, 3), SetHash.new(2, 4);
 
-say $a (<) $b;  # False
-say $a (&) $b;  # set(2)
-say $a (^) $b;  # set(1, 3, 4)
-say $a (|) $b;  # set(1, 2, 3, 4)
+say $a (<) $b;  # OUTPUT: «False␤»
+say $a (&) $b;  # OUTPUT: «set(2)␤»
+say $a (^) $b;  # OUTPUT: «set(1, 3, 4)␤»
+say $a (|) $b;  # OUTPUT: «set(1, 2, 3, 4)␤»
 
 # Unicode versions:
-say $a ⊂ $b;  # False
-say $a ∩ $b;  # set(2)
-say $a ⊖ $b;  # set(1, 3, 4)
-say $a ∪ $b;  # set(1, 2, 3, 4)
+say $a ⊂ $b;  # OUTPUT: «False␤»
+say $a ∩ $b;  # OUTPUT: «set(2)␤»
+say $a ⊖ $b;  # OUTPUT: «set(1, 3, 4)␤»
+say $a ∪ $b;  # OUTPUT: «set(1, 2, 3, 4)␤»
 =end code
 
 See L<Set/Bag Operators|/language/setbagmix#Set/Bag Operators> for a

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -21,8 +21,7 @@ Constructs a Setty object from a list of L«C<Pair> objects|/type/Pair»
 given as positional arguments:
 
     say Set.new-from-pairs: 'butter' => 0.22, 'salt' => 0, 'sugar' => 0.02;
-    # OUTPUT:
-    # set(butter, sugar)
+    # OUTPUT: «set(butter, sugar)␤»
 
 B<Note:> be sure you aren't accidentally passing the Pairs as positional arguments;
 the quotes around the keys in the above example are significant.
@@ -83,7 +82,7 @@ Defined as:
 Returns a L<Seq|/type/Seq> of all elements of the set.
 
     my $s = Set.new(1, 2, 3);
-    say $s.keys;                                      # (3 1 2)
+    say $s.keys;                                      # OUTPUT: «(3 1 2)␤»
 
 =head2 method values
 
@@ -94,7 +93,7 @@ Defined as:
 Returns a L<Seq|/type/Seq> containing as many C<True> values as the set has elements.
 
     my $s = Set.new(1, 2, 3);
-    say $s.values;                                    # (True True True)
+    say $s.values;                                    # OUTPUT: «(True True True)␤»
 
 =head2 method kv
 
@@ -105,7 +104,7 @@ Defined as:
 Returns a L<Seq|/type/Seq> of the set's elements and C<True> values interleaved.
 
     my $s = Set.new(1, 2, 3);
-    say $s.kv;                                        # (3 True 1 True 2 True)
+    say $s.kv;                                        # OUTPUT: «(3 True 1 True 2 True)␤»
 
 =head2 method elems
 
@@ -132,11 +131,11 @@ previously initialized or when accessing an element which has explicitly
 been set to C<Nil> or C<False>.
 
     my $s1 = SetHash.new(1, 2, 3);
-    say $s1{2};                                           # True
+    say $s1{2};                                           # OUTPUT: «True␤»
     $s1{2} = Nil;
-    say $s1{2};                                           # False
+    say $s1{2};                                           # OUTPUT: «False␤»
     # access non initialized element
-    say $s1{4};                                           # False
+    say $s1{4};                                           # OUTPUT: «False␤»
 
 =head2 method ACCEPTS
 
@@ -154,7 +153,7 @@ Defined as:
 Returns a L<Bag|/type/Bag> containing the elements of the invocant.
 
     my Bag $b = Set.new(1, 2, 3).Bag;
-    say $b;                                           # bag(3, 1, 2)
+    say $b;                                           # OUTPUT: «bag(3, 1, 2)␤»
 
 =head2 method BagHash
 
@@ -165,7 +164,7 @@ Defined as:
 Returns a L<BagHash|/type/BagHash> containing the elements of the invocant.
 
     my BagHash $b = Set.new(1, 2, 3).BagHash;
-    say $b;                                           # BagHash.new(3, 1, 2)
+    say $b;                                           # OUTPUT: «BagHash.new(3, 1, 2)␤»
 
 =head2 method Bool
 
@@ -176,10 +175,10 @@ Defined as:
 Returns C<True> if the invocant contains at least one element.
 
     my $s1 = Set.new(1, 2, 3);
-    say $s1.Bool;                                     # True
+    say $s1.Bool;                                     # OUTPUT: «True␤»
 
     my $s2 = $s1 ∩ Set.new(4, 5);                     # set intersection operator
-    say $s2.Bool;                                     # False
+    say $s2.Bool;                                     # OUTPUT: «False␤»
 
 =head2 method Mix
 
@@ -190,7 +189,7 @@ Defined as:
 Returns a L<Mix|/type/Mix> containing the elements of the invocant.
 
     my Mix $b = Set.new(1, 2, 3).Mix;
-    say $b;                                           # mix(3, 1, 2)
+    say $b;                                           # OUTPUT: «mix(3, 1, 2)␤»
 
 =head2 method MixHash
 
@@ -201,7 +200,7 @@ Defined as:
 Returns a L<MixHash|/type/MixHash> containing the elements of the invocant.
 
     my MixHash $b = Set.new(1, 2, 3).MixHash;
-    say $b;                                           # MixHash.new(3, 1, 2)
+    say $b;                                           # OUTPUT: «MixHash.new(3, 1, 2)␤»
 
 =head1 See Also
 

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -57,18 +57,18 @@ Smart matching signatures against a List is supported.
 
     my $sig = :(Int $i, Str $s);
     say (10, 'answer') ~~ $sig;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
     given ('answer', 10) {
         when :(Str, Int) { say 'match' }
         when $sig { say 'mismatch' }
     }
-    # OUTPUT«match␤»
+    # OUTPUT: «match␤»
 
 When smart matching against a Hash, the signature is assumed to consist of the keys of the Hash.
 
     my %h = left => 1, right => 2;
     say %h ~~ :(:$left, :$right);
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head2 Parameter Separators
 
@@ -90,7 +90,7 @@ is bound to.
             "Well I'm class $me.^name(), of course!"
         }
     }
-    say Foo.whoami; # => Well I'm class Foo, of course!
+    say Foo.whoami; # OUTPUT: «Well I'm class Foo, of course!␤»
 
 X<|type constraint (Signature)>
 =head2 Type Constraints
@@ -105,7 +105,7 @@ my $sig = :(Int $a, Str $b);
 sub divisors(Int $n) { $_ if $n %% $_ for 1..$n };
 divisors 2.5;
 CATCH { default { put .^name, ': ', .Str } };
-# OUTPUT«X::TypeCheck::Argument: Calling divisors(Rat) will never work with declared signature (Int $n)␤»
+# OUTPUT: «X::TypeCheck::Argument: Calling divisors(Rat) will never work with declared signature (Int $n)␤»
 =end code
 
 X<|anonymous arguments (Signature)>
@@ -148,8 +148,7 @@ the C<where>-clause inside the sub-signature.
     sub one-of-them(:$a, :$b, :$c where { $a.defined ^^ $b.defined ^^ $c.defined }) {
         $a // $b // $c
     };
-    say one-of-them(c=>42);
-    # OUTPUT«42␤»
+    say one-of-them(c=>42); # OUTPUT: «42␤»
 
 =head3 Constraining Optional Arguments
 
@@ -170,7 +169,7 @@ can be used to that effect.
     f(42);
     f(<a>);
     CATCH { default { say .^name, ' ==> ', .Str }  }
-    # OUTPUT«[42]␤Constraint type check failed for parameter '@a'␤  in sub f at ...»
+    # OUTPUT: «[42]␤Constraint type check failed for parameter '@a'␤  in sub f at ...»
 
 =head3 Constraining named Arguments
 
@@ -180,7 +179,7 @@ part of the L<colon-pair|/type/Pair>.
     sub f(Int :$i){};
     f :i<forty-two>;
     CATCH { default { say .^name, ' ==> ', .Str }  }
-    # OUTPUT«X::TypeCheck::Binding ==> Type check failed in binding to $i; expected Int but got Str ("forty-two")␤»
+    # OUTPUT: «X::TypeCheck::Binding ==> Type check failed in binding to $i; expected Int but got Str ("forty-two")␤»
 
 =head3 X<Constraining Defined and Undefined Values|
          type constraint,:D;type constraint,:U;type constraint,:_>
@@ -208,8 +207,8 @@ use the C<:D> type constraint.
     sub limit-lines(Str:D $s, Int $limit) { };
     say limit-lines Str, 3;
     CATCH { default { put .^name ~ '--' ~~ .Str } };
-    # OUTPUT«X::AdHoc--Parameter '$s' requires an instance of type Str, but a
-    # type object was passed.  Did you forget a .new?»
+    # OUTPUT: «X::AdHoc--Parameter '$s' requires an instance of type Str, but a
+    #           type object was passed.  Did you forget a .new?»
 
 This is much better than the way the program failed before, since here the
 reason for failure is clearer.
@@ -222,7 +221,7 @@ the C<:U> constraint.
 =for code :allow<B L>
 multi limit-lines(Str $s, Int:D $limit) { }
 multi limit-lines(Str $s, Int:U $) { $s }
-say limit-lines "a \n b \n c", Int; # "a \n b \n c"
+say limit-lines "a \n b \n c", Int; # OUTPUT: «"a \n b \n c"␤»
 
 For explicitly indicating the normal behaviour, C<:_> can be used, but this is
 unnecessary. C<:(Num:_ $)> is the same as C<:(Num $)>.
@@ -235,7 +234,7 @@ on their signature write the signature after the argument name.
     sub f(&c:(Int, Str))  { say c(10, 'ten') };
     sub g(Int $i, Str $s) { $s ~ $i };
     f(&g);
-    # OUTPUT«ten10␤»
+    # OUTPUT: «ten10␤»
 
 =head3 X«Constraining Return Types|-->;returns»
 
@@ -280,7 +279,7 @@ L<C<Nil>|/type/Nil> and L<C<Failure>|/type/Failure> are always allowed as return
 regardless of any type constraint.
 
     sub foo(--> Int) { Nil };
-    say foo.perl; # Nil
+    say foo.perl; # OUTPUT: «Nil␤»
 
 Type captures and coercion types are not supported.
 
@@ -292,13 +291,13 @@ be omitted.
 
     sub f(Int(Str) $want-int, Str() $want-str) { say $want-int.WHAT, $want-str.WHAT }
     f '10', 10;
-    # OUTPUT«(Int)(Str)␤»
+    # OUTPUT: «(Int)(Str)␤»
 
     use MONKEY;
     augment class Str { method Date() { Date.new(self) } };
     sub foo(Date(Str) $d) { say $d.WHAT; say $d };
     foo "2016-12-01";
-    # OUTPUT«Date.new(2016,11,1)␤»
+    # OUTPUT: «Date.new(2016,11,1)␤»
 
 =head2 X<Slurpy (A.K.A. Variadic) Parameters|parameter,*@;parameter,*%,slurpy argument (Signature)>
 
@@ -324,14 +323,14 @@ to a function, like someone slurping up noodles.
     # one-arg  5, 6, 7 ; # X::TypeCheck::Argument
 
     sub named-names (*%named-args) { %named-args.keys };
-    say named-names :foo(42) :bar<baz>; # foo bar
+    say named-names :foo(42) :bar<baz>; # OUTPUT: «foo bar␤»
 
 Note that positional parameters aren't allowed after slurpy parameters.
 
 =begin code :skip-test
 :(*@args, $last);
 CATCH { when X::Parameter::WrongOrder { put .^name, ': ', .Str } }
-# OUTPUT«X::Parameter::WrongOrder: Cannot put required parameter $last after variadic parameters␤»
+# OUTPUT: «X::Parameter::WrongOrder: Cannot put required parameter $last after variadic parameters␤»
 =end code
 
 Normally a slurpy parameter will create an Array, create a new
@@ -366,11 +365,11 @@ dissolving one or more layers of bare C<Iterables>.
     my @array = <a b c>;
     my $list := <d e f>;
     sub a(*@a)  { @a.perl.say };
-    a(@array);                 # ["a", "b", "c"]
-    a(1, $list, [2, 3]);       # [1, "d", "e", "f", 2, 3]
-    a([1, 2]);                 # [1, 2]
-    a(1, [1, 2], ([3, 4], 5)); # [1, 1, 2, 3, 4 5]
-    a(($_ for 1, 2, 3));       # [1, 2, 3]
+    a(@array);                 # OUTPUT: «["a", "b", "c"]»
+    a(1, $list, [2, 3]);       # OUTPUT: «[1, "d", "e", "f", 2, 3]»
+    a([1, 2]);                 # OUTPUT: «[1, 2]»
+    a(1, [1, 2], ([3, 4], 5)); # OUTPUT: «[1, 1, 2, 3, 4 5]»
+    a(($_ for 1, 2, 3));       # OUTPUT: «[1, 2, 3]»
 
 A single asterisk slurpy flattens all given iterables, effectively hoisting any
 object created with commas up to the top level.
@@ -383,11 +382,11 @@ within the list, but keep the arguments more or less as-is:
     my @array = <a b c>;
     my $list := <d e f>;
     sub b(**@b) { @b.perl.say };
-    b(@array);                 # [["a", "b", "c"]]
-    b(1, $list, [2, 3]);       # [1, ("d", "e", "f"), [2, 3]]
-    b([1, 2]);                 # [[1, 2]]
-    b(1, [1, 2], ([3, 4], 5)); # [1, [1, 2], ([3, 4], 5)]
-    b(($_ for 1, 2, 3));       # [(1, 2, 3),]
+    b(@array);                 # OUTPUT: «[["a", "b", "c"]]␤»
+    b(1, $list, [2, 3]);       # OUTPUT: «[1, ("d", "e", "f"), [2, 3]]␤»
+    b([1, 2]);                 # OUTPUT: «[[1, 2]]␤»
+    b(1, [1, 2], ([3, 4], 5)); # OUTPUT: «[1, [1, 2], ([3, 4], 5)]␤»
+    b(($_ for 1, 2, 3));       # OUTPUT: «[(1, 2, 3),]␤»
 
 The double asterisk slurpy hides the nested comma objects and leaves them as-is
 in the slurpy array.
@@ -403,11 +402,11 @@ C<**@>.
     my @array = <a b c>;
     my $list := <d e f>;
     sub c(+@b) { @b.perl.say };
-    c(@array);                 # ["a", "b", "c"]
-    c(1, $list, [2, 3]);       # [1, ("d", "e", "f"), [2, 3]]
-    c([1, 2]);                 # [1, 2]
-    c(1, [1, 2], ([3, 4], 5)); # [1, [1, 2], ([3, 4], 5)]
-    c(($_ for 1, 2, 3));       # [1, 2, 3]
+    c(@array);                 # OUTPUT: «["a", "b", "c"]␤»
+    c(1, $list, [2, 3]);       # OUTPUT: «[1, ("d", "e", "f"), [2, 3]]␤»
+    c([1, 2]);                 # OUTPUT: «[1, 2]␤»
+    c(1, [1, 2], ([3, 4], 5)); # OUTPUT: «[1, [1, 2], ([3, 4], 5)]␤»
+    c(($_ for 1, 2, 3));       # OUTPUT: «[1, 2, 3]␤»
 
 For additional discussion and examples, see L<Slurpy Conventions for Functions|/language/functions#Slurpy_Conventions>.
 
@@ -448,14 +447,14 @@ On the caller side, positional arguments are passed in the same order
 as the parameters were declared.
 
     sub pos($x, $y) { "x=$x y=$y" }
-    pos(4, 5);                          # x=4 y=5
+    pos(4, 5);                          # RESULT: «x=4 y=5»
 
 In the case of named arguments and parameters, only the name is used for
 mapping arguments to parameters
 
     =for code :allow<L>
     sub named(:$x, :$y) { "x=$x y=$y" }
-    named( y => 5, x => 4);             # x=4 y=5
+    named( y => 5, x => 4);             # RESULT: «x=4 y=5»
 
 It is possible to have a different name for a named parameter than the
 variable name:
@@ -474,11 +473,11 @@ L<Pair|/type/Pair> with C<|> to turn it into a named argument.
     multi f(:$named) { note &?ROUTINE.signature };
     multi f(:$also-named) { note &?ROUTINE.signature };
     for 'named', 'also-named' -> $n {
-        f(|($n => rand))                    # «(:$named)␤(:$also-named)␤»
+        f(|($n => rand))                    # RESULT: «(:$named)␤(:$also-named)␤»
     }
 
     my $pair = :named(1);
-    f |$pair;                               # «(:$named)␤»
+    f |$pair;                               # RESULT: «(:$named)␤»
 
 The same can be used to convert a C<Hash> into named arguments.
 
@@ -493,7 +492,7 @@ before slipping.
     class C { has $.x; has $.y; has @.z };
     my %h = <x y z> Z=> (5, 20, [1,2]);
     say C.new(|%h.Map);
-    # OUTPUT«C.new(x => 5, y => 20, z => [1, 2])␤»
+    # OUTPUT: «C.new(x => 5, y => 20, z => [1, 2])␤»
 
 X<|optional argument (Signature)>
 =head2 Optional and Mandatory Parameters
@@ -556,7 +555,7 @@ name in parentheses.
        put "called with {c.perl}"
     };
     foo(42, "answer");
-    # OUTPUT«called with \(42, "answer")␤»
+    # OUTPUT: «called with \(42, "answer")␤»
 
 X<|Long Names>
 =head2 Long Names
@@ -566,7 +565,7 @@ separate them with a double semi-colon.
 
     multi sub f(Int $i, Str $s;; :$b) { dd $i, $s, $b };
     f(10, 'answer');
-    # OUTPUT«10␤"answer"␤Any $b = Any␤»
+    # OUTPUT: «10␤"answer"␤Any $b = Any␤»
 
 =head2 X<Capture Parameters|parameter,|>
 
@@ -584,7 +583,7 @@ If bound to a variable arguments can be forwarded as a whole using the slip oper
     sub a(Int $i, Str $s) { say $i.WHAT, $s.WHAT }
     sub b(|c) { say c.WHAT; a(|c) }
     b(42, "answer");
-    # OUTPUT«(Capture)␤(Int)(Str)␤»
+    # OUTPUT: «(Capture)␤(Int)(Str)␤»
 
 =head2 X<Parameter Traits and Modifiers|trait,is copy;trait,is rw>
 
@@ -648,7 +647,7 @@ to the signature. Returns C<Inf> if there is a slurpy positional parameter.
 
 Whatever the Signature's return constraint is:
 
-    :($a, $b --> Int).returns # Int
+    :($a, $b --> Int).returns # RESULT: «Int»
 
 =head2 method ACCEPTS
 
@@ -661,13 +660,13 @@ The first three see if the argument could be bound to the capture,
 i.e., if a function with that C<Signature> would be able to be called
 with the C<$topic>:
 
-    (1, 2, :foo) ~~ :($a, $b, :foo($bar));   # True
-    <a b c d> ~~ :(Int $a);                  # False
+    (1, 2, :foo) ~~ :($a, $b, :foo($bar));   # RESULT: «True»
+    <a b c d> ~~ :(Int $a);                  # RESULT: «False»
 
 The last returns C<True> if anything accepted by C<$topic> would also
 be accepted by the C<Signature>.
 
-    :($a, $b) ~~ :($foo, $bar, $baz?);   # True
-    :(Int $n) ~~ :(Str);                 # False
+    :($a, $b) ~~ :($foo, $bar, $baz?);   # RESULT: «True»
+    :(Int $n) ~~ :(Str);                 # RESULT: «False»
 
 =end pod

--- a/doc/Type/Slip.pod6
+++ b/doc/Type/Slip.pod6
@@ -12,11 +12,11 @@ list-like container or iterable).
 For example it allows you to write a L<map> that produces more than one value
 into the result without nesting:
 
-    say <a b c>.map({ ($_, $_.uc).Slip }).join('|');        # a|A|b|B|c|C
+    say <a b c>.map({ ($_, $_.uc).Slip }).join('|');        # OUTPUT: «a|A|b|B|c|C␤»
 
 In contrast, when returning an ordinary List, the resulting list is nested:
 
-    say <a b c>.map({ $_, $_.uc }).join('|');               # a A|b B|c C
+    say <a b c>.map({ $_, $_.uc }).join('|');               # OUTPUT: «a A|b B|c C␤»
 
 To create a C<Slip>, either coerce another list-like type to it by calling the
 C<Slip> method, or use the C<slip> subroutine:
@@ -50,9 +50,9 @@ a routine call. It does not forward a C<Slip> to the called routine, that
 includes C<return> and C<take>.
 
     my \l = gather for 1..10 -> $a, $b { take |($a, $b) }; say l.perl;
-    # OUTPUT«((1, 2), (3, 4), (5, 6), (7, 8), (9, 10)).Seq␤»
+    # OUTPUT: «((1, 2), (3, 4), (5, 6), (7, 8), (9, 10)).Seq␤»
     my \m= gather for 1..10 -> $a, $b { take ($a, $b).Slip }; say m.perl;
-    # OUTPUT«(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Seq␤»
+    # OUTPUT: «(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Seq␤»
 
 =head1 Methods
 

--- a/doc/Type/Stash.pod6
+++ b/doc/Type/Stash.pod6
@@ -19,15 +19,15 @@ a literal, append two colons:
         my sub lexical { };
         method a_method() { }
     }
-    say Boring::.^name;             # Stash
-    say Boring.WHO === Boring::;    # True
+    say Boring::.^name;             # OUTPUT: «Stash␤»
+    say Boring.WHO === Boring::;    # OUTPUT: «True␤»
 
 Since it inherits from L<Hash|/type/Hash>, you can use all the usual hash
 functionality:
 
 =for code :skip-test
-say Boring::.keys.sort;         # (&package_sub Nested)
-say Boring::<Nested>;           # (Nested)
+say Boring::.keys.sort;         # OUTPUT: «(&package_sub Nested)␤»
+say Boring::<Nested>;           # OUTPUT: «(Nested)␤»
 
 As the example above shows only "our"-scoped things appear in the C<Stash>
 (nested classes are "our" by default, but can be excluded with "my".)  Lexicals

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -29,9 +29,9 @@ C<NEWLINE> property) removed from the end.
 
 Examples:
 
-    say chomp("abc\n");       # abc
-    say "def\r\n".chomp;      # def  NOTE: \r\n is a single grapheme!
-    say "foo\r".chomp;        # foo
+    say chomp("abc\n");       # OUTPUT: «abc␤»
+    say "def\r\n".chomp;      # OUTPUT: «def␤» NOTE: \r\n is a single grapheme!
+    say "foo\r".chomp;        # OUTPUT: «foo␤»
 
 =head2 routine lc
 
@@ -44,8 +44,8 @@ Returns a lower-case version of the string.
 
 Examples:
 
-    lc("A"); # returns "a"
-    "A".lc;  # returns "a"
+    lc("A"); # RESULT: «"a"»
+    "A".lc;  # RESULT: «"a"»
 
 =head2 routine uc
 
@@ -98,9 +98,9 @@ every word is capitalized, and all the other letters lowercased.
 Returns the numeric value that the first codepoint in the invocant represents,
 or C<NaN> if it's not numeric.
 
-    say '4'.unival;     # 4
-    say '¾'.unival;     # 0.75
-    say 'a'.unival;     # NaN
+    say '4'.unival;     # OUTPUT: «4␤»
+    say '¾'.unival;     # OUTPUT: «0.75␤»
+    say 'a'.unival;     # OUTPUT: «NaN␤»
 
 =head2 method univals
 
@@ -109,7 +109,7 @@ or C<NaN> if it's not numeric.
 Returns a list of numeric values represented by each codepoint in the invocant
 string, and C<NaN> for non-numeric characters.
 
-    say "4a¾".univals;  # (4 NaN 0.75)
+    say "4a¾".univals;  # OUTPUT: «(4 NaN 0.75)␤»
 
 =head2 routine chars
 
@@ -141,13 +141,13 @@ if it was not found.
 
 Examples:
 
-    say index "Camelia is a butterfly", "a";     # 1
-    say index "Camelia is a butterfly", "a", 2;  # 6
-    say index "Camelia is a butterfly", "er";    # 17
-    say index "Camelia is a butterfly", "Camel"; # 0
-    say index "Camelia is a butterfly", "Onion"; # Nil
+    say index "Camelia is a butterfly", "a";     # OUTPUT: «1␤»
+    say index "Camelia is a butterfly", "a", 2;  # OUTPUT: «6␤»
+    say index "Camelia is a butterfly", "er";    # OUTPUT: «17␤»
+    say index "Camelia is a butterfly", "Camel"; # OUTPUT: «0␤»
+    say index "Camelia is a butterfly", "Onion"; # OUTPUT: «Nil␤»
 
-    say index("Camelia is a butterfly", "Onion").defined ?? 'OK' !! 'NOT'; # NOT
+    say index("Camelia is a butterfly", "Onion").defined ?? 'OK' !! 'NOT'; # OUTPUT: «NOT␤»
 
 =head2 routine rindex
 
@@ -159,8 +159,8 @@ Returns an undefined value if C<$needle> wasn't found.
 
 Examples:
 
-    say rindex "Camelia is a butterfly", "a";     # 11
-    say rindex "Camelia is a butterfly", "a", 10; # 6
+    say rindex "Camelia is a butterfly", "a";     # OUTPUT: «11␤»
+    say rindex "Camelia is a butterfly", "a", 10; # OUTPUT: «6␤»
 
 =head2 method match
 
@@ -204,18 +204,19 @@ Takes as an argument the number of matches to return, stopping once the specifie
 Examples:
 =begin code
 
-say "properly".match('perl');                     # ｢perl｣
-say "properly".match(/p.../);                     # ｢perl｣
-say "1 2 3".match([1,2,3]);                       # ｢1 2 3｣
-say "a1xa2".match(/a./, :continue(2));            # ｢a2｣
-say "abracadabra".match(/ a .* a /, :exhaustive); # (｢abracadabra｣ ｢abracada｣ ｢abraca｣ ｢abra｣ ｢acadabra｣ ｢acada｣ ｢aca｣ ｢adabra｣ ｢ada｣ ｢abra｣)
-say 'several words here'.match(/\w+/,:global);    # (｢several｣ ｢words｣ ｢here｣)
-say 'abcdef'.match(/.*/, :pos(2));                # ｢cdef｣
-say "foo[bar][baz]".match(/../, :1st);            # ｢fo｣
-say "foo[bar][baz]".match(/../, :2nd);            # ｢o[｣
-say "foo[bar][baz]".match(/../, :3rd);            # ｢ba｣
-say "foo[bar][baz]".match(/../, :4th);            # ｢r]｣
-say "foo[bar][baz]bada".match('ba', :x(2));       # (｢ba｣ ｢ba｣)
+say "properly".match('perl');                     # OUTPUT: «｢perl｣␤»
+say "properly".match(/p.../);                     # OUTPUT: «｢perl｣␤»
+say "1 2 3".match([1,2,3]);                       # OUTPUT: «｢1 2 3｣␤»
+say "a1xa2".match(/a./, :continue(2));            # OUTPUT: «｢a2｣␤»
+say "abracadabra".match(/ a .* a /, :exhaustive);
+# OUTPUT: «(｢abracadabra｣ ｢abracada｣ ｢abraca｣ ｢abra｣ ｢acadabra｣ ｢acada｣ ｢aca｣ ｢adabra｣ ｢ada｣ ｢abra｣)␤»
+say 'several words here'.match(/\w+/,:global);    # OUTPUT: «(｢several｣ ｢words｣ ｢here｣)␤»
+say 'abcdef'.match(/.*/, :pos(2));                # OUTPUT: «｢cdef｣␤»
+say "foo[bar][baz]".match(/../, :1st);            # OUTPUT: «｢fo｣␤»
+say "foo[bar][baz]".match(/../, :2nd);            # OUTPUT: «｢o[｣␤»
+say "foo[bar][baz]".match(/../, :3rd);            # OUTPUT: «｢ba｣␤»
+say "foo[bar][baz]".match(/../, :4th);            # OUTPUT: «｢r]｣␤»
+say "foo[bar][baz]bada".match('ba', :x(2));       # OUTPUT: «(｢ba｣ ｢ba｣)␤»
 
 =end code
 
@@ -231,9 +232,9 @@ equivalent. Will L«C<fail>|/routine/fail» if radix is not in range C<2..36>
 or of the string being parsed contains characters that are not valid
 for the specified base.
 
-    1337.base(32).parse-base(32).say; # 1337
-    'Perl6'.parse-base(30).say;       # 20652936
-    'FF.DD'.parse-base(16).say;       # 255.863281
+    1337.base(32).parse-base(32).say; # OUTPUT: «1337␤»
+    'Perl6'.parse-base(30).say;       # OUTPUT: «20652936␤»
+    'FF.DD'.parse-base(16).say;       # OUTPUT: «255.863281␤»
 
 See also: L«:16<FF> syntax for number literals|/syntax/Number%20literals»
 
@@ -298,26 +299,22 @@ Also return the B<index> of the delimiter and the delimiter as a C<Pair>.
 
 Examples:
 
-=begin code
+    say split(";", "a;b;c").perl;           # OUTPUT: «("a", "b", "c")␤»
+    say split(";", "a;b;c", :v).perl;       # OUTPUT: «("a", ";", "b", ";", "c")␤»
+    say split(";", "a;b;c", 2).perl;        # OUTPUT: «("a", "b;c").Seq␤»
+    say split(";", "a;b;c", 2, :v).perl;    # OUTPUT: «("a", ";", "b;c")␤»
+    say split(";", "a;b;c,d").perl;         # OUTPUT: «("a", "b", "c,d")␤»
+    say split(/\;/, "a;b;c,d").perl;        # OUTPUT: «("a", "b", "c,d")␤»
+    say split(<; ,>, "a;b;c,d").perl;       # OUTPUT: «("a", "b", "c", "d")␤»
+    say split(/<[;,]>/, "a;b;c,d").perl;    # OUTPUT: «("a", "b", "c", "d")␤»
+    say split(<; ,>, "a;b;c,d", :k).perl;   # OUTPUT: «("a", 0, "b", 0, "c", 1, "d")␤»
+    say split(<; ,>, "a;b;c,d", :kv).perl;  # OUTPUT: «("a", 0, ";", "b", 0, ";", "c", 1, ",", "d")␤»
 
-    say split(";", "a;b;c").perl;            # ("a", "b", "c")
-    say split(";", "a;b;c", :v).perl;        # ("a", ";", "b", ";", "c")
-    say split(";", "a;b;c", 2).perl;         # ("a", "b;c").Seq
-    say split(";", "a;b;c", 2, :v).perl;     # ("a", ";", "b;c")
-    say split(";", "a;b;c,d").perl;          # ("a", "b", "c,d")
-    say split(/\;/, "a;b;c,d").perl;         # ("a", "b", "c,d")
-    say split(<; ,>, "a;b;c,d").perl;        # ("a", "b", "c", "d")
-    say split(/<[;,]>/, "a;b;c,d").perl;     # ("a", "b", "c", "d")
-    say split(<; ,>, "a;b;c,d", :k).perl;    # ("a", 0, "b", 0, "c", 1, "d")
-    say split(<; ,>, "a;b;c,d", :kv).perl;   # ("a", 0, ";", "b", 0, ";", "c", 1, ",", "d")
+    say "".split("x").perl;                 # OUTPUT: «("",)␤»
+    say "".split("x", :skip-empty).perl;    # OUTPUT: «("",)␤»
 
-    say "".split("x").perl;                  # ("",)
-    say "".split("x", :skip-empty).perl;     # ("",)
-
-    say "abcde".split("").perl;              # ("", "a", "b", "c", "d", "e", "")
-    say "abcde".split("",:skip-empty).perl;  # ("a", "b", "c", "d", "e")
-
-=end code
+    say "abcde".split("").perl;             # OUTPUT: «("", "a", "b", "c", "d", "e", "")␤»
+    say "abcde".split("",:skip-empty).perl; # OUTPUT: «("a", "b", "c", "d", "e")␤»
 
 =head2 routine comb
 
@@ -338,11 +335,11 @@ If no matcher is supplied, a list of characters in the string
 
 Examples:
 
-    say "abc".comb.perl;                 # ("a", "b", "c").Seq
-    say comb(/\w/, "a;b;c").perl;        # ("a", "b", "c").Seq
-    say comb(/\N/, "a;b;c").perl;        # ("a", ";", "b", ";", "c").Seq
-    say comb(/\w/, "a;b;c", 2).perl;     # ("a", "b").Seq
-    say comb(/\w\;\w/, "a;b;c", 2).perl; # ("a;b",).Seq
+    say "abc".comb.perl;                 # OUTPUT: «("a", "b", "c").Seq␤»
+    say comb(/\w/, "a;b;c").perl;        # OUTPUT: «("a", "b", "c").Seq␤»
+    say comb(/\N/, "a;b;c").perl;        # OUTPUT: «("a", ";", "b", ";", "c").Seq␤»
+    say comb(/\w/, "a;b;c", 2).perl;     # OUTPUT: «("a", "b").Seq␤»
+    say comb(/\w\;\w/, "a;b;c", 2).perl; # OUTPUT: «("a;b",).Seq␤»
 
 If the matcher is an integer value, it is considered to be a matcher that
 is similar to / . ** matcher /, but which is about 30x faster.
@@ -357,10 +354,10 @@ same as a call to C<$input.comb( / ^^ \N* /, $limit )> would.
 
 Examples:
 
-    say lines("a\nb").perl;    # ("a", "b").Seq
-    say lines("a\nb").elems;   # 2
-    say "a\nb".lines.elems;    # 2
-    say "a\n".lines.elems;     # 1
+    say lines("a\nb").perl;    # OUTPUT: «("a", "b").Seq␤»
+    say lines("a\nb").elems;   # OUTPUT: «2␤»
+    say "a\nb".lines.elems;    # OUTPUT: «2␤»
+    say "a\n".lines.elems;     # OUTPUT: «1␤»
 
 =head2 routine words
 
@@ -372,10 +369,10 @@ C<$input.comb( / \S+ /, $limit )> would.
 
 Examples:
 
-    say "a\nb\n".words.perl;       # ("a", "b").Seq
-    say "hello world".words.perl;  # ("hello", "world").Seq
-    say "foo:bar".words.perl;      # ("foo:bar",).Seq
-    say "foo:bar\tbaz".words.perl; # ("foo:bar", "baz").Seq
+    say "a\nb\n".words.perl;       # OUTPUT: «("a", "b").Seq␤»
+    say "hello world".words.perl;  # OUTPUT: «("hello", "world").Seq␤»
+    say "foo:bar".words.perl;      # OUTPUT: «("foo:bar",).Seq␤»
+    say "foo:bar\tbaz".words.perl; # OUTPUT: «("foo:bar", "baz").Seq␤»
 
 =head2 routine flip
 
@@ -386,8 +383,8 @@ Returns the string reversed character by character.
 
 Examples:
 
-    "Perl".flip;  # lreP
-    "ABBA".flip;  # ABBA
+    "Perl".flip;  # RESULT: «lreP»
+    "ABBA".flip;  # RESULT: «ABBA»
 
 =head2 sub sprintf
 
@@ -485,8 +482,8 @@ An explicit format parameter index, such as C<2$>. By default,
 C<sprintf> will format the next unused argument in the list, but this
 allows you to take the arguments out of order:
 
-  sprintf '%2$d %1$d', 12, 34;      # "34 12"
-  sprintf '%3$d %d %1$d', 1, 2, 3;  # "3 1 1"
+  sprintf '%2$d %1$d', 12, 34;      # OUTPUT: «34 12␤»
+  sprintf '%3$d %d %1$d', 1, 2, 3;  # OUTPUT: «3 1 1␤»
 
 B<flags>
 
@@ -504,33 +501,33 @@ One or more of:
 
 For example:
 
-  sprintf '<% d>',  12;   # "< 12>"
-  sprintf '<% d>',   0;   # "< 0>"
-  sprintf '<% d>', -12;   # "<-12>"
-  sprintf '<%+d>',  12;   # "<+12>"
-  sprintf '<%+d>',   0;   # "<+0>"
-  sprintf '<%+d>', -12;   # "<-12>"
-  sprintf '<%6s>',  12;   # "<    12>"
-  sprintf '<%-6s>', 12;   # "<12    >"
-  sprintf '<%06s>', 12;   # "<000012>"
-  sprintf '<%#o>',  12;   # "<014>"
-  sprintf '<%#x>',  12;   # "<0xc>"
-  sprintf '<%#X>',  12;   # "<0XC>"
-  sprintf '<%#b>',  12;   # "<0b1100>"
-  sprintf '<%#B>',  12;   # "<0B1100>"
+  sprintf '<% d>',  12;   # OUTPUT: «< 12>␤»
+  sprintf '<% d>',   0;   # OUTPUT: «< 0>"»
+  sprintf '<% d>', -12;   # OUTPUT: «<-12>␤»
+  sprintf '<%+d>',  12;   # OUTPUT: «<+12>␤»
+  sprintf '<%+d>',   0;   # OUTPUT: «<+0>"»
+  sprintf '<%+d>', -12;   # OUTPUT: «<-12>␤»
+  sprintf '<%6s>',  12;   # OUTPUT: «<    12>␤»
+  sprintf '<%-6s>', 12;   # OUTPUT: «<12    >␤»
+  sprintf '<%06s>', 12;   # OUTPUT: «<000012>␤»
+  sprintf '<%#o>',  12;   # OUTPUT: «<014>␤»
+  sprintf '<%#x>',  12;   # OUTPUT: «<0xc>␤»
+  sprintf '<%#X>',  12;   # OUTPUT: «<0XC>␤»
+  sprintf '<%#b>',  12;   # OUTPUT: «<0b1100>␤»
+  sprintf '<%#B>',  12;   # OUTPUT: «<0B1100>␤»
 
 When a space and a plus sign are given as the flags at once, the space
 is ignored:
 
-  sprintf '<%+ d>', 12;   # "<+12>"
-  sprintf '<% +d>', 12;   # "<+12>"
+  sprintf '<%+ d>', 12;   # OUTPUT: «<+12>␤»
+  sprintf '<% +d>', 12;   # OUTPUT: «<+12>␤»
 
 When the C<#> flag and a precision are given in the C<%o> conversion, the
 precision is incremented if it's necessary for the leading "0":
 
-  sprintf '<%#.5o>', 012;      # "<000012>"
-  sprintf '<%#.5o>', 012345;   # "<012345>"
-  sprintf '<%#.0o>', 0;        # "<>" # zero precision results in no output!
+  sprintf '<%#.5o>', 012;      # OUTPUT: «<000012>␤»
+  sprintf '<%#.5o>', 012345;   # OUTPUT: «<012345>␤»
+  sprintf '<%#.0o>', 0;        # OUTPUT: «<>␤» # zero precision results in no output!
 
 B<vector flag>
 
@@ -560,13 +557,13 @@ display the given value. You can override the width by putting a
 number here, or get the width from the next argument (with C<*> ) or
 from a specified argument (e.g., with C<*2$>):
 
- sprintf "<%s>", "a";           # "<a>"
- sprintf "<%6s>", "a";          # "<     a>"
- sprintf "<%*s>", 6, "a";       # "<     a>"
+ sprintf "<%s>", "a";           # OUTPUT: «<a>␤»
+ sprintf "<%6s>", "a";          # OUTPUT: «<     a>␤»
+ sprintf "<%*s>", 6, "a";       # OUTPUT: «<     a>␤»
 =begin code :skip-test
  NYI sprintf '<%*2$s>', "a", 6; # "<     a>"
 =end code
- sprintf "<%2s>", "long";       # "<long>" (does not truncate)
+ sprintf "<%2s>", "long";       # OUTPUT: «<long>␤» (does not truncate)
 
 If a field width obtained through C<*> is negative, it has the same
 effect as the C<-> flag: left-justification.
@@ -580,24 +577,24 @@ specifies how many places right of the decimal point to show (the
 default being 6). For example:
 
   # these examples are subject to system-specific variation
-  sprintf '<%f>', 1;    # "<1.000000>"
-  sprintf '<%.1f>', 1;  # "<1.0>"
-  sprintf '<%.0f>', 1;  # "<1>"
-  sprintf '<%e>', 10;   # "<1.000000e+01>"
-  sprintf '<%.1e>', 10; # "<1.0e+01>"
+  sprintf '<%f>', 1;    # OUTPUT: «"<1.000000>"␤»
+  sprintf '<%.1f>', 1;  # OUTPUT: «"<1.0>"␤»
+  sprintf '<%.0f>', 1;  # OUTPUT: «"<1>"␤»
+  sprintf '<%e>', 10;   # OUTPUT: «"<1.000000e+01>"␤»
+  sprintf '<%.1e>', 10; # OUTPUT: «"<1.0e+01>"␤»
 
 For "g" and "G", this specifies the maximum number of digits to show,
 including those prior to the decimal point and those after it; for
 example:
 
   # These examples are subject to system-specific variation.
-  sprintf '<%g>', 1;        # "<1>"
-  sprintf '<%.10g>', 1;     # "<1>"
-  sprintf '<%g>', 100;      # "<100>"
-  sprintf '<%.1g>', 100;    # "<1e+02>"
-  sprintf '<%.2g>', 100.01; # "<1e+02>"
-  sprintf '<%.5g>', 100.01; # "<100.01>"
-  sprintf '<%.4g>', 100.01; # "<100>"
+  sprintf '<%g>', 1;        # OUTPUT: «<1>␤»
+  sprintf '<%.10g>', 1;     # OUTPUT: «<1>␤»
+  sprintf '<%g>', 100;      # OUTPUT: «<100>␤»
+  sprintf '<%.1g>', 100;    # OUTPUT: «<1e+02>␤»
+  sprintf '<%.2g>', 100.01; # OUTPUT: «<1e+02>␤»
+  sprintf '<%.5g>', 100.01; # OUTPUT: «<100.01>␤»
+  sprintf '<%.4g>', 100.01; # OUTPUT: «<100>␤»
 
 For integer conversions, specifying a precision implies that the
 output of the number itself should be zero-padded to this width, where
@@ -606,43 +603,43 @@ the C<0> flag is ignored:
 (Note that this feature currently works for unsigned integer conversions, but not
 for signed integer.)
 
-  NYI sprintf '<%.6d>', 1;      # "<000001>"
-  NYI sprintf '<%+.6d>', 1;     # "<+000001>"
-  NYI sprintf '<%-10.6d>', 1;   # "<000001    >"
-  NYI sprintf '<%10.6d>', 1;    # "<    000001>"
-  NYI sprintf '<%010.6d>', 1;   # "<    000001>"
-  NYI sprintf '<%+10.6d>', 1;   # "<   +000001>"
-  sprintf '<%.6x>', 1;      # "<000001>"
-  sprintf '<%#.6x>', 1;     # "<0x000001>"
-  sprintf '<%-10.6x>', 1;   # "<000001    >"
-  sprintf '<%10.6x>', 1;    # "<    000001>"
-  sprintf '<%010.6x>', 1;   # "<    000001>"
-  sprintf '<%#10.6x>', 1;   # "<  0x000001>"
+  NYI sprintf '<%.6d>', 1;      # <000001>
+  NYI sprintf '<%+.6d>', 1;     # <+000001>
+  NYI sprintf '<%-10.6d>', 1;   # <000001    >
+  NYI sprintf '<%10.6d>', 1;    # <    000001>
+  NYI sprintf '<%010.6d>', 1;   #     000001>
+  NYI sprintf '<%+10.6d>', 1;   # <   +000001>
+  sprintf '<%.6x>', 1;         # OUTPUT: «<000001>␤»
+  sprintf '<%#.6x>', 1;        # OUTPUT: «<0x000001>␤»
+  sprintf '<%-10.6x>', 1;      # OUTPUT: «<000001    >␤»
+  sprintf '<%10.6x>', 1;       # OUTPUT: «<    000001>␤»
+  sprintf '<%010.6x>', 1;      # OUTPUT: «<    000001>␤»
+  sprintf '<%#10.6x>', 1;      # OUTPUT: «<  0x000001>␤»
 
 For string conversions, specifying a precision truncates the string to
 fit the specified width:
 
-  sprintf '<%.5s>', "truncated";   # "<trunc>"
-  sprintf '<%10.5s>', "truncated"; # "<     trunc>"
+  sprintf '<%.5s>', "truncated";   # OUTPUT: «<trunc>␤»
+  sprintf '<%10.5s>', "truncated"; # OUTPUT: «<     trunc>␤»
 
 You can also get the precision from the next argument using C<.*>, or
 from a specified argument (e.g., with C<.*2$>):
 
-  sprintf '<%.6x>', 1;       # "<000001>"
-  sprintf '<%.*x>', 6, 1;    # "<000001>"
+  sprintf '<%.6x>', 1;       # OUTPUT: «<000001>␤»
+  sprintf '<%.*x>', 6, 1;    # OUTPUT: «<000001>␤»
   NYI sprintf '<%.*2$x>', 1, 6;  # "<000001>"
   NYI sprintf '<%6.*2$x>', 1, 4; # "<  0001>"
 
 If a precision obtained through C<*> is negative, it counts as having
 no precision at all:
 
-  sprintf '<%.*s>',  7, "string";   # "<string>"
-  sprintf '<%.*s>',  3, "string";   # "<str>"
-  sprintf '<%.*s>',  0, "string";   # "<>"
-  sprintf '<%.*s>', -1, "string";   # "<string>"
-  sprintf '<%.*d>',  1, 0;          # "<0>"
-  sprintf '<%.*d>',  0, 0;          # "<>"
-  sprintf '<%.*d>', -1, 0;          # "<0>"
+  sprintf '<%.*s>',  7, "string";   # OUTPUT: «<string>␤»
+  sprintf '<%.*s>',  3, "string";   # OUTPUT: «<str>␤»
+  sprintf '<%.*s>',  0, "string";   # OUTPUT: «<>␤»
+  sprintf '<%.*s>', -1, "string";   # OUTPUT: «<string>␤»
+  sprintf '<%.*d>',  1, 0;          # OUTPUT: «<0>␤»
+  sprintf '<%.*d>',  0, 0;          # OUTPUT: «<>␤»
+  sprintf '<%.*d>', -1, 0;          # OUTPUT: «<0>␤»
 
 B<size>
 
@@ -681,7 +678,7 @@ the next argument.
 So:
 
    my $a = 5; my $b = 2; my $c = 'net';
-   sprintf "<%*.*s>", $a, $b, $c; # <   ne>
+   sprintf "<%*.*s>", $a, $b, $c; # OUTPUT: «<   ne>␤»
 
 uses C<$a> for the width, C<$b> for the precision, and C<$c> as the value to
 format; while:
@@ -695,9 +692,9 @@ Here are some more examples; be aware that when using an explicit
 index, the C<$> may need escaping:
 
 =for code :skip-test
- sprintf "%2\$d %d\n",      12, 34;     # "34 12\n"
- sprintf "%2\$d %d %d\n",   12, 34;     # "34 12 34\n"
- sprintf "%3\$d %d %d\n",   12, 34, 56; # "56 12 34\n"
+ sprintf "%2\$d %d\n",      12, 34;     # OUTPUT: «34 12␤␤»
+ sprintf "%2\$d %d %d\n",   12, 34;     # OUTPUT: «34 12 34␤␤»
+ sprintf "%3\$d %d %d\n",   12, 34, 56; # OUTPUT: «56 12 34␤␤»
  NYI sprintf "%2\$*3\$d %d\n",  12, 34,  3; # " 34 12\n"
  NYI sprintf "%*1\$.*f\n",       4,  5, 10; # "5.0000\n"
 
@@ -708,19 +705,18 @@ Other examples:
 =for code :skip-test
  NYI sprintf "%ld a big number", 4294967295;
  NYI sprintf "%%lld a bigger number", 4294967296;
- sprintf('%c', 97);                  # a
- sprintf("%.2f", 1.969);             # 1.97
- sprintf("%+.3f", 3.141592);         # +3.142
- sprintf('%2$d %1$d', 12, 34);       # 34 12
- sprintf("%x", 255);                 # ff
+ sprintf('%c', 97);                  # OUTPUT: «a␤»
+ sprintf("%.2f", 1.969);             # OUTPUT: «1.97␤»
+ sprintf("%+.3f", 3.141592);         # OUTPUT: «+3.142␤»
+ sprintf('%2$d %1$d', 12, 34);       # OUTPUT: «34 12␤»
+ sprintf("%x", 255);                 # OUTPUT: «ff␤»
 
 Special case: 'sprintf("<b>%s</b>\n", "Perl 6")' will not work, but
 one of the following will:
 
-=for code :skip-test
- sprintf Q:b "<b>%s</b>\n",  "Perl 6"; # "<b>Perl 6</b>\n"
- sprintf     "<b>\%s</b>\n", "Perl 6"; # "<b>Perl 6</b>\n"
- sprintf     "<b>%s\</b>\n", "Perl 6"; # "<b>Perl 6</b>\n"
+ sprintf Q:b "<b>%s</b>\n",  "Perl 6"; # OUTPUT: «<b>Perl 6</b>␤␤»
+ sprintf     "<b>\%s</b>\n", "Perl 6"; # OUTPUT: «<b>Perl 6</b>␤␤»
+ sprintf     "<b>%s\</b>\n", "Perl 6"; # OUTPUT: «<b>Perl 6</b>␤␤»
 
 =head2 method starts-with
 
@@ -728,8 +724,8 @@ one of the following will:
 
 Returns C<True> if the invocant is identical to or starts with C<$needle>.
 
-    say "Hello, World".starts-with("Hello");     # True
-    say "https://perl6.org/".starts-with('ftp'); # False
+    say "Hello, World".starts-with("Hello");     # OUTPUT: «True␤»
+    say "https://perl6.org/".starts-with('ftp'); # OUTPUT: «False␤»
 
 =head2 method ends-with
 
@@ -737,8 +733,8 @@ Returns C<True> if the invocant is identical to or starts with C<$needle>.
 
 Returns C<True> if the invocant is identical to or ends with C<$needle>.
 
-    say "Hello, World".ends-with('Hello');      # False
-    say "Hello, World".ends-with('ld');         # True
+    say "Hello, World".ends-with('Hello');      # OUTPUT: «False␤»
+    say "Hello, World".ends-with('ld');         # OUTPUT: «True␤»
 
 =head2 method subst
 
@@ -775,10 +771,10 @@ Here are other examples of usage:
 
 The C<:nth> adverb has readable English-looking variants:
 
-    say 'ooooo'.subst: 'o', 'x', :1st; xoooo
-    say 'ooooo'.subst: 'o', 'x', :2nd; oxooo
-    say 'ooooo'.subst: 'o', 'x', :3rd; ooxoo
-    say 'ooooo'.subst: 'o', 'x', :4th; oooxo
+    say 'ooooo'.subst: 'o', 'x', :1st; # OUTPUT: «xoooo␤»
+    say 'ooooo'.subst: 'o', 'x', :2nd; # OUTPUT: «oxooo␤»
+    say 'ooooo'.subst: 'o', 'x', :3rd; # OUTPUT: «ooxoo␤»
+    say 'ooooo'.subst: 'o', 'x', :4th; # OUTPUT: «oooxo␤»
 
 The following adverbs are supported
 
@@ -810,8 +806,8 @@ returns C<Any>.
 
     my $some-string = "Some foo";
     my $match = $some-string.subst-mutate(/foo/, "string");
-    say $some-string;  #-> Some string
-    say $match;        #-> ｢foo｣
+    say $some-string;  # OUTPUT: «Some string␤»
+    say $match;        # OUTPUT: «｢foo｣␤»
     $some-string.subst-mutate(/<[oe]>/, '', :g); # remove every o and e, notice the :g named argument from .subst
 
 =head2 routine substr
@@ -827,10 +823,10 @@ specified, its first and last indices are used to determine the size of the subs
 
 Examples:
 
-    substr("Long string", 6, 3);     # tri
-    substr("Long string", 6);        # tring
-    substr("Long string", 6, *-1);   # trin
-    substr("Long string", *-3, *-1); # in
+    substr("Long string", 6, 3);     # RESULT: «tri»
+    substr("Long string", 6);        # RESULT: «tring»
+    substr("Long string", 6, *-1);   # RESULT: «trin»
+    substr("Long string", *-3, *-1); # RESULT: «in»
 
 =head2 method substr-eq
 
@@ -842,36 +838,36 @@ starting from the given initial index C<$from>.  For example, beginning with
 the string C<"foobar">, the substring C<"bar"> will match from index 3:
 
     my $string = "foobar";
-    say $string.substr-eq("bar", 3);  #-> True
+    say $string.substr-eq("bar", 3);    # OUTPUT: «True␤»
 
 However, the substring C<"barz"> starting from index 3 won't match even
 though the first three letters of the substring do match:
 
     my $string = "foobar";
-    say $string.substr-eq("barz", 3);  #-> False
+    say $string.substr-eq("barz", 3);   # OUTPUT: «False␤»
 
 Naturally, to match the entire string, one merely matches from index 0:
 
     my $string = "foobar";
-    say $string.substr-eq("foobar", 0);  #-> True
+    say $string.substr-eq("foobar", 0); # OUTPUT: «True␤»
 
 Since this method is inherited from the C<Cool> type, it also works on
 integers.  Thus the integer C<42> will match the value C<342> starting from
 index 1:
 
     my $integer = 342;
-    say $integer.substr-eq(42, 1);  #-> True
+    say $integer.substr-eq(42, 1);      # OUTPUT: «True␤»
 
 As expected, one can match the entire value by starting at index 0:
 
     my $integer = 342;
-    say $integer.substr-eq(342, 0);  #-> True
+    say $integer.substr-eq(342, 0);     # OUTPUT: «True␤»
 
 Also using a different value or an incorrect starting index won't match:
 
     my $integer = 342;
-    say $integer.substr-eq(42, 3);  #-> False
-    say $integer.substr-eq(7342, 0);  #-> False
+    say $integer.substr-eq(42, 3);      # OUTPUT: «False␤»
+    say $integer.substr-eq(7342, 0);    # OUTPUT: «False␤»
 
 =head2 method substr-rw
 
@@ -888,14 +884,14 @@ one do this:
 
     my $string = "abc";
     $string.substr-rw(1, 1) = "z";
-    $string.say;                    #-> azc
+    $string.say;                    # OUTPUT: «azc␤»
 
 C<substr-rw> also has a function form, so the above example can also be
 written like so:
 
     my $string = "abc";
     substr-rw($string, 1, 1) = "z";
-    $string.say;                    #-> azc
+    $string.say;                    # OUTPUT: «azc␤»
 
 It is also possible to alias the writable reference returned by C<substr-rw>
 for repeated operations:
@@ -904,13 +900,13 @@ for repeated operations:
     $string ~~ /(barney)/;
     my $ref := substr-rw($string, $0.from, $0.to);
     $string.say;
-    # A character in the 'Flintstones' is: barney
+    # OUTPUT: «A character in the 'Flintstones' is: barney␤»
     $ref = "fred";
     $string.say;
-    # A character in the 'Flintstones' is: fred
+    # OUTPUT: «A character in the 'Flintstones' is: fred␤»
     $ref = "wilma";
     $string.say;
-    # A character in the 'Flintstones' is: wilma
+    # OUTPUT: «A character in the 'Flintstones' is: wilma␤»
 
 Notice that the start position and length of string to replace has been
 specified via the C<.from> and C<.to> methods on the C<Match> object, C<$0>.
@@ -930,11 +926,11 @@ character in C<$pattern>. If C<$pattern> is empty no changes will be made.
 
 Examples:
 
-    say 'åäö'.samemark('aäo');                        # aäo
-    say 'åäö'.samemark('a');                          # aao
+    say 'åäö'.samemark('aäo');                        # OUTPUT: «aäo␤»
+    say 'åäö'.samemark('a');                          # OUTPUT: «aao␤»
 
-    say samemark('Pêrl', 'a');                        # Perl
-    say samemark('aöä', '');                          # aöä
+    say samemark('Pêrl', 'a');                        # OUTPUT: «Perl␤»
+    say samemark('aöä', '');                          # OUTPUT: «aöä␤»
 
 =head2 method succ
 
@@ -945,18 +941,18 @@ Returns the string incremented by one.
 String increment is "magical". It searches for the last alphanumeric
 sequence that is not preceded by a dot, and increments it.
 
-    '12.34'.succ;      # 13.34
-    'img001.png'.succ; # img002.png
+    '12.34'.succ;      # RESULT: «13.34»
+    'img001.png'.succ; # RESULT: «img002.png»
 
 The actual increment step works by mapping the last alphanumeric
 character to a character range it belongs to, and choosing the next
 character in that range, carrying to the previous letter on overflow.
 
-    'aa'.succ;   # ab
-    'az'.succ;   # ba
-    '109'.succ;  # 110
-    'α'.succ;    # β
-    'a9'.succ;   # b0
+    'aa'.succ;   # RESULT: «ab»
+    'az'.succ;   # RESULT: «ba»
+    '109'.succ;  # RESULT: «110»
+    'α'.succ;    # RESULT: «β»
+    'a9'.succ;   # RESULT: «b0»
 
 String increment is Unicode-aware, and generally works for scripts where a
 character can be uniquely classified as belonging to one range of characters.
@@ -971,9 +967,9 @@ String decrementing is "magical" just like string increment (see
 L<succ>). It fails on underflow
 
 =for code :skip-test
-'b0'.pred;           # a9
+'b0'.pred;           # RESULT: «a9»
 'a0'.pred;           # Failure
-'img002.png'.pred;   # img001.png
+'img002.png'.pred;   # RESULT: «img001.png»
 
 =head2 routine ord
 
@@ -1031,12 +1027,12 @@ Example:
 
     $str.=trans( ['a'..'y'] => ['A'..'z'] );
 
-    "abcdefghij".trans(/<[aeiou]> \w/ => ''); # «cdgh»
+    "abcdefghij".trans(/<[aeiou]> \w/ => '');                     # RESULT: «cdgh»
 
-    "a123b123c".trans(['a'..'z'] => 'x', :complement); # «axxxbxxxc»
-    "a123b123c".trans('23' => '', :delete); # «a1b1c»
-    "aaa1123bb123c".trans('a'..'z' => 'A'..'Z', :squash); # «A1123B123C»
-    "aaa1123bb123c".trans('a'..'z' => 'x', :complement, :squash); # «aaaxbbxc»
+    "a123b123c".trans(['a'..'z'] => 'x', :complement);            # RESULT: «axxxbxxxc»
+    "a123b123c".trans('23' => '', :delete);                       # RESULT: «a1b1c»
+    "aaa1123bb123c".trans('a'..'z' => 'A'..'Z', :squash);         # RESULT: «A1123B123C»
+    "aaa1123bb123c".trans('a'..'z' => 'x', :complement, :squash); # RESULT: «aaaxbbxc»
 
 =head2 method indent
 
@@ -1048,10 +1044,8 @@ Indents each line of the string by C<$steps>. If C<$steps> is negative,
 it outdents instead. If C<$steps> is L<C<*>|*>, then the string is
 outdented to the margin:
 
-    =begin code
     "  indented by 2 spaces\n    indented even more".indent(*)
         eq "indented by 2 spaces\n  indented even more"
-    =end code
 
 =head2 method trim
 
@@ -1064,12 +1058,12 @@ C<.=trim>
 
 
     my $line = '   hello world    ';
-    say '<' ~ $line.trim ~ '>';        # <hello world>
-    say '<' ~ trim($line) ~ '>';       # <hello world>
+    say '<' ~ $line.trim ~ '>';        # OUTPUT: «<hello world>␤»
+    say '<' ~ trim($line) ~ '>';       # OUTPUT: «<hello world>␤»
     $line.trim;
-    say '<' ~ $line ~ '>';             # <   hello world    >
+    say '<' ~ $line ~ '>';             # OUTPUT: «<   hello world    >␤»
     $line.=trim;
-    say '<' ~ $line ~ '>';             # <hello world>
+    say '<' ~ $line ~ '>';             # OUTPUT: «<hello world>␤»
 
 See also L<trim-trailing> and L<trim-leading>
 
@@ -1131,10 +1125,10 @@ be parsed.  If the C<:val-or-fail> adverb is provided it will return an
 L<X::Str::Numeric|/type/X::Str::Numeric> rather than the original string if it
 cannot parse the string as a number.
 
-    say val("42").WHAT; # (IntStr)
-    say val("42e0").WHAT; # (NumStr)
-    say val("42.0").WHAT; # (RatStr)
-    say val("42+0i").WHAT; # (ComplexStr)
+    say val("42").WHAT;    # OUTPUT: «(IntStr)␤»
+    say val("42e0").WHAT;  # OUTPUT: «(NumStr)␤»
+    say val("42.0").WHAT;  # OUTPUT: «(RatStr)␤»
+    say val("42+0i").WHAT; # OUTPUT: «(ComplexStr)␤»
 
 =end pod
 

--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -13,19 +13,19 @@ then a colon and the operator name in a quote construct. For (post-)circumfix
 operators separate the two parts by white space.
 
     my $s = sub ($a, $b) { $a + $b };
-    say $s.WHAT;        # (Sub)
-    say $s(2, 5);       # 7
+    say $s.WHAT;        # OUTPUT: «(Sub)␤»
+    say $s(2, 5);       # OUTPUT: «7␤»
 
     sub postfix:<♥>($a){ say „I love $a!“ }
     42♥;
-    # OUTPUT«I love 42!␤»
+    # OUTPUT: «I love 42!␤»
     sub postcircumfix:<⸨ ⸩>(Positional $a, Whatever){ say $a[0], '…', $a[*-1] }
     [1,2,3,4]⸨*⸩;
-    # OUTPUT«1…4␤»
+    # OUTPUT: «1…4␤»
     constant term:<♥> = "♥"; # We don't want to quote "love", do we?
     sub circumfix:<α ω>($a){ say „$a is the beginning and the end.“ };
     α♥ω;
-    # OUTPUT«♥ is the beginning and the end.␤»
+    # OUTPUT: «♥ is the beginning and the end.␤»
 
 
 Note that subs that go by the same name as
@@ -34,7 +34,7 @@ coercers. To call them use the C<&>-sigil.
 
     sub Int(Str $s){'oi‽'};
     say [Int, Int('42'),&Int('42')];
-    # OUTPUT«[(Int) 42 oi‽]␤»
+    # OUTPUT: «[(Int) 42 oi‽]␤»
 
 X<|my (Sub)>X<|our (Sub)>
 Subs can be nested and scoped with C<my> and C<our>, whereby C<my> is the
@@ -62,7 +62,7 @@ language object names or parameter lists.
         say 'bar has been called'
     }
     bar();
-    # OUTPUT«⟨is foo⟩ has been called with ⟨oi‽⟩ on Sub|47563000␤start␤bar has been called␤»
+    # OUTPUT: «⟨is foo⟩ has been called with ⟨oi‽⟩ on Sub|47563000␤start␤bar has been called␤»
 
 Use L<destructuring|/type/Signature#Destructuring_Parameters> to call traits
 with complex arguments.
@@ -71,7 +71,7 @@ with complex arguments.
         say [$firstpos, @restpos, $named, %restnameds]
     }
     my $x is foo[1,2,3,:named<a>, :2b, :3c] = 1
-    # OUTPUT«[1 [2 3] a {b => 2, c => 3}]␤»
+    # OUTPUT: «[1 [2 3] a {b => 2, c => 3}]␤»
 
 Despite its funky syntax, a trait is just a normal C<Sub>. We can apply traits
 to it (or even themselves) and we can apply traits to objects at runtime.
@@ -81,7 +81,7 @@ to it (or even themselves) and we can apply traits to objects at runtime.
     }
     sub bar {}
     &trait_mod:<is>(&bar, :foo);
-    # OUTPUT«is foo called␤is foo called␤»
+    # OUTPUT: «is foo called␤is foo called␤»
 
 =head2 trait is default (Sub class)
 
@@ -93,7 +93,7 @@ called.
 
     multi sub f() is default { say "Hello there" }
     multi sub f() { say "Hello friend" }
-    f();   #"Hello there" is printed.
+    f();   # OUTPUT: «"Hello there"␤»
 
 The C<is default> trait can become very useful for debugging and other uses but
 keep in mind that it will only resolve an ambiguous dispatch between two C<Sub>s
@@ -102,7 +102,7 @@ that one will be called. For example:
 
     multi sub f() is default { say "Hello there" }
     multi sub f(:$greet) { say "Hello " ~ $greet }
-    f();   #"Use of uninitialized value $greet..."
+    f();   # "Use of uninitialized value $greet..."
 
 In this example, the C<multi> without C<is default> was called because it was
 actually narrower than the C<Sub> with it.

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -130,7 +130,7 @@ Returns C<True> if the supply is "live", that is, values are emitted to taps
 as soon as they arrive. Always returns C<True> in the default C<Supply> (but
 for example on the supply returned from C<Supply.from-list> it's C<False>).
 
-    say Supplier.new.Supply.live;    # True
+    say Supplier.new.Supply.live;    # OUTPUT: «True␤»
 
 =head2 method schedule-on
 
@@ -200,7 +200,7 @@ L<Block|/type/Block>.
 Creates an on-demand supply from the values passed to this method.
 
     my $s = Supply.from-list(1, 2, 3);
-    $s.tap(&say);           # 1\n2\n3\n
+    $s.tap(&say);           # OUTPUT: «1␤2␤3␤»
 
 =head2 method share
 
@@ -266,7 +266,7 @@ C<&mapper> and emits it to the new supply.
     my $all      = $supplier.Supply;
     my $double   = $all.map(-> $value { $value * 2 });
     $double.tap(&say);
-    $supplier.emit(4);           # 8
+    $supplier.emit(4);           # RESULT: «8»
 
 =head2 method batch
 

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -102,8 +102,8 @@ the thread will be killed when the main thread of the process terminates.
     my $t1 = Thread.new(code => { for 1..5 -> $v { say $v }});
     my $t2 = Thread.new(code => { for 1..5 -> $v { say $v }}, :app_lifetime);
 
-    say $t1.app_lifetime;                 # False
-    say $t2.app_lifetime;                 # True
+    say $t1.app_lifetime;                 # OUTPUT: «False␤»
+    say $t2.app_lifetime;                 # OUTPUT: «True␤»
 
 =head2 method name
 
@@ -116,8 +116,8 @@ was specified.
     my $t1 = Thread.new(code => { for 1..5 -> $v { say $v }});
     my $t2 = Thread.new(code => { for 1..5 -> $v { say $v }}, name => 'my thread');
 
-    say $t1.name;                 # <anon>
-    say $t2.name;                 # my thread
+    say $t1.name;                 # OUTPUT: «<anon>␤»
+    say $t2.name;                 # OUTPUT: «my thread␤»
 
 =head2 method Str
 
@@ -127,6 +127,6 @@ Returns a string which contains the invocants L<thread id|#method_id> and
 L<name|#method_name>.
 
     my $t = Thread.new(code => { for 1..5 -> $v { say $v }}, name => 'calc thread');
-    say $t.Str;                           # Thread<3>(calc thread)
+    say $t.Str;                           # OUTPUT: «Thread<3>(calc thread)␤»
 
 =end pod

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -31,12 +31,12 @@ time. Closures won't do what you expect. They are stored as is and need to be
 called by hand.
 
     my Int $x is default(42);
-    say $x;     # 42
+    say $x;     # OUTPUT: «42␤»
     $x = 5;
-    say $x;     # 5
+    say $x;     # OUTPUT: «5␤»
     # explicit reset:
     $x = Nil;
-    say $x;     # 42
+    say $x;     # OUTPUT: «42␤»
 
 =head2 trait is dynamic
 
@@ -50,7 +50,7 @@ without being in an inner lexical scope.
         say B<$CALLER::x>;
     }
     my $x B<is dynamic> = 23;
-    introspect;         # 23
+    introspect;         # OUTPUT: «23␤»
     {
         # not dynamic
         my $x;
@@ -67,6 +67,6 @@ Sets the type constraint of a container bound to a variable.
     my $i of Int = 42;
     $i = "forty plus two";
     CATCH { default { say .^name, ' ', .Str } }
-    # OUTPUT«X::TypeCheck::Assignment Type check failed in assignment to $i; expected Int but got Str ("forty plus two")␤»
+    # OUTPUT: «X::TypeCheck::Assignment Type check failed in assignment to $i; expected Int but got Str ("forty plus two")␤»
 
 =end pod

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -14,19 +14,19 @@ them with a dot. A version part is usually an integer, a string like C<alpha>,
 or a L<Whatever>-star C<*>. The latter is used to indicate that any version
 part is acceptable in another version that is compared to the current one.
 
-    say v1.0.1 ~~ v1.*;     # True
+    say v1.0.1 ~~ v1.*;     # OUTPUT: «True␤»
 
 Version literals can only contain numeric and L<Whatever> parts. They start
 with a lower-case C<v>, and are followed by at least one part. Multiple parts
 are separate with a dot C<.>. A trailing C<+> indicates that higher versions
 are OK in comparisons:
 
-    say v1.2 ~~ v1.0;       # False
-    say v1.2 ~~ v1.0+;      # True
+    say v1.2 ~~ v1.0;       # OUTPUT: «False␤»
+    say v1.2 ~~ v1.0+;      # OUTPUT: «True␤»
 
 In comparisons, early parts take precedence over later parts.
 
-    say v1.2 cmp v2.1;      # Less
+    say v1.2 cmp v2.1;      # OUTPUT: «Less␤»
 
 Please note that method calls, including pseudo methods like C<WHAT> require
 version literals to be enclosed with parentheses.
@@ -51,8 +51,8 @@ Returns the list of parts that make up this Version object
 
     my $v1 = v1.0.1;
     my $v2 = v1.0.1+;
-    say $v1.parts;                                    # (1 0 1)
-    say $v2.parts;                                    # (1 0 1)
+    say $v1.parts;                                    # OUTPUT: «(1 0 1)␤»
+    say $v2.parts;                                    # OUTPUT: «(1 0 1)␤»
 
 =head2 method plus
 
@@ -62,8 +62,8 @@ Returns C<True> if comparisons against this version allow larger versions too.
 
     my $v1 = v1.0.1;
     my $v2 = v1.0.1+;
-    say $v1.plus;                                     # False
-    say $v2.plus;                                     # True
+    say $v1.plus;                                     # OUTPUT: «False␤»
+    say $v2.plus;                                     # OUTPUT: «True␤»
 
 =head2 method Str
 
@@ -73,8 +73,8 @@ Returns a string representation of the invocant.
 
     my $v1 = v1.0.1;
     my $v2 = Version.new('1.0.1');
-    say $v1.Str;                                      # 1.0.1
-    say $v2.Str;                                      # 1.0.1
+    say $v1.Str;                                      # OUTPUT: «1.0.1␤»
+    say $v2.Str;                                      # OUTPUT: «1.0.1␤»
 
 =head2 method gist
 
@@ -85,7 +85,7 @@ L<Str|#method_Str>, prepended with a lower-case C<v>.
 
     my $v1 = v1.0.1;
     my $v2 = Version.new('1.0.1');
-    say $v1.gist;                                      # v1.0.1
-    say $v2.gist;                                      # v1.0.1
+    say $v1.gist;                                      # OUTPUT: «v1.0.1␤»
+    say $v2.gist;                                      # OUTPUT: «v1.0.1␤»
 
 =end pod

--- a/doc/Type/Whatever.pod6
+++ b/doc/Type/Whatever.pod6
@@ -16,7 +16,7 @@ position in combination with most operators, the compiler will transform the
 expression into a closure of type L<WhateverCode>.
 
     my $c = * + 2;          # same as   -> $x { $x + 2 };
-    say $c(4);              # 6
+    say $c(4);              # OUTPUT: «6␤»
 
 Multiple C<*> in one expression generate closures with as many arguments:
 
@@ -51,8 +51,8 @@ a C<Whatever> object.
 The range operators are handled specially. They do not curry with
 C<Whatever>-stars, but they do curry with C<WhateverCode>
 
-    say (1..*).WHAT;        # (Range)
-    say (1..*-1).WHAT;      # (WhateverCode)
+    say (1..*).WHAT;        # OUTPUT: «(Range)␤»
+    say (1..*-1).WHAT;      # OUTPUT: «(WhateverCode)␤»
 
 This allow all these constructs to work:
 
@@ -62,8 +62,8 @@ This allow all these constructs to work:
 and
 
     my @a = 1..4;
-    say @a[0..*];           # (1 2 3 4)
-    say @a[0..*-2];         # (1 2 3)
+    say @a[0..*];           # OUTPUT: «(1 2 3 4)␤»
+    say @a[0..*-2];         # OUTPUT: «(1 2 3)␤»
 
 Because I<Whatever-currying> is a purely syntactic compiler transform, you will get no
 runtime currying of stored C<Whatever>-stars into C<WhateverCode>s.

--- a/doc/Type/WhateverCode.pod6
+++ b/doc/Type/WhateverCode.pod6
@@ -34,9 +34,9 @@ C<WhateverCode> parameters to do so, as in the following example:
 
     my Cycle $c .= new(:pos(2), :vals(0..^10));
 
-    say get_val($c, 3);   # 3
-    say get_val($c, *);   # 2
-    say get_val($c, *-1); # 1
+    say get_val($c, 3);   # OUTPUT: «3␤»
+    say get_val($c, *);   # OUTPUT: «2␤»
+    say get_val($c, *-1); # OUTPUT: «1␤»
 
 Since C<WhateverCode> objects are C<Callable> you may use introspection
 to create as fancy a behavior as you wish.  Continuing the following

--- a/doc/Type/WrapHandle.pod6
+++ b/doc/Type/WrapHandle.pod6
@@ -14,7 +14,7 @@ C<WrapHandle> is created and returned by L<wrap|/type/Routine#method_wrap>. It's
     f;
     $wrap-handle.restore;
     f;
-    # OUTPUT«before␤f was called␤after␤f was called␤»
+    # OUTPUT: «before␤f was called␤after␤f was called␤»
 
 =head1 Methods
 


### PR DESCRIPTION
**General description**

[Here](https://github.com/perl6/doc/issues/776) was raised a question about different styles of output of the examples. Soon it led to efforts to make examples extracted and executed automatically(with @gfldex++ support) and thoughts about automatic checking of output correctness(not yet).

So this PR introduces a migration of Type/ directory files to a style that was proposed by @coke, simply saying:
- say 3; # OUTPUT: «3␤»
- 2+5; # RESULT: «7»
- 2+5i; # this is a complex number

**Why is single style important**

* Inconsistency is bad for the reader. We have `#!>` in some places, `OUTPUT«`, `# prints` and others without any logic between usages.
* We cannot adequately write a tool to automate our examples testing without some machine-easy recognizable style.

**Pros**

* With unified style we can check our examples(it is important - the wrong examples are tedious to catch by hands and it confuses reader).
* With unified style we can easily convert it to other styles automatically.

**Cons**

* While working on it, I noticed that in some rare places(Str.pod6, Date-related pod6 files, for example) this style of output is... A bit noisy to read. But it can be solved by simple "stripping out" this "OUTPUT|RESULT" things on pod6-to-html stage. Or this style can be changed automatically to something else.
* It somewhat makes contribution harder. If we have a single style, we need to document it in CONTRIBUTION.md and stick to it.

**Additional questions**

* I don't know what to do with Language/ folder. Theoretically, we need to test it too, but it isn't even compileable(at this moment), so I didn't touch it. I also have concerns about "Is this work needed at all?"-part.
* ~~There are conflicts now, but I still have some time and I will resolve them if this PR will be accepted as helpful.~~ I can do some additional work if needed.

**Additional points**

* I've reviewed it carefully and it(hopefully) doesn't introduce any typo. Instead, I've fixed a few.
* It passes `make test` and `make xtest`.
* I know that I'm leaving my "trace" all over the docs, 79 files were changed after all. Can't be helped.