### PR TITLE
unicode quotes messes up syntax highlighting

### DIFF
--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -16,14 +16,14 @@ operators separate the two parts by white space.
     say $s.WHAT;        # (Sub)
     say $s(2, 5);       # 7
 
-    sub postfix:<♥>($a){ say „I love $a!“ }
+    sub postfix:<♥>($a){ say "I love $a!" }
     42♥;
     # OUTPUT«I love 42!␤»
     sub postcircumfix:<⸨ ⸩>(Positional $a, Whatever){ say $a[0], '…', $a[*-1] }
     [1,2,3,4]⸨*⸩;
     # OUTPUT«1…4␤»
     constant term:<♥> = "♥"; # We don't want to quote "love", do we?
-    sub circumfix:<α ω>($a){ say „$a is the beginning and the end.“ };
+    sub circumfix:<α ω>($a){ say "$a is the beginning and the end." };
     α♥ω;
     # OUTPUT«♥ is the beginning and the end.␤»
 


### PR DESCRIPTION
I assume they were unicode. I'm sure it works in code, but it was messing up the rest of the syntax for that code block.

Also, the first " that was on the bottom of the line was invisible on the docs website anyway.