### PR TITLE
Language section examples reworking (part two)

### DIFF
--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -93,7 +93,7 @@ example, often contain the methods the class implements.
 Definitions must be in one of the following forms to be recognized as
 the start of a documentable named, say, Z.  First the code in the document source:
 
-=begin code
+=begin code :skip-test
 
 =item X<C<How to use the Z infix> | infix,Z> (This a special case, which
 is always considered a definition)
@@ -131,7 +131,7 @@ You can add emphasis with bold (B<V< B<> >>) or italicized (B<V< I<> >>),
 with or without code formatting (B<V< C<> >>).  Due to current parser limitations,
 special steps have to be taken to use B<V< X<> >> with other formatting codes; for example:
 
-=begin code
+=begin code :skip-test
 =item X<B<foo>|foo> a fancy subroutine
 =end code
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -145,7 +145,8 @@ key principles of object oriented design.
 The first declaration specifies instance storage for a callback – a bit of
 code to invoke in order to perform the task that an object represents:
 
-    has &!callback;
+=for code :skip-test
+has &!callback;
 
 X<|sigils,&>
 X<|twigils>
@@ -158,7 +159,8 @@ this attribute is private to the class.
 
 The second declaration also uses the private twigil:
 
-    has Task @!dependencies;
+=for code :skip-test
+has Task @!dependencies;
 
 However, this attribute represents an array of items, so it requires the
 C<@> sigil. These items each specify a task that must be completed before
@@ -168,7 +170,8 @@ class (or some subclass of it).
 
 The third attribute represents the state of completion of a task:
 
-    has Bool $.done;
+=for code :skip-test
+has Bool $.done;
 
 X<|twigils,.>
 X<|twigils,accessors>
@@ -210,26 +213,27 @@ those with and without accessors):
 The assignment is carried out at object build time. The right-hand side is
 evaluated at that time, and can even reference earlier attributes:
 
-    has Task @!dependencies;
-    has $.ready = not @!dependencies;
+=for code :skip-test
+has Task @!dependencies;
+has $.ready = not @!dependencies;
 
 =head1 Static fields?
 
 Perl 6 has no B<static> keyword. Nevertheless, any class may declare anything
 that a module can, so making a scoped variable sounds like good idea.
 
-       =begin code
+    =begin code
 
-       class Singleton {
-           my Singleton $instance;
-           method new {!!!}
-           submethod instance {
-               $instance = Singleton.bless unless $instance;
-               $instance;
-           }
-       }
+    class Singleton {
+        my Singleton $instance;
+        method new {!!!}
+        submethod instance {
+            $instance = Singleton.bless unless $instance;
+            $instance;
+        }
+    }
 
-       =end code
+    =end code
 
 Class attributes defined by L<my|/syntax/my> or L<our|/syntax/our> may also be initialized when
 being declared, however we are implementing the Singleton pattern here and
@@ -238,9 +242,11 @@ predict the moment when attribute initialization will be executed, because
 it can take place during compilation, runtime or both, especially when
 importing the class using the L<use|/syntax/use> keyword.
 
+    =begin code :skip-test
     class HaveStaticAttr {
           my Foo $.foo = some_complicated_subroutine;
     }
+    =end code
 
 Class attributes may also be declared with a secondary sigil – in a similar
 manner to object attributes – that will generate read-only accessors if the
@@ -256,9 +262,11 @@ ignore the C<new> method temporarily; it's a special type of method.
 Consider the second method, C<add-dependency>, which adds a new task to a
 task's dependency list.
 
+    =begin code :skip-test
     method add-dependency(Task $dependency) {
         push @!dependencies, $dependency;
     }
+    =end code
 
 X<|invocant>
 
@@ -274,6 +282,7 @@ attribute.
 
 The C<perform> method contains the main logic of the dependency handler:
 
+    =begin code :skip-test
     method perform() {
         unless $!done {
             .perform() for @!dependencies;
@@ -281,6 +290,7 @@ The C<perform> method contains the main logic of the dependency handler:
             $!done = True;
         }
     }
+    =end code
 
 It takes no parameters, working instead with the object's attributes. First,
 it checks if the task has already completed by checking the C<$!done>
@@ -377,7 +387,8 @@ allowed to bind things to C<&!callback> and C<@!dependencies> directly. To
 do this, we override the C<BUILD> submethod, which is called on the brand
 new object by C<bless>:
 
-    submethod BUILD(:&!callback, :@!dependencies) { }
+=for code :skip-test
+submethod BUILD(:&!callback, :@!dependencies) { }
 
 Since C<BUILD> runs in the context of the newly created C<Task> object, it
 is allowed to manipulate those private attributes. The trick here is that
@@ -389,6 +400,7 @@ more information.
 The C<BUILD> method is responsible for initializing all attributes and must also
 handle default values:
 
+    =begin code :skip-test
     has &!callback;
     has @!dependencies;
     has Bool ($.done, $.ready);
@@ -398,6 +410,7 @@ handle default values:
             :$!done = False,
             :$!ready = not @!dependencies
         ) { }
+    =end code
 
 See L<Object Construction|/language/objects#Object_Construction> for more
 options to influence object construction and attribute initialization.
@@ -408,7 +421,8 @@ After creating a class, you can create instances of the class.  Declaring a
 custom constructor provides a simple way of declaring tasks along with their
 dependencies. To create a single task with no dependencies, write:
 
-    my $eat = Task.new({ say 'eating dinner. NOM!' });
+=for code :skip-test
+my $eat = Task.new({ say 'eating dinner. NOM!' });
 
 An earlier section explained that declaring the class C<Task> installed a
 type object in the namespace.  This type object is a kind of "empty
@@ -419,6 +433,7 @@ modifying or accessing an existing object.
 
 Unfortunately, dinner never magically happens.  It has dependent tasks:
 
+    =begin code :skip-test
     my $eat =
         Task.new({ say 'eating dinner. NOM!' },
             Task.new({ say 'making dinner' },
@@ -429,18 +444,21 @@ Unfortunately, dinner never magically happens.  It has dependent tasks:
                 Task.new({ say 'cleaning kitchen' })
             )
         );
+    =end code
 
 Notice how the custom constructor and sensible use of whitespace makes task dependencies clear.
 
 Finally, the C<perform> method call recursively calls the C<perform> method
 on the various other dependencies in order, giving the output:
 
+    =begin code :skip-test
     making some money
     going to the store
     buying food
     cleaning kitchen
     making dinner
     eating dinner. NOM!
+    =end code
 
 =head1 Inheritance
 
@@ -477,7 +495,7 @@ other means, such as attribute accessors.
 Now, any object of type Programmer can make use of the methods and accessors
 defined in the Employee class as though they were from the Programmer class.
 
-    =begin code
+    =begin code :skip-test
     my $programmer = Programmer.new(
         salary => 100_000,
         known_languages => <Perl5 Perl6 Erlang C++>,
@@ -494,7 +512,7 @@ Of course, classes can override methods and attributes defined by parent
 classes by defining their own.  The example below demonstrates the C<Baker>
 class overriding the C<Cook>'s C<cook> method.
 
-    =begin code
+    =begin code :skip-test
     class Cook is Employee {
         has @.utensils  is rw;
         has @.cookbooks is rw;
@@ -545,7 +563,7 @@ algorithm to linearize multiple inheritance hierarchies, which is a
 significant improvement over Perl 5's default approach
 (depth-first search) to handling multiple inheritance.
 
-    =begin code
+    =begin code :skip-test
     class GeekCook is Programmer is Cook {
         method new( *%params ) {
             push( %params<cookbooks>, "Cooking for Geeks" );
@@ -580,6 +598,7 @@ Classes to be inherited from can be listed in the class declaration body by
 prefixing the C<is> trait with C<also>. This also works for the role
 composition trait C<does>.
 
+    =begin code :skip-test
     class GeekCook {
         also is Programmer;
         also is Cook;
@@ -589,6 +608,7 @@ composition trait C<does>.
     role A {};
     role B {};
     class C { also does A; also does B }
+    =end code
 
 =head1 Introspection
 
@@ -599,21 +619,25 @@ a controlling object) for some properties, such as its type.
 Given an object C<$o> and the class definitions from the previous sections,
 we can ask it a few questions:
 
+    =begin code :skip-test
     if $o ~~ Employee { say "It's an employee" };
     if $o ~~ GeekCook { say "It's a geeky cook" };
     say $o.WHAT;
     say $o.perl;
     say $o.^methods(:local)».name.join(', ');
     say $o.^name;
+    =end code
 
 The output can look like this:
 
+    =begin code :skip-test
     It's an employee
     (Programmer)
     Programmer.new(known_languages => ["Perl", "Python", "Pascal"],
             favorite_editor => "gvim", salary => "too small")
     code_to_solve, known_languages, favorite_editor
     Programmer
+    =end code
 
 The first two tests each smart-match against a class name. If the object is
 of that class, or of an inheriting class, it returns true. So the object in
@@ -640,8 +664,9 @@ it is actually a method call on its I<meta class>, which is a class managing
 the properties of the C<Programmer> class – or any other class you are
 interested in. This meta class enables other ways of introspection too:
 
-    say $o.^attributes.join(', ');
-    say $o.^parents.map({ $_.^name }).join(', ');
+=for code :skip-test
+say $o.^attributes.join(', ');
+say $o.^parents.map({ $_.^name }).join(', ');
 
 Finally C<$o.^name> calls the C<name> method on the meta object, which
 unsurprisingly returns the class name.

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -374,11 +374,13 @@ to the C<map> is emitted:
 If you need to have an action that runs when the supply finishes, you can do so
 by setting the C<done> and C<quit> options in the call to C<tap>:
 
+    =begin code :skip-test
     $supply.tap: { ... },
         done => { say 'Job is done.' },
         quit => {
             when X::MyApp::Error { say "App Error: ", $_.message }
         };
+    =end code
 
 The C<quit> block works very similar to a C<CATCH>. If the exception is marked
 as seen by a C<when> or C<default> block, the exception is caught and handled.
@@ -390,6 +392,7 @@ If you are using the C<react> or C<supply> block syntax with C<whenever>, you
 can add phasers within your C<whenever> blocks to handle the C<done> and C<quit>
 messages from the tapped supply:
 
+    =begin code :skip-test
     react {
         whenever $supply {
             ...; # your usual supply tap code here
@@ -397,6 +400,7 @@ messages from the tapped supply:
             QUIT { when X::MyApp::Error { say "App Error: ", $_.message } }
         }
     }
+    =end code
 
 The behavior here is the same as setting C<done> and C<quit> on C<tap>.
 
@@ -492,6 +496,7 @@ The C<.poll> method can be used in combination with C<.receive> method, as a
 caching mechanism where lack of value returned by `.poll` is a signal that
 more values need to be fetched and loaded into the channel:
 
+    =begin code :skip-test
     sub get-value {
         return $c.poll // do { start replenish-cache; $c.receive };
     }
@@ -501,10 +506,12 @@ more values need to be fetched and loaded into the channel:
             $c.send: $_ for slowly-fetch-a-thing();
         }
     }
+    =end code
 
 Channels can be used in place of the L<Supply> in the C<whenever> of a
 C<react> block described earlier:
 
+    =begin code :skip-test
     my $channel = Channel.new;
     my $p = start {
         react {
@@ -523,6 +530,7 @@ C<react> block described earlier:
 
     $channel.close;
     await $p;
+    =end code
 
 It is also possible to obtain a L<Channel> from a L<Supply> using the
 L<Channel method|/type/Supply#method_Channel> which returns a L<Channel>
@@ -642,7 +650,8 @@ In both cases the completion of the code encapsulated by the L<Thread>
 object can be waited on with the C<finish> method which will block until
 the thread completes:
 
-    $thread.finish;
+=for code :skip-test
+$thread.finish;
 
 Beyond that there are  no further facilities for synchronization or resource
 sharing which is largely why it should be emphasized that threads are unlikely

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -91,7 +91,8 @@ as the enclosing block gets left immediately:
 
 Output:
 
-  something went wrong ...
+=for code :skip-test
+something went wrong ...
 
 Compare  with this one:
 
@@ -105,11 +106,7 @@ Compare  with this one:
 
   }
 
-  say "Hi! I am at the outer block!";
-
-Output:
-
-  Hi! I am at the outer block!
+  say "Hi! I am at the outer block!"; # OUTPUT: «Hi! I am at the outer block!␤»
 
 See also "Resuming of Exceptions" to return control back to where the exception originated.
 
@@ -146,17 +143,19 @@ rethrown.
 
 Output:
 
+    =begin code :skip-test
     I'm alive!
     No, I expect you to DIE Mr. Bond!
     I'm immortal.
     Just stop already!
       in block <unit> at exception.p6 line 21
+    =end code
 
 A C<try>-block is a normal block and as such treats it's last statement as the
 return value of itself. We can therefore use it as a RHS.
 
-    say try { +"99999" } // "oh no"
-    say try { +"hello" } // "oh no"
+    say try { +"99999" } // "oh no";
+    say try { +"hello" } // "oh no";
     # OUTPUT«99999␤oh no␤»
 
 =head1 Throwing exceptions

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -10,9 +10,7 @@ these features may be made part of the Perl 6 specification.  To use these
 features, one uses the C<experimental> pragma in program source code, for
 example, like this:
 
-=begin code
-use experimental :macros;
-=end code
+    use experimental :macros;
 
 Following is a list of current experimental features and a short
 description of each feature's purpose or a link to more details about

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -22,7 +22,8 @@ versions of the spec may have point releases (e.g. v6.c.2) or major releases
 You can check if your Rakudo compiler is at least the current release version
 (note this may not be true of vendor binaries) with the following:
 
-    perl6 -e 'say q[too old] if $*PERL.version before Version.new(q[6.c])'
+=for code :skip-test
+perl6 -e 'say q[too old] if $*PERL.version before Version.new(q[6.c])'
 
 It was first implemented by the Rakudo Perl 6 compiler version 2015.12 and is
 likely to be supported by subsequent releases by use
@@ -152,10 +153,10 @@ X<|Data::Dumper (FAQ)>
 
 Examples:
 
-    my $foo="bar"
-    dd $foo           # Str $foo = "bar"
-    say :$foo.perl    # :foo("bar")
-    say :$foo.gist    # foo => bar
+    my $foo="bar";
+    dd $foo;          # Str $foo = "bar"
+    say :$foo.perl;   # :foo("bar")
+    say :$foo.gist;   # foo => bar
 
 There are also modules in the ecosystem to do this, like
 L<Data::Dump|https://github.com/tony-o/perl6-data-dump/>, which colors the output.
@@ -175,10 +176,12 @@ otherwise it's runtime.
 
 Example:
 
-    say 1/0    # Attempt to divide 1 by zero using div
+    =begin code :skip-test
+    say 1/0;   # Attempt to divide 1 by zero using div
 
     sub foo( Int $a, Int $b ) {...}
     foo(1)     # ===SORRY!=== Error while compiling ...
+    =end code
 
 =head2 What is C<(Any)>?
 
@@ -189,16 +192,16 @@ languages.
 
 Example:
 
-    my $foo
-    say $foo          # (Any) note the parentheses indicate type object
-    say $foo.^name    # Any
+    my $foo;
+    say $foo;         # (Any) note the parentheses indicate type object
+    say $foo.^name;   # Any
 
 (Any) shouldn't be used to check for definedness. In Perl 6, definedness is a
 property of an object. Usually, instances are defined and type objects are
 undefined.
 
-    say 1.defined        # True
-    say (Any).defined    # False
+    say 1.defined;       # True
+    say (Any).defined;   # False
 
 =head2 What is C<so>?
 
@@ -227,7 +230,8 @@ For example, if you declare a variable
 then not only can you assign integers (that is, instances of class Int) to it,
 but the C<Int> type object itself:
 
-    $x = Int
+=for code :skip-test
+$x = Int
 
 If you want to exclude type objects, you can append the C<:D> type smiley,
 which stands for "definite":
@@ -362,6 +366,7 @@ Perl 6 has no C<yield> statement like Python does, but it does offer similar
 functionality through lazy lists. There are two popular ways to write
 routines that return lazy lists:
 
+    =begin code :skip-test
     # first method, gather/take
     my @values = gather while have_data() {
         # do some computations
@@ -372,6 +377,7 @@ routines that return lazy lists:
     # second method, use .map or similar method
     # on a lazy list
     my @squares = (1..*).map(-> \x { x² });
+    =end code
 
 =head2 Why can't I initialize private attributes from the new method, and how can I fix this?
 
@@ -399,7 +405,7 @@ initializes them:
             say $!x;
         }
     }
-    A.new(x => 5).show-x;
+    B.new(x => 5).show-x;
 
 C<BUILD> is called by the default constructor (indirectly, see
 L<Object Construction|/language/objects#Object_Construction>
@@ -483,9 +489,11 @@ only when the results are used later).
 
 For example, Perl 6 has multiple dispatch. So, in a code example like
 
+    =begin code :skip-test
     multi w(Int $x) { say 'Int' }
     multi w(Str $x) { say 'Str' }
     w(f());
+    =end code
 
 there's no way to determine if the caller of sub C<f> wants a string or
 an integer, because it's not yet known what the caller is. In general
@@ -682,6 +690,7 @@ Try it on your system. You may be pleasantly surprised!
 
 Examples:
 
+    =begin code :skip-test
     # Perl 6 version
     use v6.c;
 
@@ -731,5 +740,6 @@ Examples:
         ($prev, $current) = ($current, $prev + $current);
     }
     print $current;
+    =end code
 
 =end pod

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -33,11 +33,11 @@ Generically, an adverb is a named argument to a function.  There are also
 some specific syntax forms that allow adverbs to be tucked into some
 convenient places:
 
-    q:w"foo bar"   # ":w" is a Quotelike form modifier adverb
-    m:g/a|b|c/     # ":g" is also
+    q:w"foo bar";   # ":w" is a Quotelike form modifier adverb
+    m:g/a|b|c/;     # ":g" is also
 =comment TODO: Add this back in when :rotate on infix operators is supported
 =comment 4 +> 5 :rotate # ":rotate" is an operator adverb
-    @h{3}:exists   # ":exists" is also, but is known as a subscript adverb
+    @h{3}:exists;   # ":exists" is also, but is known as a subscript adverb
 
 Adverbs are usually expressed with colon pair notation, and for this
 reason colon pair notation is also known as the adverbial pair form:
@@ -57,6 +57,7 @@ X<|Adverbial Pair>
 
 A generalized form of C<pair notation>.  They all start with the colon, like:
 
+=begin table
   adverbial pair  | pair notation
   ================|==============
     :foo<bar>     | foo => 'bar'
@@ -65,6 +66,7 @@ A generalized form of C<pair notation>.  They all start with the colon, like:
     :$foo         | foo => $foo
     :foo          | foo => True
     :!foo         | foo => False
+=end table
 
 Also see L<#Adverb> and L<#Colon Pair and Colon List>.
 
@@ -111,10 +113,12 @@ called by name.
 Note that it is still allowed to have a name, but you cannot call it by
 that name:
 
+    =begin code :skip-test
     # anonymous, but knows its own name
     my $s = anon sub triple($x) { 3 * $x }
     say $s.name;        # triple
     say triple(42);     # Undeclared routine: triple
+    =end code
 
 =head1 API
 X<|API>
@@ -139,10 +143,12 @@ X<|Arity>
 The number of L<positional|/type/Positional> operands expected by an
 L<operator|#Operator>, subroutine, method or callable block.
 
+    =begin code :skip-test
     sub infix:<+>(Foo $a, Foo $b) { $a.Int + $b.Int }  # arity of "+" is 2
     sub frobnicate($x) { ... }                         # arity of 1
     sub the-answer() { 42 }                            # arity of 0
     -> $key, $value { ... }                            # arity of 2
+    =end code
 
 The arity of a C<Callable> is one of the main selectors in
 L<multi-dispatch|#Multi-Dispatch>.
@@ -171,6 +177,7 @@ If you use the resulting junction in a boolean context, such as with an
 C<if>, it collapses into a single boolean which is C<True> if any of the
 values in the junction are True.
 
+    =for code :skip-test
     if f(1|2|3) == 4 {    # fires because f(2) == 4 is true
         say 'success';
     }
@@ -213,10 +220,12 @@ Finally, if there is a variable with the same name as an intended adverbial
 pair, you don't have to specify the name twice, but just specify the adverb
 with the appropriate sigil:
 
+    =begin code :skip-test
     :$foo          # same as foo => $foo
     :@bar          # same as bar => @bar
     :%mapper       # same as mapper => %mapper
     :&test         # same as test => &test
+    =end code
 
 See also L<#Adverb>.
 
@@ -297,8 +306,10 @@ X<|camelia>
 
 The L<#Bot> on the #perl6 L<#IRC> channel that evaluates code, e.g.:
 
-  [16:28:27]  <lizmat>  m: say "Hello world"
-  [16:28:28]  <+camelia>    rakudo-moar 812a48: OUTPUT«Hello world␤»
+    =begin code :skip-test
+    [16:28:27]  <lizmat>  m: say "Hello world"
+    [16:28:28]  <+camelia>    rakudo-moar 812a48: OUTPUT«Hello world␤»
+    =end code
 
 This is a handy tool for showing people if the output is (un)expected.
 
@@ -308,9 +319,11 @@ X<|dalek>
 The L<#Bot> on the #perl6 L<#IRC> channel that reports changes made to
 various Perl 6 related L<repositories|#Repository>.
 
-  [15:46:40] <+dalek> doc: 2819f25 | lizmat++ | doc/Language/glossary.pod:
-  [15:46:40] <+dalek> doc: Add stubs for stuff inside the glossary already
-  [15:46:40] <+dalek> doc: review: https://github.com/perl6/doc/commit/2819f250
+    =begin code :skip-test
+    [15:46:40] <+dalek> doc: 2819f25 | lizmat++ | doc/Language/glossary.pod:
+    [15:46:40] <+dalek> doc: Add stubs for stuff inside the glossary already
+    [15:46:40] <+dalek> doc: review: https://github.com/perl6/doc/commit/2819f250
+    =end code
 
 =head2 yoleaux
 X<|yoleaux>
@@ -324,17 +337,21 @@ Some often used commands are:
 Leave a message to another user who is currently not logged in.  The message
 will be relayed as soon as the user says anything on the channel.
 
-  .tell lizmat I've read the glossary
+    =begin code :skip-test
+    .tell lizmat I've read the glossary
+    =end code
 
 =head3 .u
 
 Look up unicode codepoint information from either a codepoint, or the name
 of a codepoint.
 
- [16:35:44]  <lizmat>   .u empty set
- [16:35:45]  <yoleaux>  U+2205 EMPTY SET [Sm] (∅)
- [16:36:29]  <lizmat>   .u ∅
- [16:36:30]  <yoleaux>  U+2205 EMPTY SET [Sm] (∅)
+    =begin code :skip-test
+    [16:35:44]  <lizmat>   .u empty set
+    [16:35:45]  <yoleaux>  U+2205 EMPTY SET [Sm] (∅)
+    [16:36:29]  <lizmat>   .u ∅
+    [16:36:30]  <yoleaux>  U+2205 EMPTY SET [Sm] (∅)
+    =end code
 
 Some L<#IRC> clients then easily allow you to copy/paste the codepoint in
 question, which can be sometimes be easier than other unicode codepoint
@@ -534,6 +551,7 @@ variables and lvalue subroutines.
 
 Examples of lvalues:
 
+=begin table
     Declaration             lvalue          Comments
 
     my $x;                  $x
@@ -541,14 +559,17 @@ Examples of lvalues:
     has $!attribute;        $!attribute     Only inside classes
     has $.attrib is rw;     $.attrib
     sub a is rw { $x };     a()
+=end table
 
 Examples of things that are not lvalues:
 
+=begin table
     3                        # literals
     constant x = 3;          # constants
     has $.attrib;            # attributes; you can only assign to $!attrib
     sub f { }; f();          # "normal" subs are not writable
     sub f($x) { $x = 3 };    # error - parameters are read-only by default
+=end table
 
 These are typically called L<rvalues|#rvalue>.
 

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -36,7 +36,7 @@ the C<my> keyword, because named regexes are normally used within grammars.
 Being named gives us the advantage of being able to easily reuse the regex
 elsewhere:
 
-    =begin code :allow<B>
+    =begin code :allow<B> :skip-test
     say so "32.51" ~~ B<&number>;                                    # True
     say so "15 + 4.5" ~~ /B<< <number> >>\s* '+' \s*B<< <number> >>/ # True
     =end code
@@ -143,6 +143,7 @@ The real beauty of this method can be seen when you subclass that grammar
 and actions class. Let's say we want to add a multiplication feature to the
 calculator:
 
+    =begin code :skip-test
     grammar BetterCalculator is Calculator {
         rule calc-op:sym<mult> { <num> '*' <num> }
     }
@@ -155,6 +156,7 @@ calculator:
 
     # OUTPUT:
     # 6
+    =end code
 
 All we had to add are additional rule and action to the C<calc-op> group and
 the thing works—all thanks to protoregexes.
@@ -255,6 +257,7 @@ as they return a L</type/Cursor>:
 The grammar above will attempt different matches depending on the arguments
 provided by parse methods:
 
+    =begin code :skip-test
     say +DigitMatcher.subparse: '12७१७९०९', args => \(:full-unicode);
     # OUTPUT:
     # 12717909
@@ -262,6 +265,7 @@ provided by parse methods:
     say +DigitMatcher.subparse: '12७१७९०९', args => \(:!full-unicode);
     # OUTPUT:
     # 12
+    =end code
 
 =head1 Action Objects
 X<|Actions>
@@ -347,7 +351,7 @@ for @$res -> $p {
 
 This produces the following output:
 
-=begin code
+=begin code :skip-test
 Key: second     Value: b
 Key: hits       Value: 42
 Key: perl       Value: 6

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -39,13 +39,14 @@ the file for you.
 Of course, we also have the option to read a file line-by-line. The new line
 separator (i.e., C<$*IN.nl-in>) will be excluded.
 
-=for code :skip-test
+=begin code :skip-test
 for 'huge-csv'.IO.lines -> $line {
     # Do something with $line
 }
 
-    # or if you'll be processing later
-    my @lines = 'huge-csv'.IO.lines;
+# or if you'll be processing later
+my @lines = 'huge-csv'.IO.lines;
+=end code
 
 =head1 Writing to files
 

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -61,6 +61,7 @@ you will want to make use of L<Proc::Async|/type/Proc::Async>. This class
 provides support for asynchronous communication with a program, as well as the
 ability to send signals to that program.
 
+    =begin code :skip-test
     # Get ready to run the program
     my $log = Proc::Async.new('tail', '-f',  '/var/log/system.log');
     $log.stdout.tap(-> $buf { print $buf });
@@ -75,6 +76,7 @@ ability to send signals to that program.
 
     # Wait for the program to finish
     await $done;
+    =end code
 
 Here is a small program that uses the "tail" program to print out the contents
 of the log named C<system.log> for 10 seconds and then tells the program to stop

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -15,11 +15,11 @@ an elegant system for handling them.
 Literal L<C<List>s|/type/List> are created with commas and semicolons B<not>
 with parentheses, so:
 
-    1, 2        # This is two-element list
-    (1, 2)      # This is also a List, in parentheses
-    (1; 2)      # same List
-    (1)         # This is not a List, just a 1 in parentheses
-    (1,)        # This is a one-element List
+    1, 2;        # This is two-element list
+    (1, 2);      # This is also a List, in parentheses
+    (1; 2);      # same List
+    (1);         # This is not a List, just a 1 in parentheses
+    (1,);        # This is a one-element List
 
 Parentheses can be used to mark the beginning and end of a C<List>, so:
 
@@ -36,10 +36,12 @@ They can be used in routine argument lists and subscripts.
 Individual elements can be pulled out of a list using a subscript.  The
 first element of a list is at index number zero:
 
+    =begin code :skip-test
     say (1, 2)[0];  # says 1
     say (1, 2)[1];  # says 2
     say (1, 2)[2];  # says Nil
     say (1, 2)[-1]; # Error
+    =end code
 
 =head1 The @ sigil
 
@@ -114,9 +116,11 @@ This is useful behavior if you have a very long sequence, as you may want to
 throw values away after using them, so that your program does not fill up memory.
 For example, when processing a file of a million lines:
 
+    =begin code :skip-test
     for 'filename'.IO.lines -> $line {
         do-something-with($line);
     }
+    =end code
 
 You can be confident that the entire content of the file will not stay around
 in memory, unless you are explicitly storing the lines somewhere.
@@ -309,10 +313,10 @@ Inside an Array Literal, the list of initialization values is not in capture
 context and is just a normal list.  It is, however, eagerly evaluated just as
 in assignment.
 
-    [ 1, 2, :c(3) ] eqv Array.new((1, 2, :c(3))) # says True
-    [while $++ < 2 { 42.say; 43 }].map: *.say;   # says 42 twice then 43 twice
-    (while $++ < 2 { 42.say; 43 }).map: *.say;   # says "42" then "43"
-                                                 # then "42" then "43"
+    [ 1, 2, :c(3) ] eqv Array.new((1, 2, :c(3))); # says True
+    [while $++ < 2 { 42.say; 43 }].map: *.say;    # says 42 twice then 43 twice
+    (while $++ < 2 { 42.say; 43 }).map: *.say;    # says "42" then "43"
+                                                  # then "42" then "43"
 
 Which brings us to Arrays...
 
@@ -367,25 +371,31 @@ Given the following sub declaration:
 
 Calls that pass an Array[Int] will be successful:
 
+    =begin code :skip-test
     my Int @b = 1, 3, 5;
     say mean(@b);                       # @b is Array[Int]
     say mean(Array[Int].new(1, 3, 5));  # Anonymous Array[Int]
     say mean(my Int @ = 1, 3, 5);       # Another anonymous Array[Int]
+    =end code
 
 However, the following calls will all fail, due to passing an untyped array,
 even if the array just happens to contain Int values at the point it is
 passed:
 
+    =begin code :skip-test
     my @c = 1, 3, 5;
     say mean(@c);                       # Fails, passing untyped Array
     say mean([1, 3, 5]);                # Same
     say mean(Array.new(1, 3, 5));       # Same again
+    =end code
 
 Note that in any given compiler, there may be fancy, under-the-hood, ways to
 bypass the type check on arrays, so when handling untrusted input, it can be
 good practice to perform additional type checks, where it matters:
 
+    =begin code :skip-test
     for @a -> Int $i { $_++.say };
+    =end code
 
 However, as long as you stick to normal assignment operations inside a trusted
 area of code, this will not be a problem, and typecheck errors will happen

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -467,7 +467,7 @@ To share your module, do the following:
     =begin item
     Make your X<C<META6.json>|META6.json> file look something like this:
 
-    =for code :allow<R>
+    =begin code :allow<R>
     {
         "perl" : "6.c",
         "name" : "Vortex::TotalPerspective",
@@ -481,6 +481,7 @@ To share your module, do the following:
         "resources" : [ ],
         "source-url" : "git://github.com/R<you>/Vortex-TotalPerspective.git"
     }
+    =end code
 
     For choosing a version numbering scheme, perhaps use
     "major.minor.patch" (see L<the spec on versioning |

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -30,20 +30,20 @@ This calls the L<C<uc>|uc> method on C<"abc">, which is an object of type
 L<C<Str>|Str>. To supply arguments to the method, add arguments inside parentheses
 after the method.
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 my $formatted-text = "Fourscore and seven years ago...".L<indent>B<(8)>;
 
 C<$formatted-text> now contains the above text, but indented 8 spaces.
 
 Multiple arguments are separated by commas:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 my @words = "Abe", "Lincoln";
 @words.L<push>("said"B<,> $formatted-text.L<comb>(L</\w+/|/language/regexes>));
 
 Multiple arguments can be specified by separating the argument list with a colon:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 say @words.L<join>: '--';
 # Abe--Lincoln--said--Fourscore--and--seven--years--ago
 
@@ -101,7 +101,7 @@ sub f(Int $x) {
 
 Although, in most cases, the L<C<.isa>|isa> method will suffice:
 
-=begin code :allow<B L>
+=begin code :allow<B L> :skip-test
 
 sub f($x) {
     if $xB<.L<isa>>(Int) {
@@ -114,7 +114,7 @@ sub f($x) {
 
 Subtype checking is done by smart-matching:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 if $type B<L<~~>> L<Real> {
     say '$type contains Real or a subtype thereof';
 }
@@ -195,7 +195,7 @@ Since classes inherit a default constructor from C<Mu> and we have requested
 that some accessor methods are generated for us, our class is already
 somewhat functional.
 
-    =begin code :allow<B L>
+    =begin code :allow<B L> :skip-test
     # Create a new instance of the class.
     my $vacation = Journey.new(
         origin      L«=>» 'Sweden',
@@ -341,7 +341,7 @@ say InvertiblePoint2D.new(x => 1, y => 2);
 
 This produces the following output:
 
-=begin code
+=begin code :skip-test
 Initializing Point2D
 Initializing InvertiblePoint2D
 InvertiblePoint2D.new(x => 1, y => 2)
@@ -353,7 +353,7 @@ See also: L<#Object Construction>.
 
 Classes can have I<parent classes>.
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 class Child B<L<is> Parent1 is Parent2> { }
 
 If a method is called on the child class, and the child class does not
@@ -364,7 +364,7 @@ L<C3 method resolution
 order|https://en.wikipedia.org/wiki/C3_linearization>.  You can ask a type
 for its MRO through a call to its meta class:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 say ListB<.^L<mro|/type/Metamodel::C3MRO#mro>>;      # List() Cool() Any() Mu()
 
 If a class does not specify a parent class, L<Any> is assumed by default.
@@ -395,7 +395,9 @@ declared type:
 
 This produces the output:
 
+    =begin code :skip-test
     the child's somewhat more fancy frob is called
+    =end code
 
 =head2 X<Object Construction|BUILDALL (method)>
 
@@ -406,7 +408,7 @@ object or on another object of the same type.
 Class L<Mu> provides a constructor method called L<new>, which takes named
 arguments and uses them to initialize public attributes.
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 class Point {
     has $.x;
     has $.y = 2 * $!x;
@@ -418,10 +420,12 @@ say "y: ", $p.y;
 
 This outputs:
 
+    =begin code :skip-test
     x: 5
     y: 2
+    =end code
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 my $p2 = PointB<.new>( x => 5 );
 # the given value for x is used to calculate the right
 # value for y.
@@ -430,8 +434,10 @@ say "y: ", $p.y;
 
 This outputs:
 
+    =begin code :skip-test
     x: 5
     y: 10
+    =end code
 
 C<Mu.new> calls method L<bless> on its invocant, passing all the named
 arguments. C<bless> creates the new object and then calls method C<BUILDALL>
@@ -461,7 +467,7 @@ C<BUILD> submethods can be used to run custom code at object construction
 time. They can also be used for creating aliases for attribute
 initialization:
 
-    =begin code :allow<B L>
+    =begin code :allow<B L> :skip-test
     class EncodedBuffer {
         has $.enc;
         has $.data;
@@ -480,7 +486,7 @@ Since passing arguments to a routine binds the arguments to the parameters,
 a separate binding step is unnecessary if the attribute is used as a
 parameter.  Hence the example above could also have been written as:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 submethod BUILD(:encoding(:$B<!>enc), :$B<!>data) {
     # nothing to do here anymore, the signature binding
     # does all the work for us.
@@ -494,7 +500,7 @@ default value will be Any, which would cause a type error.
 The third implication is that if you want a constructor that accepts
 positional arguments, you must write your own C<new> method:
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 class Point {
     has $.x;
     has $.y;
@@ -575,6 +581,7 @@ This works well for simple classes, but in some cases one might need
 to follow C<BUILDALL>'s lead and work in reverse method resolution
 order:
 
+    =begin code :skip-test
     class B is A {
         has $.b;
         #...
@@ -584,6 +591,7 @@ order:
             $obj
         }
     }
+    =end code
 
 =head1 X<Roles|declarator,role>
 
@@ -593,7 +601,7 @@ describing only parts of an object's behavior and in how roles are applied
 to classes. Or to phrase it differently, classes are meant for managing
 objects and roles are meant for managing behavior and code reuse.
 
-    =begin code :allow<B L>
+    =begin code :allow<B L> :skip-test
     use MONKEY-SEE-NO-EVAL;
     role Serializable {
         method serialize() {
@@ -656,6 +664,7 @@ With this setup, your poor customers will find themselves unable to turn
 their Taurus and you won't be able to make more of your product!  In this
 case, it may have been better to use roles:
 
+    =begin code :skip-test
     role Bull-Like {
         has Bool $.castrated = False;
         method steer {
@@ -671,20 +680,25 @@ case, it may have been better to use roles:
         }
     }
     class Taurus does Bull-Like does Steerable { }
+    =end code
 
 This code will die with something like:
 
+    =begin code :skip-test
     ===SORRY!===
     Method 'steer' must be resolved by class Taurus because it exists in
     multiple roles (Steerable, Bull-Like)
+    =end code
 
 This check will save you a lot of headaches:
 
+    =begin code :skip-test
     class Taurus does Bull-Like does Steerable {
         method steer($direction?) {
             self.Steerable::steer($direction?)
         }
     }
+    =end code
 
 When a role is applied to a second role, the actual application is delayed
 until the second role is applied to a class, at which point both roles are
@@ -714,7 +728,7 @@ When a role contains a stubbed method, a non-stubbed version of a method of
 the same name must be supplied at the time the role is applied to a class.
 This allows you to create roles that act as abstract interfaces.
 
-    =begin code :allow<B L>
+    =begin code :allow<B L> :skip-test
     role AbstractSerializable {
         method serialize() { B<L<...>> }  # literal ... here marks the
                                           # method as a stub

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -305,8 +305,8 @@ L<nodality|/language/typesystem#trait_is_nodal> of the inner operator of a
 chain. For the hyper method call operator (».) the nodality of the target
 method is significant.
 
-    say (<a b>, <c d e>)».elems        # (2 3)
-    say (<a b>, <c d e>)».&{ .elems }  # ((1 1) (1 1 1))
+    say (<a b>, <c d e>)».elems;        # (2 3)
+    say (<a b>, <c d e>)».&{ .elems };  # ((1 1) (1 1 1))
 
 You can chain hyper operators to destructure a List of Lists.
 
@@ -604,7 +604,9 @@ X<Hyper method call operator>. Will call a method on all elements of a C<List> o
 Take care to avoid a common mistake of expecting side-effects to occur in order. The following
 C<say> is B<not> guaranteed to produce the output in order:
 
+    =begin code :skip-test
     @a».say;  # WRONG! Could produce a␤b␤c␤ or c␤b␤a␤ or any other order
+    =end code
 
 =head2 postfix C<.postfix> / C<.postcircumfix>
 X<|.( )>X<|.[ ]>X<|.{ }>
@@ -1202,7 +1204,9 @@ restored to its original value.
 
 Note that you can also assign immediately as part of the call to temp:
 
+    =begin code :skip-test
     temp $a = "five";
+    =end code
 
 =head2 prefix C«let»
 
@@ -2083,7 +2087,7 @@ values for all C<Z> operators in a chain.
     for <a b c> Z <1 2 3> -> [$l, $r] {
         say "$l:$r"
     }
-    OUTPUT«a:1␤b:2␤c:3␤»
+    # OUTPUT: «a:1␤b:2␤c:3␤»
 
 The C<Z> operator also exists as a meta operator, in which case the inner
 lists are replaced by the value from applying the operator to the

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -55,27 +55,31 @@ not-yet-declared package name.
 X«|MY (package)»X«|OUR (package)»X«|CORE (package)»X«|GLOBAL (package)»X«|PROCESS (package)»X«|COMPILING(package)»
 The following pseudo-package names are reserved at the front of a name:
 
-    MY          # Symbols in the current lexical scope (aka $?SCOPE)
-    OUR         # Symbols in the current package (aka $?PACKAGE)
-    CORE        # Outermost lexical scope, definition of standard Perl
-    GLOBAL      # Interpreter-wide package symbols, really UNIT::GLOBAL
-    PROCESS     # Process-related globals (superglobals)
-    COMPILING   # Lexical symbols in the scope being compiled
+=begin table
+    MY          Symbols in the current lexical scope (aka $?SCOPE)
+    OUR         Symbols in the current package (aka $?PACKAGE)
+    CORE        Outermost lexical scope, definition of standard Perl
+    GLOBAL      Interpreter-wide package symbols, really UNIT::GLOBAL
+    PROCESS     Process-related globals (superglobals)
+    COMPILING   Lexical symbols in the scope being compiled
+=end table
 
 X«|CALLER (package)»X«|CALLERS (package)»X«|DYNAMIC (package)»X«|OUTER (package)»X«|OUTERS (package)»X«|LEXICAL (package)»X«|UNIT (package)»X«|SETTING (package)»X«|PARENT (package)»X«|CLIENT (package)»
 The following relative names are also reserved but may be used
 anywhere in a name:
 
-    CALLER      # Contextual symbols in the immediate caller's lexical scope
-    CALLERS     # Contextual symbols in any caller's lexical scope
-    DYNAMIC     # Contextual symbols in my or any caller's lexical scope
-    OUTER       # Symbols in the next outer lexical scope
-    OUTERS      # Symbols in any outer lexical scope
-    LEXICAL     # Contextual symbols in my or any outer's lexical scope
-    UNIT        # Symbols in the outermost lexical scope of compilation unit
-    SETTING     # Lexical symbols in the unit's DSL (usually CORE)
-    PARENT      # Symbols in this package's parent package (or lexical scope)
-    CLIENT      # The nearest CALLER that comes from a different package
+=begin table
+    CALLER      Contextual symbols in the immediate caller's lexical scope
+    CALLERS     Contextual symbols in any caller's lexical scope
+    DYNAMIC     Contextual symbols in my or any caller's lexical scope
+    OUTER       Symbols in the next outer lexical scope
+    OUTERS      Symbols in any outer lexical scope
+    LEXICAL     Contextual symbols in my or any outer's lexical scope
+    UNIT        Symbols in the outermost lexical scope of compilation unit
+    SETTING     Lexical symbols in the unit's DSL (usually CORE)
+    PARENT      Symbols in this package's parent package (or lexical scope)
+    CLIENT      The nearest CALLER that comes from a different package
+=end table
 
 The file's scope is known as C<UNIT>, but there are one or more lexical scopes
 outside of that corresponding to the linguistic setting (often known as the

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -20,8 +20,10 @@ L<phase in the running of a Perl 6 program|/language/phasers>, provide a great 
 Use the C<m: your code goes here> L<#perl6 channel evalbot|/language/glossary#camelia>
 to write lines like:
 
+    =begin code :skip-test
     m: say now - INIT now
     rakudo-moar abc1234: OUTPUT«0.0018558␤»
+    =end code
 
 The C<now> to the left of C<INIT> runs 0.0018558 seconds I<later> than the C<now> to the right of the C<INIT>
 because the latter occurs during L<the INIT phase|/language/phasers#INIT>.
@@ -32,13 +34,13 @@ Enter C<prof-m: your code goes here> in the L<#perl6 channel|/language/glossary#
 to invoke a Perl 6 compiler with a C<--profile> option.
 The evalbot's output includes a link to L<profile info|https://en.wikipedia.org/wiki/Profiling_(computer_programming)>:
 
-=begin code :allow< L >
+    =begin code :allow< L > :skip-test
 
     yournick prof-m: say 'hello world'
     camelia  prof-m 273e89: OUTPUT«hello world␤...»
              .. Prof: L<http://p.p6c.org/20f9e25>
 
-=end code
+    =end code
 
 Click on the profile info link to see a profile for C<say 'hello world'>.
 
@@ -55,6 +57,7 @@ JSON file.
 Another option (especially useful for profiles too big even for the Qt viewer) is to use an extension of C<.sql>.
 This will write the profile data as a series of SQL statements, suitable for opening in SQLite.
 
+    =begin code :skip-test
     # create a profile
     perl6 --profile --profile-filename=demo.sql -e 'say (^20).combinations(3).elems'
 
@@ -81,6 +84,7 @@ This will write the profile data as a series of SQL statements, suitable for ope
        ...>   c.id
        ...> order by
        ...>   inclusive_time desc;
+    =end code
 
 To learn how to interpret the profile info, use the C<prof-m: your code goes here> evalbot (explained
 above) and ask questions on channel.

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -14,7 +14,7 @@ described in more detail in the following sections.
 
 =head2 X<Literal strings: Q|quote,Q;quote,｢ ｣>
 
-=for code :allow<B>
+=for code :allow<B> :skip-test
 B<Q[>A literal stringB<]>
 B<｢>More plainly.B<｣>
 B<Q ^>Almost any non-word character can be a delimiter!B<^>
@@ -33,36 +33,38 @@ with a space. Please note that some natural languages use a left delimiting
 quote on the right side of a string. C<Q> will not support those as it relies
 on unicode properties to tell left and right delimiters apart.
 
-=for code :allow<B>
+=for code :allow<B> :skip-test
 B<Q'>this will not work!B<'>
 B<Q(>this won't work either!B<)>
 B<Q (>this is fine, because of space after QB<)>
 B<Q '>and so is thisB<'>
 
-=for code :allow<B>
+=for code :allow<B> :skip-test
 Q<Make sure you B«<»matchB«>» opening and closing delimiters>
 Q{This is still a closing curly brace → B<\>}
 
 These examples produce:
 
+    =begin code :skip-test
     A literal string
     More plainly.
     Almost any non-word character can be a delimiter!
     Make sure you <match> opening and closing delimiters
     This is still a closing curly brace → \
+    =end code
 
 The other quote forms add to this basic functionality:
 
 =head2 X<Escaping: q|quote,q;quote,' '>
 
-    'Very plain'
-    q[This back\slash stays]
-    q[This back\\slash stays] # Identical output
-    q{This is not a closing curly brace → \}, but this is → }
-    Q :q $There are no backslashes here, only lots of \$\$\$>!$
-    '(Just kidding. There\'s no money in that string)'
-    'No $interpolation {here}!'
-    Q:q!Just a literal "\n" here!
+    'Very plain';
+    q[This back\slash stays];
+    q[This back\\slash stays]; # Identical output
+    q{This is not a closing curly brace → \}, but this is → };
+    Q :q $There are no backslashes here, only lots of \$\$\$>!$;
+    '(Just kidding. There\'s no money in that string)';
+    'No $interpolation {here}!';
+    Q:q!Just a literal "\n" here!;
 
 The C<q> form allows for escaping characters that would otherwise end the
 string using a backslash. The backslash itself can be escaped, too, as in
@@ -71,7 +73,7 @@ delimiter, but it's also available as an adverb on C<Q>, as in the fifth and
 last example above.
 
 These examples produce:
-=for code :allow<B>
+=for code :allow<B> :skip-test
 Very plain
 This back\slash stays
 This back\slash stays
@@ -83,11 +85,12 @@ Just a literal "\n" here
 
 =head2 X<Interpolation: qq|quote,qq;quote," ">
 
-=for code :allow<B L>
+=begin code :allow<B L> :skip-test
 my $color = 'blue';
 L<say> B<">My favorite color is B<$color>!B<">
 
-    My favorite color is blue!
+My favorite color is blue!
+=end code
 
 X<|\ (quoting)>
 The C<qq> form – usually written using double quotes – allows for
@@ -96,41 +99,45 @@ written within the string so that the content of the variable is inserted into
 the string. It is also possible to escape variables within a C<qq>-quoted
 string:
 
-=for code :allow<B>
+=begin code :allow<B> :skip-test
 say B<">The B<\>$color variable contains the value '$color'B<">;
 
-    The $color variable contains the value 'blue'
+The $color variable contains the value 'blue'
+=end code
 
 Another feature of C<qq> is the ability to interpolate Perl 6 code from
 within the string, using curly braces:
 
-=for code :allow<B L>
+=begin code :allow<B L> :skip-test
 my ($x, $y, $z) = 4, 3.5, 3;
 say "This room is B<$x> m by B<$y> m by B<$z> m.";
 say "Therefore its volume should be B<{ $x * $y * $z }> m³!";
 
-    This room is 4 m by 3.5 m by 3 m.
-    Therefore its volume should be 42 m³!
+This room is 4 m by 3.5 m by 3 m.
+Therefore its volume should be 42 m³!
+=end code
 
 By default, only variables with the C<$> sigil are interpolated normally.
 This way, when you write C<"documentation@perl6.org">, you aren't
 interpolating the C<@perl6> variable. If that's what you want to do, append
 a C<[]> to the variable name:
 
-=for code :allow<B>
+=begin code :allow<B> :skip-test
 my @neighbors = "Felix", "Danielle", "Lucinda";
 say "@neighborsB<[]> and I try our best to coexist peacefully."
 
-    Felix Danielle Lucinda and I try our best to coexist peacefully.
+Felix Danielle Lucinda and I try our best to coexist peacefully.
+=end code
 
 Often a method call is more appropriate.  These are allowed within C<qq>
 quotes as long as they have parentheses after the call. Thus the following
 code will work:
 
-=for code :allow<B L>
+=begin code :allow<B L> :skip-test
 say "@neighborsB<.L<join>(', ')> and I try our best to coexist peacefully."
 
-    Felix, Danielle, Lucinda and I try our best to coexist peacefully.
+Felix, Danielle, Lucinda and I try our best to coexist peacefully.
+=end code
 
 However, C<"@example.com"> produces C<@example.com>.
 
@@ -144,23 +151,23 @@ Postcircumfix operators and therefore L<subscripts|/language/subscripts> are
 interpolated as well.
 
     my %h = :1st; say "abc%h<st>ghi";
-    OUTPUT«abc1ghi␤»
+    # OUTPUT«abc1ghi␤»
 
 To enter unicode sequences use C<\x> or C<\x[]> with the hex-code of the
 character or a list of characters.
 
     my $s = "I \x[2665] Perl 6!";
     dd $s;
-    OUTPUT«Str $s = "I ♥ Perl 6!"␤»
+    # OUTPUT«Str $s = "I ♥ Perl 6!"␤»
     my $s = "I really \x[2661,2665,2764,1f495] Perl 6!";
     dd $s;
-    OUTPUT«Str $s = "I really ♡♥❤💕 Perl 6!"␤»
+    # OUTPUT«Str $s = "I really ♡♥❤💕 Perl 6!"␤»
 
 You can also use unicode names with C<\c[]>.
 
     my $s = "Camelia \c[BROKEN HEART] my \c[HEAVY BLACK HEART]!";
     dd $s;
-    OUTPUT«Str $s = "Str $s = "Camelia 💔 my ❤!"␤»
+    # OUTPUT«Str $s = "Str $s = "Camelia 💔 my ❤!"␤»
 
 Interpolation of undefined values will raise a control exception that can be
 caught in the current block with
@@ -175,7 +182,7 @@ L<CONTROL|https://docs.perl6.org/syntax/CONTROL>.
 =head2 Word quoting: qw
 X<|qw word quote>
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 B<qw|>! @ # $ % ^ & * \| < > B<|> eqv '! @ # $ % ^ & * | < >'.words
 B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}')
 B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}')
@@ -199,7 +206,7 @@ It's easier to write and to read this:
 =head2 Word quoting: < >
 X«|< > word quote»
 
-=for code :allow<B L>
+=for code :allow<B L> :skip-test
 B«<»a b cB«>» L<eqv> ('a', 'b', 'c');   # True
 B«<»a b 42B«>» L<eqv> ('a', 'b', '42'); # False, the 42 become an IntStr allomorph
 say < 42 > ~~ Int; # True
@@ -223,13 +230,16 @@ brackets around the number, without any extra spaces:
 Compared to C<42/10> and C<1+42i>, there's no division (or addition) operation
 involved. This is useful for literals in routine signatures, for example:
 
+    =begin code :skip-test
     sub close-enough-π (<355/113>) {
         say "Your π is close enough!"
     }
     close-enough-π 710/226; # Your π is close enough!
 
     # WRONG: can't do this, since it's a division operation
+
     sub compilation-failure (355/113) {}
+    =end code
 
 =head2 X<Word quoting with quote protection: qww|quote,qww>
 
@@ -303,8 +313,10 @@ prints simply C<hello>.  Nevertheless, if you have declared an environment
 variable before calling C<perl6>, this will be available within C<qx>, for
 instance
 
+    =begin code :skip-test
     WORLD="there" perl6
     > say qx{echo "hello $WORLD"}
+    =end code
 
 will now print C<hello there>.
 
@@ -354,7 +366,7 @@ END
 The contents of the heredoc only begin on the next line, so you can (and
 should) finish the line.
 
-=begin code
+=begin code :skip-test
 my $escaped = my-escaping-function(q:to/TERMINATOR/, language => 'html');
 Here are the contents of the heredoc.
 Potentially multiple lines.
@@ -374,7 +386,7 @@ say q:to/END/;
 
 produces this output:
 
-=begin code
+=begin code :skip-test
 Here is
 some multi line
     string
@@ -397,9 +409,11 @@ C<{\> as well as C<$> if it is not the sigil for a defined variable.  For exampl
 
 would produce:
 
-  option {
-      file "db.7.3.8";
-  };
+=begin code :skip-test
+option {
+    file "db.7.3.8";
+};
+=end code
 
 You can begin multiple Heredocs in the same line.
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -100,10 +100,12 @@ match C<\d>, but also digits from other scripts.
 
 Examples for digits are:
 
+    =begin code :skip-test
     U+0035 5 DIGIT FIVE
     U+07C2 ߂ NKO DIGIT TWO
     U+0E53 ๓ THAI DIGIT THREE
     U+1B56 ᭖ BALINESE DIGIT SIX
+    =end code
 
 =item X<\h and \H|regex,\h;regex,\H>
 
@@ -112,10 +114,12 @@ single character that is not a horizontal whitespace character.
 
 Examples for horizontal whitespace characters are
 
+    =begin code :skip-test
     U+0020 SPACE
     U+00A0 NO-BREAK SPACE
     U+0009 CHARACTER TABULATION
     U+2001 EM QUAD
+    =end code
 
 Vertical whitespace like newline characters are explicitly excluded; those
 can be matched with C<\v>, and C<\s> matches any kind of whitespace.
@@ -149,6 +153,7 @@ character that is not vertical whitespace.
 
 Examples for vertical whitespace characters:
 
+    =begin code :skip-test
     U+000A LINE FEED
     U+000B VERTICAL TABULATION
     U+000C FORM FEED
@@ -156,6 +161,7 @@ Examples for vertical whitespace characters:
     U+0085 NEXT LINE
     U+2028 LINE SEPARATOR
     U+2029 PARAGRAPH SEPARATOR
+    =end code
 
 Use C<\s> to match any kind of whitespace, not just vertical whitespace.
 
@@ -167,14 +173,17 @@ character.
 
 Examples of word characters:
 
+    =begin code :skip-test
     0041 A LATIN CAPITAL LETTER A
     0031 1 DIGIT ONE
     03B4 δ GREEK SMALL LETTER DELTA
     03F3 ϳ GREEK LETTER YOT
     0409 Љ CYRILLIC CAPITAL LETTER LJE
+    =end code
 
 Predefined subrules:
 
+    =begin code :skip-test
     <alnum>   \w       'alpha' plus 'digit'
     <alpha>   <:L>     Alphabetic characters
     <blank>   \h       Horizontal whitespace
@@ -189,6 +198,7 @@ Predefined subrules:
     <|wb>               Word Boundary (zero-width assertion)
     <ww>               Within Word (zero-width assertion)
     <xdigit>           Hexadecimal digit [0-9A-Fa-f]
+    =end code
 
 =head2 X«Unicode properties|regex,<:property>»
 
@@ -199,10 +209,10 @@ Category name. These use pair syntax.
 
 To match against a Unicode Property:
 
-    "a".uniprop('Script')                 # Latin
-    "a" ~~ / <:Script<Latin>> /
-    "a".uniprop('Block')                  # Basic Latin
-    "a" ~~ / <:Block('Basic Latin')> /
+    "a".uniprop('Script');                 # Latin
+    "a" ~~ / <:Script<Latin>> /;
+    "a".uniprop('Block');                  # Basic Latin
+    "a" ~~ / <:Block('Basic Latin')> /;
 
 The following list of Unicode General Categories is stolen from the Perl 5
 L<perlunicode|http://perldoc.perl.org/perlunicode.html> documentation:
@@ -288,20 +298,20 @@ Fortunately, defining your own is fairly simple. Within C<< <[ ]> >>, you
 can put any number of single characters and ranges of characters (expressed
 with two dots between the end points), with or without whitespace.
 
-    "abacabadabacaba" ~~ / <[ a .. c 1 2 3 ]> /
+    "abacabadabacaba" ~~ / <[ a .. c 1 2 3 ]> /;
     # Unicode hex codepoint range
-    "ÀÁÂÃÄÅÆ" ~~ / <[ \x[00C0] .. \x[00C6] ]> /
+    "ÀÁÂÃÄÅÆ" ~~ / <[ \x[00C0] .. \x[00C6] ]> /;
     # Unicode named codepoint range
-    "ÀÁÂÃÄÅÆ" ~~ / <[ \c[LATIN CAPITAL LETTER A WITH GRAVE] .. \c[LATIN CAPITAL LETTER AE] ]> /
+    "ÀÁÂÃÄÅÆ" ~~ / <[ \c[LATIN CAPITAL LETTER A WITH GRAVE] .. \c[LATIN CAPITAL LETTER AE] ]> /;
 
 Within the C<< < > >> you can use C<+> and C<-> to add or
 remove multiple range definitions and
 even mix in some of the unicode categories above. You can also
 write the backslashed forms for character classes between the C< [ ] >.
 
-    / <[\d] - [13579]> /
+    / <[\d] - [13579]> /;
     # starts with \d and removes odd ASCII digits, but not quite the same as
-    / <[02468]> /
+    / <[02468]> /;
     # because the first one also contains "weird" unicodey digits
 
 To negate a character class, put a C<-> after the opening angle:
@@ -433,8 +443,10 @@ first matching alternative wins.
 
 For example, C<ini> files have the following form:
 
+    =begin code :skip-test
     [section]
     key = value
+    =end code
 
 Hence, if you parse a single line of an C<ini> file, it can be either a
 section or a key-value pair and the regex would be (to a first
@@ -568,6 +580,7 @@ the end of the string).
 
 You can also use the variants C<«> and C<»> :
 
+    my $str = 'The quick brown fox';
     say so $str ~~ /« own/;          # False
     say so $str ~~ /own »/;          # True
 
@@ -581,14 +594,14 @@ together, usually to override operator precedence:
 
 The same grouping facility is available in regexes:
 
-    / a || b c /        # matches 'a' or 'bc'
-    / ( a || b ) c /    # matches 'ac' or 'bc'
+    / a || b c /;        # matches 'a' or 'bc'
+    / ( a || b ) c /;    # matches 'ac' or 'bc'
 
 The same grouping applies to quantifiers:
 
-    / a b+ /            # matches an 'a' followed by one or more 'b's
-    / (a b)+ /          # matches one or more sequences of 'ab'
-    / (a || b)+ /       # matches a sequence of 'a's and 'b's, at least one long
+    / a b+ /;            # matches an 'a' followed by one or more 'b's
+    / (a b)+ /;          # matches one or more sequences of 'ab'
+    / (a || b)+ /;       # matches a sequence of 'a's and 'b's, at least one long
 
 An unquantified capture produces a L<Match> object. When a capture is
 quantified (except with the C<?> quantifier) the capture becomes a list of
@@ -738,8 +751,10 @@ expression goes, and the right side is what you want to replace it with.
 Substitutions are written similarly to matching, but the substitution operator
 has both an area for the regex to match, and the text to substitute:
 
+    =begin code :skip-test
     s/replace/with/;           # a substitution that is applied to $_
     $str ~~ s/replace/with/;   # a substitution applied to a scalar
+    =end code
 
 The substitution operator allows delimiters other than the slash:
 
@@ -1026,16 +1041,18 @@ have it parse the input in a way you don't expect.
 Since ratcheting behavior is often desirable in parsers, there's a
 shortcut to declaring a ratcheting regex:
 
+    =begin code :skip-test
     my token thing { .... }
     # short for
     my regex thing { :r ... }
+    =end code
 
 =head3 X<Sigspace|regex adverb,:sigspace;regex adverb,:s>
 
 The B<C<:sigspace>> or B<C<:s>> adverb makes whitespace significant in a
 regex.
 
-    =begin code :allow<B>
+    =begin code :allow<B> :skip-test
     say so "I used Photoshop®"   ~~ m:i/   photo shop /;      # True
     say so "I used a photo shop" ~~ m:iB<:s>/ photo shop /;   # True
     say so "I used Photoshop®"   ~~ m:iB<:s>/ photo shop /;   # False
@@ -1060,7 +1077,7 @@ becomes C«foo+ <.ws>».
 
 In all, this code:
 
-    =begin code :allow<B>
+    =begin code :allow<B> :skip-test
     rx :s {
         ^^
         {
@@ -1080,7 +1097,7 @@ In all, this code:
 
 Becomes:
 
-    =begin code :allow<B>
+    =begin code :allow<B> :skip-test
     rx {
         ^^ B«<.ws>»
         {
@@ -1165,7 +1182,7 @@ C<:ex>) adverb.
 
 The above code produces this output:
 
-=begin code
+=begin code :skip-test
 abracadabra
 abracada
 abraca
@@ -1225,7 +1242,7 @@ adverb:
 
 produces
 
-=begin code
+=begin code :skip-test
 abracadabra
    acadabra
      adabra
@@ -1385,8 +1402,10 @@ in what you expect, but only so long as there are no possible ambiguities.
 
 For example, in C<ini> files:
 
+    =begin code :skip-test
     [section]
     key=value
+    =end code
 
 What can be inside the section header? Allowing only a word might be too
 restrictive. Somebody might write C<[two words]>, or use dashes, or so on.
@@ -1402,8 +1421,10 @@ This leaves us with
 which is fine if you are only processing one line. But if you're processing
 a whole file, suddenly the regex parses
 
+    =begin code :skip-test
     [with a
     newline in between]
+    =end code
 
 which might not be a good idea.  A compromise would be
 

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -302,13 +302,17 @@ X<Union operator>.
 Returns the B<union> of all its arguments. Generally, this creates a new
 C<Set> that contains all the elements its arguments contain.
 
+    =begin code :skip-test
     <a a b c d> (|) <h g f e d c> (|) <i j> === set <a b c d e f g h i j>
+    =end code
 
 If any of its arguments are C<Baggy>, it creates a new C<Bag> that contains
 all the elements of the arguments, each weighed by the highest weight that
 appeared for that element.
 
+    =begin code :skip-test
     bag(<a a b c a>) (|) bag(<a a b c c>) === bag(<a a a b c c>)
+    =end code
 
 =head4 infix ∪
 
@@ -327,14 +331,18 @@ X<Intersection operator>.
 Returns the B<intersection> of all of its arguments. Generally, this creates
 a new C<Set> that contains only the elements common to all of the arguments.
 
+    =begin code :skip-test
     <a b c> (&) <b c d> === set <b c>
     <a b c d> (&) <b c d e> (&) <c d e f> === set <c d>
+    =end code
 
 If any of the arguments are C<Baggy>, the result is a new C<Bag> containing
 the common elements, each weighted by the largest I<common> weight (which
 is the minimum of the weights of that element over all arguments).
 
+    =begin code :skip-test
     bag(<a a b c a>) (&) bag(<a a b c c>) === bag(<a a b c>)
+    =end code
 
 =head4 infix ∩
 
@@ -360,8 +368,10 @@ If the first argument is C<Baggy>, this returns a C<Bag> that contains each
 element of the first argument with its weight subtracted by the weight of
 that element in each of the other arguments.
 
+    =begin code :skip-test
     bag(<a a b c a d>) (-) bag(<a a b c c>) = bag(<a d>)
     bag(<a a a a c d d d>) (-) bag(<a b d a>) (-) bag(<d c>) = bag(<a a d d>)
+    =end code
 
 =head4 infix ∖
 
@@ -402,8 +412,10 @@ Returns the Baggy B<multiplication> of its arguments, i.e., a C<Bag> that
 contains each element of the arguments with the weights of the element
 across the arguments multiplied together to get the new weight.
 
+    =begin code :skip-test
     <a b c> (.) <a b c d> === bag <a b c> # Since 1 * 0 == 0, in the case of 'd'
     bag(<a a b c a d>) (.) bag(<a a b c c>) === ("a"=>6,"c"=>2,"b"=>1).Bag
+    =end code
 
 =head4 infix ⊍
 
@@ -423,8 +435,9 @@ Returns the Baggy B<addition> of its arguments, i.e., a C<Bag> that contains
 each element of the arguments with the weights of the element across the
 arguments added together to get the new weight.
 
+    =begin code :skip-test
     bag(<a a b c a d>) (+) bag(<a a b c c>) === ("a"=>5,"c"=>3,"b"=>2,"d"=>1).Bag
-
+    =end code
 
 =head4 infix ⊎
 

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -52,15 +52,18 @@ For passing single-word string keys to C<{ }>, you can also use the
 L<angle-bracketed word quoting constructs|/language/quoting#Word_quoting:_qw>
 as if they were postcircumfix operators:
 
+    my %grade = Zoe => "C", Ben => "B+";
     say %grade<Zoe>;    #-> C
     say %grade<Ben>;    #-> B+
 
 This is really just syntactic sugar that gets turned into the corresponding
 C<{ }> form at compile-time:
 
+    =begin code :skip-test
     %hash<foo bar>;     # same as %hash{ <foo bar> }
     %hash«foo $var»;    # same as %hash{ «foo $var» }
     %hash<<foo $var>>;  # same as %hash{ <<foo $var>> }
+    =end code
 
 You may have noted above that we avoided having to quote C<Zoe> by using
 the C<< => >> operator, but that same operator did not just put invisible
@@ -77,11 +80,11 @@ default C<Hash>, subscripts coerce keys into strings, as long as
 those keys produce something C<Cool>.  You can use C<.perl> on a
 collection to be sure whether the keys are strings or objects:
 
-    ( 1  => 1 ).perl.say             #-> 1 => 1
+    ( 1  => 1 ).perl.say;            #-> 1 => 1
     my %h; %h{1}   = 1; say %h.perl; #-> { "1" => 1 }
-    ( 1/2 => 1 ).perl.say            #-> 0.5 => 1
+    ( 1/2 => 1 ).perl.say;           #-> 0.5 => 1
     my %h; %h{1/2} = 1; say %h.perl; #-> { "0.5" => 1 }
-    ( pi => 1 ).perl.say             #-> :pi(1)
+    ( pi => 1 ).perl.say;            #-> :pi(1)
     my %h; %h{pi}  = 1; say %h.perl; #-> { "3.14159265358979" => 1 }
 
 While the invisible quotes around single names is built into C<< => >>,
@@ -163,9 +166,11 @@ words, C<@alphabet[*-1]> becomes C<@alphabet[@alphabet.elems - 1]>.
 This means that you can use arbitrary expressions which depend on the size of
 the collection:
 
+    =begin code :skip-test
     say @array[* div 2];  # select the middlemost element
     say @array[$i % *];   # wrap around a given index ("modular arithmetic")
     say @array[ -> $size { $i % $size } ];  # same as previous
+    =end code
 
 =head1 Slices
 
@@ -211,8 +216,10 @@ Be aware that slices are controlled by the I<type> of what is passed to
 
 So even a one-element list returns a slice, whereas a bare scalar value doesn't:
 
+    =begin code :skip-test
     dd @alphabet[2,];  #-> ("c",)
     dd @alphabet[2];   #-> "c"
+    =end code
 
 (The angle-bracket form for associative subscripts works out because
 L<word quoting|/language/quoting#Word_quoting:_qw> conveniently returns a
@@ -222,10 +229,12 @@ In fact, the list structure of (L<the current dimension of|#Multiple
 dimensions>) the subscript is preserved across the slice operation
 (but the kind of Iterable is not – the result is always just lists.)
 
+    =begin code :skip-test
     dd @alphabet[0, (1..2, (3,))];  #-> ("a", (("b", "c"), ("d",)))
     dd @alphabet[0, (1..2, [3,])];  #-> ("a", (("b", "c"), ("d",)))
     dd @alphabet[flat 0, (1..2, (3,))];  #-> ("a", "b", "c", "d")
     dd flat @alphabet[0, (1..2, (3,))];  #-> ("a", "b", "c", "d")
+    =end code
 
 =head2 Truncating slices
 
@@ -243,7 +252,9 @@ collection:
 
 L<From-the-end|#From the end> indices are allowed as range end-points.
 
+    =begin code :skip-test
     say @array[*-3 .. *];       # select the last three elements
+    =end code
 
 A similar thing is done for lazy sequences, but it is often impossible to
 determine whether the sequence is infinite.  Just as often, the first part
@@ -253,7 +264,9 @@ lists, a lazy subscript will not truncate as long as it does not have to
 lazily generate values, but once it starts generating values lazily, it
 will stop if it generates a value that points to a nonexistent index.
 
+    =begin code :skip-test
     dd @letters[0, 2, 4 ... *];     # Every other element of the array.
+    =end code
 
 This feature is more for protection against accidental out-of-memory
 problems than for actual use.  Since some lazy sequences cache their
@@ -261,9 +274,11 @@ results, every time they are used in a truncation, they accumulate one
 more known element.  Things like this should probably be avoided rather
 than used for effect:
 
+    =begin code :skip-test
     my @a = 2, 3 ... *;
     dd flat @letters[0, 7, @a]; #-> ("a", Any, "c", "d", "e", "f")
     dd flat @letters[0, 7, @a]; #-> ("a", Any, "c", "d", "e", "f", Any)
+    =end code
 
 The runaway protection is not perfect.  The indices are eagerly evaluated,
 with the only stop condition being truncation.  This is to provide
@@ -271,13 +286,17 @@ mostly consistent results when there is self-reference/mutation inside
 the indices.  As such, the following will most likely hang until all
 memory has been consumed:
 
+    =begin code :skip-test
     @letters[0 xx *];
+    =end code
 
 So, to safely use lazy indices, they should be one-shot things which
 are guaranteed to overrun the array.  The following alternate formulation
 will produce a fully lazy result (but will not truncate):
 
+    =begin code :skip-test
     my $a = (0 xx *).map({ @letters[$_] }); # "a", "a", "a" ... forever
+    =end code
 
 If you I<don't> want to specify your slice as a range/sequence but still want
 to silently skip nonexistent elements, you can use the L<#:v> adverb.
@@ -400,9 +419,11 @@ controlled using adverbs.
 Beware of the relatively loose precedence of operator adverbs, which may
 require you to add parentheses in compound expressions:
 
+    =begin code :skip-test
     if $foo || %hash<key>:exists { ... }    # WRONG, tries to adverb the || op
     if $foo || (%hash<key>:exists) { ... }  # correct
     if $foo or %hash<key>:exists { ... }    # also correct
+    =end code
 
 The supported adverbs are:
 
@@ -426,11 +447,15 @@ an undefined value, and elements that aren't part of the collection at all:
 
 May also be negated to test for non-existence:
 
+    =begin code :skip-test
     dd %fruit<apple banana>:!exists; #-> (False, True)
+    =end code
 
 To check if I<all> elements of a slice exist, use an L<all> junction:
 
+    =begin code :skip-test
     if all %fruit<apple orange banana>:exists { ... }
+    =end code
 
 C<:exists> can be combined with the L<#:delete> and L<#:p>/L<#:kv> adverbs -
 in which case the behavior is determined by those adverbs, except that any
@@ -469,8 +494,10 @@ instead.
 With the negated form of the adverb, the element is not actually deleted. This
 means you can pass a flag to make it conditional:
 
+    =begin code :skip-test
     dd %fruit<apple> :delete($flag);  # deletes the element only if $flag is
                                       # true, but always returns the value.
+    =end code
 
 Can be combined with the L<#:exists> and L<#:p>/L<#:kv>/L<#:k>/L<#:v> adverbs -
 in which case the return value will be determined by those adverbs, but the
@@ -494,7 +521,9 @@ L<Pair>, and silently skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
+    =begin code :skip-test
     dd %month<Jan Foo Mar>:!p;  #-> ("Jan" => 1, "Foo" => Any, "Mar" => 3)
+    =end code
 
 Can be combined with the L<#:exists> and L<#:delete> adverbs.
 
@@ -517,13 +546,17 @@ and values:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
+    =begin code :skip-test
     dd %month<Jan Foo Mar>:!kv;  #-> ("Jan", 1, "Foo", Any, "Mar", 3)
+    =end code
 
 This adverb is commonly used to iterate over slices:
 
+    =begin code :skip-test
     for %month<Feb Mar>:kv -> $month, $i {
         say "$month had {Date.new(2015, $i, 1).days-in-month} days in 2015"
     }
+    =end code
 
 Can be combined with the L<#:exists> and L<#:delete> adverbs.
 
@@ -544,7 +577,9 @@ skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
+    =begin code :skip-test
     dd %month<Jan Foo Mar>:!k;  #-> ("Jan", "Foo", "Mar")
+    =end code
 
 See also the L<keys> routine.
 
@@ -565,7 +600,9 @@ mutable value container), and silently skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
+    =begin code :skip-test
     dd %month<Jan Foo Mar>:!v;  #-> (1, Any, 3)
+    =end code
 
 See also the L<values> routine.
 
@@ -624,6 +661,7 @@ type L<Hash>, and delegate all subscripting and iterating related functionality
 to that attribute (using a custom type constraint to make sure users don't
 insert anything invalid into it):
 
+    =begin code :skip-test
     class HTTP::Header does Associative is Iterable {
         subset StrOrArrayOfStr where Str | ( Array & {.all ~~ Str} );
 
@@ -633,18 +671,21 @@ insert anything invalid into it):
 
         method Str { #`[not shown, for brevity] }
     }
+    =end code
 
 However, HTTP header field names are supposed to be case-insensitive (and
 preferred in camel-case). We can accommodate this by taking the C<*-KEY>
 and C<push> methods out of the C<handles> list, and implementing them
 separately like this:
 
+    =begin code :skip-test
     method AT-KEY     ($key) is rw { %!fields{normalize-key $key}        }
     method EXISTS-KEY ($key)       { %!fields{normalize-key $key}:exists }
     method DELETE-KEY ($key)       { %!fields{normalize-key $key}:delete }
     method push(*@_) { #`[not shown, for brevity] }
 
     sub normalize-key ($key) { $key.subst(/\w+/, *.tc, :g) }
+    =end code
 
 Note that subscripting C<%!fields> returns an appropriate rw container, which
 our C<AT-KEY> can simply pass on.
@@ -655,6 +696,7 @@ the C<StrOrArrayOfStr> type constraint on C<%!fields>, and replace our
 C<AT-KEY> implementation with one that returns a custom C<Proxy> container
 which takes care of sanitizing values on assignment:
 
+    =begin code :skip-test
     multi method AT-KEY (::?CLASS:D: $key) is rw {
         my $element := %!fields{normalize-key $key};
 
@@ -669,6 +711,7 @@ which takes care of sanitizing values on assignment:
             }
         );
     }
+    =end code
 
 Note that declaring the method as C<multi> and restricting it to C<:D> (defined
 invocants) makes sure that the undefined case is passed through to the default
@@ -784,8 +827,10 @@ Expected to bind the value or container C<new> to the slot at position
 C<$index>, replacing any container that would be naturally found there.
 This is what is called when you write:
 
+    =begin code :skip-test
     my $x = 10;
     @numbers[5] := $x;
+    =end code
 
 The generic L<Array> class supports this in order to allow building complex
 linked data structures, but for more domain-specific types it may not make
@@ -892,8 +937,10 @@ Expected to bind the value or container C<new> to the slot associated with
 C<$key>, replacing any container that would be naturally found there.
 This is what is called when you write:
 
+    =begin code :skip-test
     my $x = 10;
     %age<Claire> := $x;
+    =end code
 
 The generic L<Hash> class supports this in order to allow building complex
 linked data structures, but for more domain-specific types it may not make

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -111,7 +111,7 @@ whitespace disambiguates possible parses.
 The most common form of comments in Perl 6 starts with a single hash character
 C<#> and goes until the end of the line.
 
-=begin code
+=begin code :skip-test
 if $age > 250 {     # catch obvious outliers
     # this is another comment!
     die "That doesn't look right"
@@ -163,6 +163,7 @@ underscore or number). You can also embed dashes C<-> or single quotes C<'>
 in the middle, but not two in a row, and only if followed immediately by an
 alphabetic character.
 
+    =begin code :skip-test
     # valid identifiers:
     x
     something-longer
@@ -170,12 +171,15 @@ alphabetic character.
     don't
     fish-food
     π
+    =end code
 
+    =begin code :skip-test
     # not valid identifiers:
     with-numbers1234-5
     42
     is-prime?
     fish--food
+    =end code
 
 Names of constants, types (including classes and modules) and routines (subs
 and methods) are identifiers, and they also appear in variable names (usually
@@ -219,7 +223,9 @@ expression (and thus also a statement).
 
 The C<do> prefix turns statements into expressions. So while
 
+    =begin code :skip-test
     my $x = if True { 42 };     # Syntax error!
+    =end code
 
 is an error,
 
@@ -283,10 +289,12 @@ Named entities, such as variables, constants, classes, modules, subs, etc, are
 part of a namespace. Nested parts of a name use C<::> to separate the
 hierarchy. Some examples:
 
+    =begin code :skip-test
     $foo                # simple identifiers
     $Foo::Bar::baz      # compound identifiers separated by ::
     $Foo::($bar)::baz   # compound identifiers that perform interpolations
     Foo::Bar::bob(23)   # function invocation given qualified name
+    =end code
 
 See the L<documentation on packages|/language/packages> for more details.
 
@@ -321,43 +329,51 @@ In all literal formats, you can use underscores to group digits;
 they don't carry any semantic information; the following literals all evaluate to the same
 number:
 
+    =begin code :skip-test
     1000000
     1_000_000
     10_00000
     100_00_00
+    =end code
 
 =head4 Int literals
 
 Integers default to signed base-10, but you can use other bases. For details,
 see L<Int|/type/Int>.
 
+    =begin code :skip-test
     -2          # actually not a literal, but unary - operator applied to numeric literal 2
     12345
     0xBEEF      # base 16
     0o755       # base 8
     :3<1201>    # arbitrary base, here base 3
+    =end code
 
 =head4 Rat literals
 
 L<Rat|/type/Rat> literals (rationals) are very common, and take the place of decimals or floats in many other languages. Integer division also results in a C<Rat>.
 
+    =begin code :skip-test
     1.0
     3.14159
     -2.5        # Not actually a literal, but still a Rat
     :3<21.0012> # Base 3 rational
     ⅔
     2/3         # Not actually a literal, but still a Rat
+    =end code
 
 =head4 Num literals
 
 Scientific notation with an integer exponent to base ten after an C<e> produces
 L<floating point number|/type/Num>:
 
+    =begin code :skip-test
     1e0
     6.022e23
     1e-9
     -2e48
     2e2.5       # error
+    =end code
 
 =head4 Complex literals
 
@@ -365,9 +381,10 @@ L<Complex|/type/Complex> numbers are written either as an imaginary number
 (which is just a rational number with postfix C<i> appended), or as a sum of
 a real and an imaginary number:
 
+    =begin code :skip-test
     1+2i
     6.123e5i    # note that this is 6.123e5 * i and not 6.123 * 10 ** (5i)
-
+    =end code
 
 =head3 Pair literals
 
@@ -378,28 +395,34 @@ constructing them: C<< key => 'value' >> and C<:key('value')>.
 
 Arrow pairs can have an expression or an identifier on the left-hand side:
 
+    =begin code :skip-test
     identifier => 42
     "identifier" => 42
     ('a' ~ 'b') => 1
+    =end code
 
 =head4 Adverbial pairs (colon pairs)
 
 Short forms without explicit values:
 
+    =begin code :skip-test
     my $thing = 42;
     :$thing                 # same as  thing => $thing
     :thing                  # same as  thing => True
     :!thing                 # same as  thing => False
+    =end code
 
 The variable form also works with other sigils, like C<:&callback> or
 C<:@elements>.
 
 Long forms with explicit values:
 
+    =begin code :skip-test
     :thing($value)              # same as  thing => $value
     :thing<quoted list>         # same as  thing => <quoted list>
     :thing['some', 'values']    # same as  thing => ['some', 'values']
     :thing{a => 'b'}            # same as  thing => { a => 'b' }
+    =end code
 
 =head3 Array literals
 
@@ -451,11 +474,13 @@ Note that with objects as keys, you cannot access non-string keys as strings:
 
 A L<Regex|/type/Regex> is declared with slashes like C</foo/>. Note that this C<//> syntax is shorthand for the full C<rx//> syntax.
 
+    =begin code :skip-test
     /foo/          # Short version
     rx/foo/        # Longer version
     Q :regex /foo/ # Even longer version
 
     my $r = /foo/; # Regexes can be assigned to variables
+    =end code
 
 =head3 Signature literals
 
@@ -518,8 +543,10 @@ keyword, a name, some optional traits, and a body of functions.
 
 You can declare a unit of things without explicit curly brackets.
 
+    =begin code :skip-test
     unit module Gar;
     # ... stuff goes here instead of in {}'s
+    =end code
 
 =head3 Multi-dispatch declaration
 
@@ -541,17 +568,21 @@ See L<functions|/language/functions>.
 
 =comment TODO
 
+    =begin code :skip-test
     foo;   # Invoke the function foo with no arguments
     foo(); # Invoke the function foo with no arguments
     &f();  # Invoke &f, which contains a function
     &f.(); # Same as above, needed to make the following work
     my @functions = ({say 1}, {say 2}, {say 3});
     @functions>>.();
+    =end code
 
+    =begin code :skip-test
     # Method invocation. Object (instance) is $person, method is set-name-age
     $person.set-name-age('jane', 98);  # Most common way
     $person.set-name: 'jane', 98;      # Precedence drop
     set-name($person: 'jane', 98);     # Invocant marker
+    =end code
 
 =head1 Operators
 
@@ -563,11 +594,13 @@ usage.
 
 There are five types (arrangements) for operators, each taking either one or two arguments.
 
+    =begin code :skip-test
     ++$x           # prefix, operator comes before single input
     5 + 3          # infix, operator is between two inputs
     $x++           # postfix, operator is after single input
     <the blue sky> # circumfix, operator surrounds single input
     %foo<bar>      # postcircumfix, operator comes after first input and surrounds second
+    =end code
 
 =head2 Meta Operators
 
@@ -575,14 +608,16 @@ Operators can be composed. A common example of this is combining an infix
 (binary) operator with assignment. You can combine assignment with any binary
 operator.
 
+    =begin code :skip-test
     $x += 5     # Adds 5 to $x, same as $x = $x + 5
     $x min= 3   # Sets $x to the smaller of $x and 3, same as $x = $x min 3
     $x .= child # Equivalent to $x = $x.child
+    =end code
 
 Wrap an infix operator in C<[ ]> to create a new reduction operator that works
 on a single list of inputs, resulting in a single value.
 
-    [+] <1 2 3 4 5>         # 15
+    [+] <1 2 3 4 5>;        # 15
     (((1 + 2) + 3) + 4) + 5 # equivalent expanded version
 
 Wrap an infix operator in C<« »> (or the ASCII equivalent C<<< >>>) to create a
@@ -592,10 +627,12 @@ new hyper operator that works pairwise on two lists.
 
 The direction of the arrows indicates what to do when the lists are not the same size.
 
+    =begin code :skip-test
     @a «+« @b # Result is the size of @b, elements from @a will be re-used
     @a »+» @b # Result is the size of @a, elements from @b will be re-used
     @a «+» @b # Result is the size of the biggest input, the smaller one is re-used
     @a »+« @b # Exception if @a and @b are different sizes
+    =end code
 
 You can also wrap a unary operator with a hyper operator.
 

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -13,9 +13,11 @@ Here you can find an overview of different kinds of terms.
 
 =head2 Int
 
+    =begin code :skip-test
     42
     12_300_00
     :16<DEAD_BEEF>
+    =end code
 
 L<Int> literals consist of digits and can contain underscores
 between any two digits.
@@ -24,8 +26,10 @@ To specify a base other than ten, use the colonpair form C<< :radix<number> >>.
 
 =head2 Rat
 
+    =begin code :skip-test
     12.34
     1_200.345_678
+    =end code
 
 L<Rat> literals (rational numbers) contain two integer parts joined by a dot.
 
@@ -35,8 +39,10 @@ with a dot, for example the C<..> L<Range> operator).
 
 =head2 Num
 
+    =begin code :skip-test
     12.3e-32
     3e8
+    =end code
 
 L<Num> literals (floating point numbers) consist of L<Rat> or L<Int>
 literals followed by an C<e> and a (possibly negative) exponent. C<3e8>
@@ -44,24 +50,29 @@ constructs a L<Num> with value C<3 * 10**8>.
 
 =head2 Str
 
+    =begin code :skip-test
     'a string'
     'I\'m escaped!'
     "I don't need to be"
     "\"But I still can be,\" he said."
     q|Other delimiters can be used too!|
+    =end code
 
 String literals are most often created with C<'> or C<">, however strings
 are actually a powerful sub-language of Perl 6. See L<Quoting Constructs|/language/quoting>.
 
 =head2 Regex
 
+    =begin code :skip-test
     / match some text /
     rx/slurp \s rest (.*) $/
+    =end code
 
 These forms produce regex literals. See L<Quoting Constructs|/language/quoting>.
 
 =head2 Pair
 
+    =begin code :skip-test
     a => 1
     'a' => 'b'
     :identifier
@@ -76,6 +87,7 @@ These forms produce regex literals. See L<Quoting Constructs|/language/quoting>.
     :@array
     :%hash
     :&callable
+    =end code
 
 L<Pair> objects can be created either with C<< infix:«=>» >> (which
 auto-quotes the left-hand side if it is an identifier), or with the various
@@ -94,11 +106,13 @@ with the exception of C<< 'quoted string' => $value >>.
 
 =head2 List
 
+    =begin code :skip-test
     ()
     1, 2, 3
     <a b c>
     «a b c»
     qw/a b c/
+    =end code
 
 L<List> literals are: the empty pair of parentheses C<()>, a comma-separated
 list, or several quoting constructs.

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -593,6 +593,7 @@ list of the object in question. If a role is used instead of a class (using
 auto-punning), the auto-generated class' type-object, of the same name as the
 role, is added to the inheritance chain.
 
+=begin code :skip-test
     role Unitish[$unit = fail('Please provide a SI unit quantifier as a parameter to the role Unitish')] {
         has $.SI-unit-symbol = $unit;
         has $.SI-unit-name = %SI-UNITS{$unit};
@@ -627,6 +628,7 @@ role, is added to the inheritance chain.
     # OUTPUT«[75kg 735.49875kN]»
     say [(75kg).^name, N(75kg).^name];
     # OUTPUT«[Int+{SI-kilogram} Rat+{SI-Newton}]»
+=end code
 
 =head3 Versioning and Authorship
 

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -30,16 +30,16 @@ Control codes without any official name:
 
 Corrections:
 
-    say "\c[LATIN CAPITAL LETTER GHA]" # Ƣ
-    say "Ƣ".uniname # LATIN CAPITAL LETTER OI
+    say "\c[LATIN CAPITAL LETTER GHA]"; # Ƣ
+    say "Ƣ".uniname; # LATIN CAPITAL LETTER OI
     # This one is a spelling mistake that was corrected in a Name Alias:
-    say "\c[PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET]".uniname
+    say "\c[PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET]".uniname;
     # Output: PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
 
 Abbreviations:
 
-    say "\c[ZWJ]".uniname # ZERO WIDTH JOINER
-    say "\c[NBSP]".uniname # NO-BREAK SPACE
+    say "\c[ZWJ]".uniname; # ZERO WIDTH JOINER
+    say "\c[NBSP]".uniname; # NO-BREAK SPACE
 
 =head1 Named Sequences
 

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -42,12 +42,16 @@ insert-mode) by pressing first C<Ctrl-V> (also denoted C<^V>), then C<u> and
 then the hexadecimal value of the unicode character to be entered.  For
 example, the Greek letter λ (lambda) is entered via the key combination:
 
+    =begin code :skip-test
     ^Vu03BB
+    =end code
 
 You can also use C<Ctrl-K>/C<^K> along with a digraph to type in some
 characters.  So an alternative to the above using digraphs looks like this:
 
+    =begin code :skip-test
     ^Kl*
+    =end code
 
 The list of digraphs Vim provides is documented
 L<here|http://vimdoc.sourceforge.net/htmldoc/digraph.html>; you can add
@@ -66,7 +70,9 @@ the unicode code point hexadecimal number followed by the enter key.  The
 unicode character will now appear in the document.  Thus, to enter the Greek
 letter λ (lambda), one uses the following key combination:
 
+    =begin code :skip-test
     C-x 8 RET 3bb RET
+    =end code
 
 Further information about unicode and its entry into Emacs can be found on
 the L<Unicode Encoding Emacs wiki
@@ -75,7 +81,9 @@ page|https://www.emacswiki.org/emacs/UnicodeEncoding>.
 You can also use L<RFC 1345|https://tools.ietf.org/html/rfc1345> character
 mnemonics by typing:
 
+    =begin code :skip-test
     C-x RET C-\ rfc1345 RET
+    =end code
 
 Or C<C-u C-\ rfc1345 RET>.
 
@@ -83,7 +91,9 @@ To type special characters, type C<&> followed by a mnemonic.
 Emacs will show the possible characters in the echo area.
 For example, Greek letter λ (lambda) can be entered by typing:
 
+    =begin code :skip-test
     &l*
+    =end code
 
 You can use C<C-\> to toggle
 L<input method|https://www.gnu.org/software/emacs/manual/html_node/emacs/Select-Input-Method.html>.
@@ -94,12 +104,16 @@ L<TeX|https://www.emacswiki.org/emacs/TeXInputMethod>.
 Select it by typing C<C-u C-\ TeX RET>. You can enter a special character
 by using a prefix such as C<\>. For example, to enter λ, type:
 
+    =begin code :skip-test
     \lambda
+    =end code
 
 To view characters and sequences provided by an input method,
 run the C<describe-input-method> command:
 
+    =begin code :skip-test
     C-h I TeX
+    =end code
 
 =head2 Unix shell
 
@@ -108,7 +122,9 @@ C<Ctrl-Shift-u>, then the unicode code point value followed by enter.  For
 instance, to enter the character for the element-of operator (∈) use the
 following key combination (whitespace has been added for clarity):
 
+    =begin code :skip-test
     Ctrl-Shift-u 2208 Enter
+    =end code
 
 This also the method one would use to enter unicode characters into the
 C<perl6> REPL, if one has started the REPL inside a Unix shell.
@@ -120,7 +136,9 @@ command but with a rather limited digraph table. Thanks to B<bindkey> and
 B<exec> an external program can be used to insert characters to the current
 screen window.
 
+    =begin code :skip-test
     bindkey ^K exec .! digraphs
+    =end code
 
 This will bind control-k to the shell command digraphs. You can use
 L<digraphs|https://github.com/gfldex/digraphs> if you prefer a Perl 6 friendly
@@ -136,15 +154,17 @@ they are used as L<quoting characters|/language/quoting>
 
 Constructs such as these are now possible:
 
-    say ｢What?!｣
-    say ”Whoa!“
-    say „This works too!”
-    say „There are just too many ways“
-    say “here: “no problem” at all!” # You can nest them!
+    say ｢What?!｣;
+    say ”Whoa!“;
+    say „This works too!”;
+    say „There are just too many ways“;
+    say “here: “no problem” at all!”; # You can nest them!
 
 This is very useful in shell:
 
+    =begin code :skip-test
     perl6 -e 'say ‘hello world’'
+    =end code
 
 since you can just copy and paste some piece of code and not worry about quotes.
 
@@ -165,7 +185,7 @@ alternative in POD6.
 Thus constructs such as these are now possible:
 
     say (1, 2) »+« (3, 4);     # (4 6) - element-wise add
-    @array »+=» 42;            # add 42 to each element of @array
+    [1, 2, 3] »+=» 42;            # add 42 to each element of @array
     say «moo»;                 # moo
     my $baa = 123; say «$baa»; # (123)
     =begin pod
@@ -220,9 +240,10 @@ Wikipedia article|https://en.wikipedia.org/wiki/Greek_alphabet#Greek_in_Unicode>
 For example, to assign the value 3 to π, enter the following in Vim
 (whitespace added to the compose sequences for clarity):
 
-=for code :allow<B>
+    =begin code :allow<B> :skip-test
     my $B<Ctrl-V u 03C0> = 3;  # same as: my $π = 3;
     say $B<Ctrl-V u 03C0>;     # 3    same as: say $π;
+    =end code
 
 =head2 Superscripts and subscripts
 
@@ -238,17 +259,19 @@ Thus, to write the L<Taylor series|https://en.wikipedia.org/wiki/Taylor_series>
 expansion around zero of the function C<exp(x)> one would input into e.g.
 vim the following:
 
-=for code :allow<B>
+    =begin code :allow<B> :skip-test
     exp(x) = 1 + x + xB<Ctrl-V u 00B2>/2! + xB<Ctrl-V u 00B3>/3!
     + ... + xB<Ctrl-V u 207F>/n!
     # which would appear as
     exp(x) = 1 + x + x²/2! + x³/3! + ... + xⁿ/n!
+    =end code
 
 Or to specify the elements in a list from C<1> up to C<k>:
 
-=for code :allow<B>
+    =begin code :allow<B> :skip-test
     AB<Ctrl-V u 2081>, AB<Ctrl-V u 2082>, ..., AB<Ctrl-V u 2096>
     # which would appear as
     A₁, A₂, ..., Aₖ
+    =end code
 
 =end pod

--- a/doc/Language/unicode_texas.pod6
+++ b/doc/Language/unicode_texas.pod6
@@ -25,12 +25,8 @@ alphabetic character from the ASCII range.
 Any codepoint that has the C<Nd> (Number, decimal digit) property, can
 be used as a digit in any number.  For example:
 
-=begin code
-
   my $var = １９; # U+FF11 U+FF19
   say $var + 2;  # 21
-
-=end code
 
 =head1 Numeric values
 
@@ -38,12 +34,8 @@ Any codepoint that has the C<No> (Number, other) or C<Nl> (Number, letter)
 property can be used standalone as a numeric value, such as ½ and ⅓. (These
 aren't decimal digit characters, so can't be combined.) For example:
 
-=begin code
-
   my $var = ⅒ + 2 + Ⅻ; # here ⅒ is No and Rat and Ⅻ is Nl and Int
   say $var;              # 14.1
-
-=end code
 
 =head1 Whitespace characters
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -371,6 +371,7 @@ current file can be accessed via a Pod object, such as C<$=data>,
 C<$=SYNOPSIS> or C<=UserBlock>. That is: a variable with the same name of
 the desired block and a C<=> twigil.
 
+  =begin code :skip-test
     =begin code
     =begin Foo
     ...
@@ -378,6 +379,7 @@ the desired block and a C<=> twigil.
 
     #after that, $=Foo gives you all Foo-Pod-blocks
     =end code
+  =end code
 
 You may access the Pod tree which contains all Pod structures as a
 hierarchical data structure through C<$=pod>.
@@ -687,8 +689,10 @@ itself, not the expression that may contain an initializer. If the
 initializer has to be called exactly once, the C<state> declarator has to be
 provided.
 
+    =begin code :skip-test
     subset DynInt where $ = ::('Int'); # the initializer will be called for each type check
     subset DynInt where state $ = ::('Int'); # the initializer is called once, this is a proper cache
+    =end code
 
 =head3 The C<@> Variable
 


### PR DESCRIPTION
* Make many examples compile by adding semicolons, adding actual test data, etc.
* Add `:skip-test` directive to many examples. For further explanation see https://github.com/perl6/doc/issues/776.
* Use `table` instead of plain code where appropriately;
* Reformatting of some old examples.

Sadly, this is not the end, just some preparation work; My further plan is:
* To reformat results in this section too, just as for Type/.
* To write an addition to the contribution guide about the output style.
* To close this big issue.

I wanted this to be merged quickly to prevent conflicts, since this work is slow and our commits to master are everyday thing. After that, I will be able to continue my work in a small chunks directly into the master to be closer to upstream.