### PR TITLE
Unify Language/ examples output style

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -30,7 +30,7 @@ A default constructor allows the setting of attributes for the created object:
     # Create a new Rectangle from two Points
     my $r = Rectangle.new(lower => Point.new(x => 0, y => 0), upper => Point.new(x => 10, y => 10));
 
-    say $r.area(); # -> 100
+    say $r.area(); # OUTPUT: «100␤»
     =end code
 
 You can also provide your own construction and build
@@ -114,19 +114,19 @@ method.
 You can use C<.DEFINITE> method to find out if what you have is an instance
 or a type object:
 
-    say Int.DEFINITE; # False (type object)
-    say 426.DEFINITE; # True  (instance)
+    say Int.DEFINITE; # OUTPUT: «False␤» (type object)
+    say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
 
     class Foo {};
-    say Foo.DEFINITE;     # False (type object)
-    say Foo.new.DEFINITE; # True  (instance)
+    say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
+    say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
 
 You can also use type smileys to only accept instances or type objects:
 
     multi foo (Int:U) { "It's a type object!" }
     multi foo (Int:D) { "It's an instance!"   }
-    say foo Int; # It's a type object!
-    say foo 42;  # It's an instance!
+    say foo Int; # OUTPUT: «It's a type object!␤»
+    say foo 42;  # OUTPUT: «It's an instance!␤»
 
 =head1 State
 
@@ -537,14 +537,14 @@ class overriding the C<Cook>'s C<cook> method.
         cookbooks => 'The Joy of Cooking',
         salary => 40000);
 
-    $cook.cook( 'pizza' ); # Cooking pizza
+    $cook.cook( 'pizza' ); # OUTPUT: «Cooking pizza␤»
 
     my $baker = Baker.new(
         utensils => 'self cleaning oven',
         cookbooks => "The Baker's Apprentice",
         salary => 50000);
 
-    $baker.cook('brioche'); # Baking a tasty brioche
+    $baker.cook('brioche'); # OUTPUT: «Baking a tasty brioche␤»
     =end code
 
 Because the dispatcher will see the C<cook> method on C<Baker> before it

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -45,16 +45,18 @@ in a concurrent or asynchronous manner.
 
 =begin code
 my $p1 = Promise.new;
-say $p1.status;         # Planned;
+say $p1.status;         # OUTPUT: «Planned␤»
 $p1.keep('result');
-say $p1.status;         # Kept
-say $p1.result;         # result
+say $p1.status;         # OUTPUT: «Kept␤»
+say $p1.result;         # OUTPUT: «result␤»
                         # (since it has been kept, a result is available!)
 
 my $p2 = Promise.new;
 $p2.break('oh no');
-say $p2.status;         # Broken
-say $p2.result;         # dies with "oh no", because the promise has been broken
+say $p2.status;         # OUTPUT: «Broken␤»
+say $p2.result;         # dies, because the promise has been broken
+CATCH { default { say .^name, ': ', .Str } };
+# OUTPUT: «X::AdHoc+{X::Promise::Broken}: oh no␤»
 =end code
 
 Promises gain much of their power by being composable, for example by
@@ -65,7 +67,7 @@ chaining, usually by the L<then|/type/Promise#method_then> method:
         -> $v { say $v.result; "Second Result" }
     );
     $promise1.keep("First Result");
-    say $promise2.result;   # First Result \n Second Result
+    say $promise2.result;   # OUTPUT: «First Result␤Second Result␤»
 
 Here the L<then|/type/Promise#method_then> method schedules code to be
 executed when the first L<Promise> is kept or broken, itself returning
@@ -82,7 +84,7 @@ is illustrated with:
     my $promise2 = $promise1.then(-> $v { say "Handled but : "; say $v.result});
     $promise1.break("First Result");
     try $promise2.result;
-    say $promise2.cause;        # Handled but : \n First Result
+    say $promise2.cause;        # OUTPUT: «Handled but : ␤First Result␤»
 
 Here the C<break> will cause the code block of the C<then> to throw an
 exception when it calls the C<result> method on the original promise
@@ -110,7 +112,7 @@ for that:
     my $promise = Promise.start(
         { my $i = 0; for 1 .. 10 { $i += $_ }; $i}
     );
-    say $promise.result;    # 55
+    say $promise.result;    # OUTPUT: «55␤»
 
 Here the C<result> of the promise returned is the value returned from
 the code.  Similarly if the code fails (and the promise is thus broken),
@@ -152,7 +154,7 @@ the result of each:
         $i
     };
     my @result = await $p1, $p2;
-    say @result;            # 55 -55
+    say @result;            # OUTPUT: «[55 -55]␤»
 
 In addition to C<await>, two class methods combine several
 L<Promise> objects into a new promise: C<allof> returns a promise that
@@ -217,6 +219,8 @@ as the vow object is kept private, the status of the promise is safe:
     # Will throw an exception
     # "Access denied to keep/break this Promise; already vowed"
     $promise.keep;
+    CATCH { default { say .^name, ': ', .Str } };
+    # OUTPUT: «X::Promise::Vowed: Access denied to keep/break this Promise; already vowed␤»
 
 The methods that return a promise that will be kept or broken
 automatically such as C<in> or C<start> will do this, so it is not
@@ -421,7 +425,7 @@ and returns it, blocking until a new item is sent if the queue is empty:
 
     my $channel = Channel.new;
     $channel.send('Channel One');
-    say $channel.receive;  # 'Channel One'
+    say $channel.receive;  # OUTPUT: «Channel One␤»
 
 If the channel has been closed with the L<method
 close|/type/Channel#method_close> then any C<send> will cause the
@@ -758,7 +762,7 @@ at a time:
         }
     }
 
-    say $a; # 10
+    say $a; # OUTPUT: «10␤»
 
 C<protect> returns whatever the code block returns.
 

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -323,6 +323,6 @@ work with types in Perl 6.
     say $a = 12;    # OUTPUT: «12␤»
     say $a = 'FOO'; # X::TypeCheck::Binding
     say $a = 13;    # X::OutOfRange
-    CATCH { default { say .^name, ': ', .Str; .resume } };
+    CATCH { default { say .^name, ': ', .Str } };
 
 =end pod

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -52,7 +52,7 @@ Note that subroutine signatures allow passing around of containers:
     }
     my $x = 42;
     f($x);
-    say $x;         # 23
+    say $x;         # OUTPUT: «23␤»
 
 Inside the subroutine, the lexpad entry for C<$a> points to the same
 container that C<$x> points to outside the subroutine. Which is why
@@ -63,7 +63,7 @@ Likewise a routine can return a container if it is marked as C<is rw>:
     my $x = 23;
     sub f() is rw { $x };
     f() = 42;
-    say $x;         # 42
+    say $x;         # OUTPUT: «42␤»
 
 For explicit returns, C<return-rw> instead of C<return> must be used.
 
@@ -84,8 +84,8 @@ Scalar containers are transparent to type checks and most kinds of read-only
 accesses. A C<.VAR> makes them visible:
 
     my $x = 42;
-    say $x.^name;       # Int
-    say $x.VAR.^name;   # Scalar
+    say $x.^name;       # OUTPUT: «Int␤»
+    say $x.VAR.^name;   # OUTPUT: «Scalar␤»
 
 And C<is rw> on a parameter requires the presence of a writable Scalar
 container:
@@ -93,7 +93,7 @@ container:
     sub f($x is rw) { say $x };
     f 42;
     CATCH { default { say .^name, ': ', .Str } };
-    # OUTPUT«X::Parameter::RW: Parameter '$x' expected a writable container, but got Int value␤»
+    # OUTPUT: «X::Parameter::RW: Parameter '$x' expected a writable container, but got Int value␤»
 
 =head1 Binding
 
@@ -109,7 +109,7 @@ means that you cannot assign to it anymore:
     my $x := 42;
     $x = 23;
     CATCH { default { say .^name, ': ', .Str } };
-    # OUTPUT«X::AdHoc: Cannot assign to an immutable value␤»
+    # OUTPUT: «X::AdHoc: Cannot assign to an immutable value␤»
 
 You can also bind variables to other variables:
 
@@ -117,7 +117,7 @@ You can also bind variables to other variables:
     my $b = 0;
     $a := $b;
     $b = 42;
-    say $a;         # 42
+    say $a;         # OUTPUT: «42␤»
 
 Here, after the initial binding, the lexpad entries for C<$a> and C<$b> both
 point to the same scalar container, so assigning to one variable also
@@ -132,11 +132,11 @@ Sigilless variables also bind by default and so do parameters with the trait C<i
     my $a = 42;
     my \b = $a;
     b++;
-    say $a;         # 43
+    say $a;         # OUTPUT: «43␤»
 
     sub f($c is raw) { $c++ }
     f($a);
-    say $a;         # 44
+    say $a;         # OUTPUT: «44␤»
 
 =head1 Scalar containers and listy things
 
@@ -144,7 +144,7 @@ There are a number of positional container types with slightly different
 semantics in Perl 6. The most basic one is L<List|/type/List>
 It is created by the comma operator.
 
-    say (1, 2, 3).^name;    # List
+    say (1, 2, 3).^name;    # OUTPUT: «List␤»
 
 A list is immutable, which means you cannot change the number of elements
 in a list. But if one of the elements happens to be a scalar container,
@@ -152,12 +152,10 @@ you can still assign to it:
 
     my $x = 42;
     ($x, 1, 2)[0] = 23;
-    say $x;                 # 23
-    ($x, 1, 2)[1] = 23;     # Error: Cannot modify an immutable value
+    say $x;                 # OUTPUT: «23␤»
+    ($x, 1, 2)[1] = 23;     # Cannot modify an immutable value
     CATCH { default { say .^name, ': ', .Str } };
-    # OUTPUT:
-    # 23
-    # X::Assignment::RO: Cannot modify an immutable Int
+    # OUTPUT: «X::Assignment::RO: Cannot modify an immutable Int␤»
 
 So the list doesn't care about whether its elements are values or
 containers, they just store and retrieve whatever was given to them.
@@ -170,7 +168,7 @@ be containers, which means that you can always assign to elements:
 
     my @a = 1, 2, 3;
     @a[0] = 42;
-    say @a;         # 42 2 3
+    say @a;         # OUTPUT: «[42 2 3]␤»
 
 C<@a> actually stores three scalar containers. C<@a[0]> returns one of
 them, and the assignment operator replaces the integer value stored in that
@@ -186,8 +184,8 @@ the same thing: discard the old value(s), and enter some new value(s).
 
 Nevertheless, it's easy to observe how different they are:
 
-    my $x = 42; say $x.^name;   # Int
-    my @a = 42; say @a.^name;   # Array
+    my $x = 42; say $x.^name;   # OUTPUT: «Int␤»
+    my @a = 42; say @a.^name;   # OUTPUT: «Array␤»
 
 This is because the C<Scalar> container type hides itself well, but C<Array>
 makes no such effort. Also assignment to an array variable is coercive, so
@@ -196,7 +194,7 @@ you can assign a non-array value to an array variable.
 To place a non-C<Array> into an array variable, binding works:
 
     my @a := (1, 2, 3);
-    say @a.WHAT;                # (List)
+    say @a.WHAT;                # OUTPUT: «(List)␤»
 
 =head1 Binding to array elements
 
@@ -205,7 +203,7 @@ As a curious side note, Perl 6 supports binding to array elements:
     my @a = (1, 2, 3);
     @a[0] := my $x;
     $x = 42;
-    say @a;                     # 42 2 3
+    say @a;                     # OUTPUT: «[42 2 3]␤»
 
 If you've read and understood the previous explanations, it is now time to
 wonder how this can possibly work. After all, binding to a variable requires
@@ -229,7 +227,7 @@ counter-intuitive results when the array is used later.
     @a[2] = $b;          # ...but this is fine.
     @a[1, 2] := 1, 2;    # runtime error: X::Bind::Slice
     CATCH { default { say .^name, ': ', .Str } };
-    # OUTPUT«X::Bind::Slice: Cannot bind to Array slice␤»
+    # OUTPUT: «X::Bind::Slice: Cannot bind to Array slice␤»
 
 Operations that mix Lists and Arrays generally protect against such
 a thing happening accidentally.
@@ -249,23 +247,23 @@ do not flatten in list context:
 
     my @a = 1, 2, 3;
     my @b = @a, 4, 5;
-    say @b.elems;               # 3
+    say @b.elems;               # OUTPUT: «3␤»
 
 There are operations that flatten out sublists that are not inside a scalar
 container: slurpy parameters (C<*@a>) and explicit calls to C<flat>:
 
 
     my @a = 1, 2, 3;
-    say (flat @a, 4, 5).elems;  # 5
+    say (flat @a, 4, 5).elems;  # OUTPUT: «5␤»
 
     sub f(*@x) { @x.elems };
-    say f @a, 4, 5;             # 5
+    say f @a, 4, 5;             # OUTPUT: «5␤»
 
 As hinted above, scalar containers prevent that flattening:
 
     sub f(*@x) { @x.elems };
     my @a = 1, 2, 3;
-    say f $@a, 4, 5;            # 3
+    say f $@a, 4, 5;            # OUTPUT: «3␤»
 
 The C<@> character can also be used as a prefix to remove a scalar container:
 
@@ -289,7 +287,7 @@ user to L<handle|/type/Promise#method_in> timeouts.
     my @a;
     @a[0] = @a;
     put @a.perl;
-    # OUTPUT«(my \Array_54878224 = [Array_54878224,])␤»
+    # OUTPUT: «(my \Array_54878224 = [Array_54878224,])»
 
 =head1 Type Constraints
 
@@ -297,7 +295,7 @@ Any container can have a type constraint in form of a L<type object|/language/ty
 
     EVAL ‚my $i = 42; say $i.VAR.of; $i := "forty plus two"; say $i.VAR.of;‘;
     CATCH { default { say .^name, ' ', .Str } }
-    # OUTPUT«(Mu)␤X::Method::NotFound No such method 'of' for invocant of type 'Str'␤»
+    # OUTPUT: «(Mu)␤X::Method::NotFound No such method 'of' for invocant of type 'Str'␤»
 
 
 =head1 Custom containers
@@ -322,9 +320,9 @@ work with types in Perl 6.
     }
 
     my Int $a := lucky(Int);
-    say $a = 12;
+    say $a = 12;    # OUTPUT: «12␤»
     say $a = 'FOO'; # X::TypeCheck::Binding
-    say $a = 13; # X::OutOfRange
+    say $a = 13;    # X::OutOfRange
     CATCH { default { say .^name, ': ', .Str; .resume } };
 
 =end pod

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -116,8 +116,8 @@ but this is mainly just useful for avoiding the syntactical need to
 parenthesize a statement if it is the last thing in an expression:
 
 =for code :skip-test
-3, do if 1 { 2 }  ; #-> 3, 2
-3,   (if 1 { 2 }) ; #-> 3, 2
+3, do if 1 { 2 }  ; # OUTPUT: «(3, 2)␤»
+3,   (if 1 { 2 }) ; # OUTPUT: «(3, 2)␤»
 3,    if 1 { 2 }  ; # Syntax error
 
 ...which brings us to C<if>.

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -33,9 +33,9 @@ When a block stands alone as a statement, it will be entered immediately
 after the previous statement finishes, and the statements inside it will be
 executed.
 
-    say 1;                    # says "1"
-    { say 2; say 3 };         # says "2" then says "3"
-    say 4;                    # says "4"
+    say 1;                    # OUTPUT: «1␤»
+    { say 2; say 3 };         # OUTPUT: «2␤3␤»
+    say 4;                    # OUTPUT: «4␤»
 
 Unless it stands alone as a statement, a block simply creates a closure.  The
 statements inside are not executed immediately.  Closures are another topic
@@ -62,22 +62,22 @@ nothing (or nothing but comments) on a line after a closing curly brace where
 you would normally put semicolon, then you do not need the semicolon:
 
     # All three of these lines can appear as a group, as is, in a program
-    { 42.say }                #-> says "42"
-    { 43.say }                #-> says "43"
-    { 42.say }; { 43.say }    #-> says "42" then says "43"
+    { 42.say }                # OUTPUT: «42␤»
+    { 43.say }                # OUTPUT: «43␤»
+    { 42.say }; { 43.say }    # OUTPUT: «42␤43␤»
 
 ...but:
 
 =begin code :skip-test
-{ 42.say }  { 43.say }    #-> Syntax error
-{ 42.say; } { 43.say }    #-> Also a syntax error, of course
+{ 42.say }  { 43.say }    # Syntax error
+{ 42.say; } { 43.say }    # Also a syntax error, of course
 =end code
 
 So, be careful when you backspace in a line-wrapping editor:
 
 =begin code :skip-test
 { "Without semicolons line-wrapping can be a bit treacherous.".say } \
-{ 43.say } #-> Syntax error
+{ 43.say } # Syntax error
 =end code
 
 You have to watch out for this in most languages anyway to prevent things
@@ -337,7 +337,7 @@ with missing elements.
     for @list -> $a, $b = 'N/A', $c = 'N/A' {
         say "$a $b $c"
     }
-    # OUTPUT«1 2 3␤4 N/A N/A␤»
+    # OUTPUT: «1 2 3␤4 N/A N/A␤»
 
 A C<for> may be used on lazy lists – it will only take elements from the
 list when they are needed, so to read a file line by line, you could
@@ -375,7 +375,7 @@ dynamic scope of the C<gather> block.
         take 5;
         take 42;
     }
-    say join ', ', $a;          # 1, 5, 42
+    say join ', ', $a;          # OUTPUT: «1, 5, 42␤»
 
 C<gather/take> can generate values lazily, depending on context. If you want to
 force lazy evaluation use the L<lazy|/type/Iterable#method_lazy> subroutine or
@@ -411,7 +411,7 @@ from within C<gather>:
         return gather %direction{$direction}();
     }
 
-    say weird(<a b c>, :direction<backward> );          # (c b a)
+    say weird(<a b c>, :direction<backward> );          # OUTPUT: «(c b a)␤»
 
 If values need to be mutable on the caller side, use L<take-rw|/type/Mu#routine_take-rw>.
 
@@ -464,7 +464,7 @@ regular expressions, and types when specifying a match.
         when Int { .say }
         default  { say "Not an Int" }
     }
-    #-> 42 43 Not an Int 44
+    # OUTPUT: «42 43 Not an Int 44␤»
 
 In this form, the C<given>/C<when> construct acts much like a set of
 C<if>/C<elsif>/C<else> statements.  Be careful with the order of the
@@ -475,7 +475,7 @@ C<when> statements.  The following code says C<"Int"> not C<42>.
         when 42  { say 42 }
         default  { say "huh?" }
     }
-    #-> Int
+    # OUTPUT: «Int␤»
 
 When a C<when> statement or C<default> statement causes the outer
 block to return, nesting C<when> or C<default> blocks do not count
@@ -489,7 +489,7 @@ be in the same "switch" just so long as you do not open a new block:
         }
         default  { say "huh?" }
     }
-    #-> 42
+    # OUTPUT: «42»
 
 C<when> statements can smart match against L<Signatures|/language/syntax#Signature_literals>.
 
@@ -519,8 +519,8 @@ resume matching after a successful match, like so:
         when 40..* { say "greater than 40" }
         default    { say "huh?" }
     }
-    # -> Int
-    # -> 42
+    # OUTPUT: «Int␤»
+    # OUTPUT: «42␤»
 
 Note that the C<when 40..*> match didn't occur.  For this to match
 such cases as well, one would need a proceed in the C<when 42> block.
@@ -535,8 +535,8 @@ the C<given> value once more, consider this code:
         when 42  { 42.say }
         default  { "got change for an existential answer?".say }
     }
-    #-> Int
-    #-> 42
+    # OUTPUT: «Int␤»
+    # OUTPUT: «42␤»
 
 ...which matches the C<Int>, skips C<43> since the value doesn't match, matches
 C<42> since this is the next positive match, but doesn't enter the
@@ -555,7 +555,7 @@ specify a final value for the block.
         when 42 { say 42 }
         default { say "dunno?" }
     }
-    #-> Int
+    # OUTPUT: «Int␤»
 
 If you are not inside a when or default block, it is an error to try
 to use C<proceed> or C<succeed>.  Also remember, the C<when> statement
@@ -577,7 +577,7 @@ if there is one:
 C<given> can follow a statement to set the topic in the statement it follows.
 
     .say given "foo";
-    # OUTPUT«foo␤»
+    # OUTPUT: «foo␤»
 
     printf "%s %02i.%02i.%i",
             <Mo Tu We Th Fr Sa Su>[.day-of-week - 1],
@@ -585,7 +585,7 @@ C<given> can follow a statement to set the topic in the statement it follows.
             .month,
             .year
         given DateTime.now;
-    # OUTPUT«Sa 03.06.2016»
+    # OUTPUT: «Sa 03.06.2016»
 
 =head1 X<loop|control flow>
 
@@ -608,9 +608,9 @@ loop { say 'forever' }
 The C<loop> statement may be used to produce values from the result of each
 run of the attached block if it appears in lists:
 
-    (loop ( my $i = 0; $i++ < 3;) { $i * 2 }).say;               #-> "(2 4 6)"
-    my @a = (loop ( my $j = 0; $j++ < 3;) { $j * 2 }); @a.say;   #-> "[2 4 6]"
-    my @b = do loop ( my $k = 0; $k++ < 3;) { $k * 2 }; @b.say; # same thing
+    (loop ( my $i = 0; $i++ < 3;) { $i * 2 }).say;               # OUTPUT: «(2 4 6)␤»
+    my @a = (loop ( my $j = 0; $j++ < 3;) { $j * 2 }); @a.say;   # OUTPUT: «[2 4 6]␤»
+    my @b = do loop ( my $k = 0; $k++ < 3;) { $k * 2 }; @b.say;  # same thing
 
 Unlike a C<for> loop, one should not rely on whether returned values are produced
 lazily, for now.  It would probably be best to use C<eager> to guarantee that a
@@ -631,8 +631,7 @@ true. So
     }
     print "\n";
 
-    # OUTPUT:
-    # 123
+    # OUTPUT: «123␤»
 
 Similarly, the C<until> statement executes the block as long as the
 expression is false.
@@ -643,8 +642,7 @@ expression is false.
     }
     print "\n";
 
-    # OUTPUT:
-    # 123
+    # OUTPUT: «123␤»
 
 The condition for C<while> or C<until> can be parenthesized, but there
 must be a space between the keyword and the opening parenthesis of the
@@ -669,42 +667,42 @@ is evaluated at the end of the loop, even if it appears at the front.
     repeat {
         $x++;
     } while $x < 5;
-    $x.say; # 5
+    $x.say; # OUTPUT: «5␤»
 
     repeat {
         $x++;
     } while $x < 5;
-    $x.say; # 6
+    $x.say; # OUTPUT: «6␤»
 
     repeat while $x < 10 {
         $x++;
     }
-    $x.say; # 10
+    $x.say; # OUTPUT: «10␤»
 
     repeat while $x < 10 {
         $x++;
     }
-    $x.say; # 11
+    $x.say; # OUTPUT: «11␤»
 
     repeat {
         $x++;
     } until $x >= 15;
-    $x.say; # 15
+    $x.say; # OUTPUT: «15␤»
 
     repeat {
         $x++;
     } until $x >= 15;
-    $x.say; # 16
+    $x.say; # OUTPUT: «16␤»
 
     repeat until $x >= 20 {
         $x++;
     }
-    $x.say; # 20
+    $x.say; # OUTPUT: «20␤»
 
     repeat until $x >= 20 {
         $x++;
     }
-    $x.say; # 21
+    $x.say; # OUTPUT: «21␤»
 
 All these forms may produce a return value the same way C<loop> does.
 
@@ -736,13 +734,13 @@ and will lead to runtime errors when attempted to be mutated.
     sub s(){ my $a = 41; return $a };
     say ++s();
     CATCH { default { say .^name, ': ', .Str } };
-    # OUTPUT«X::Multi::NoMatch.new(dispatcher …
+    # OUTPUT: «X::Multi::NoMatch.new(dispatcher …
 
 To return a mutable container, use C<return-rw>.
 
     sub s(){ my $a = 41; return-rw $a };
     say ++s();
-    # OUTPUT«42␤»
+    # OUTPUT: «42␤»
 
 The same rules as for C<return> regarding phasers and control exceptions apply.
 
@@ -758,7 +756,7 @@ thrown instead of being returned as a C<Failure>.
     sub f { fail "WELP!" };
     say f;
     CATCH { default { say .^name, ': ', .Str } }
-    # OUTPUT«X::AdHoc: WELP!␤»
+    # OUTPUT: «X::AdHoc: WELP!␤»
 
 =head1 X<once|control flow>
 
@@ -770,7 +768,7 @@ loop or a recursive routine.
         last if $guard-- <= 0;
         once { put 'once' };
         print 'many'
-    } # OUTPUT«once␤manymanymany»
+    } # OUTPUT: «once␤manymanymany»
 
 This works per "clone" of the containing code object, so:
 
@@ -786,7 +784,7 @@ A C<quietly> block will suppress warnings.
 
     quietly { warn 'kaput!' };
     warn 'still kaput!';
-    # OUTPUT«still kaput! [...]␤»
+    # OUTPUT: «still kaput! [...]␤»
 
 =head1 LABELs
 

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -19,7 +19,7 @@ a description of the error.
 
     die "oops, something went wrong";
 
-    # !> oops, something went wrong in block <unit> at my-script.p6:1
+    # RESULT: «oops, something went wrong in block <unit> at my-script.p6:1␤»
 
 =head1 Typed exceptions
 
@@ -32,8 +32,8 @@ then an L<X::IO::DoesNotExist> exception can be raised:
 
     die X::IO::DoesNotExist.new(:path("foo/bar"), :trying("zombie copy"))
 
-    # !> Failed to find 'foo/bar' while trying to do '.zombie copy'
-    # !> in block <unit> at my-script.p6:1
+    # RESULT: «!> Failed to find 'foo/bar' while trying to do '.zombie copy'
+    #          in block <unit> at my-script.p6:1»
 
 Note how the object has provided the backtrace with information about what
 went wrong. A user of the code can now more easily find and correct the
@@ -49,7 +49,7 @@ It's possible to handle exceptional circumstances by supplying a C<CATCH> block:
         when X::IO { say "some kind of IO exception was caught!" }
     }
 
-    # !> some kind of IO exception was caught!
+    # RESULT: «some kind of IO exception was caught!»
 
 Here, we are saying that if any exception of type C<X::IO> occurs, then the
 message C<some kind of IO exception was caught!> will be displayed.
@@ -85,11 +85,7 @@ In other words, even when the exception is handled successfully, the I<rest of t
 
   say "This won't be said.";   # but this line will be never reached since
                                # the enclosing block will be exited immediately
-
-Output:
-
-=for code :skip-test
-something went wrong ...
+  # OUTPUT: «something went wrong ...␤»
 
 Compare with this:
 
@@ -155,7 +151,7 @@ return value of itself. We can therefore use it as a RHS.
     say try { +"99999" } // "oh no";
     say try { +"hello" } // "oh no";
 
-    # OUTPUT«99999␤oh no␤»
+    # OUTPUT: «99999␤oh no␤»
     =end code
 
 =head1 Throwing exceptions
@@ -176,8 +172,7 @@ to continue from the point of the exception by calling the C<.resume> method.
 
     "OBAI".say;
 
-    # -> OHAI
-    # -> OBAI
+    # OUTPUT: «OHAI␤OBAI␤»
 
 If the C<CATCH> block doesn't match the exception thrown, then the
 exception's payload is passed on to the backtrace printing mechanism.
@@ -190,8 +185,8 @@ exception's payload is passed on to the backtrace printing mechanism.
 
     "OBAI".say;
 
-    # !> foo
-    # !> in block <unit> at my-script.p6:1
+    # RESULT: «foo
+    #          in block <unit> at my-script.p6:1»
 
 This next example doesn't resume from the point of the exception. Instead,
 it continues after the enclosing block, since the exception is caught, and then
@@ -207,7 +202,7 @@ control continues after the C<CATCH> block.
 
     "OBAI".say;
 
-    # -> OBAI
+    # OUTPUT: «OBAI␤»
 
 C<throw> can be viewed as the method form of C<die>, just that in this
 particular case, the sub and method forms of the routine have different
@@ -221,9 +216,9 @@ user can be resumed and control flow will continue with the statement
 following the statement that threw the exception. To do so, call the
 method C<.resume> on the exception object.
 
-    CATCH { when X::AdHoc { .resume } } # this is step 2
+    CATCH { when X::AdHoc { .resume } }         # this is step 2
 
-    die "We leave control after this."; # this is step 1
+    die "We leave control after this.";         # this is step 1
 
     say "We have continued with control flow."; # this is step 3
 
@@ -253,7 +248,7 @@ converted to a normal exception.
 
     { return; CATCH { default { say .^name, ': ',.Str } } }
 
-    # OUTPUT«X::ControlFlow::Return: Attempt to return outside of any Routine␤»
+    # OUTPUT: «X::ControlFlow::Return: Attempt to return outside of any Routine␤»
     # was CX::Return
 
 =end pod

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -32,7 +32,7 @@ then an L<X::IO::DoesNotExist> exception can be raised:
 
     die X::IO::DoesNotExist.new(:path("foo/bar"), :trying("zombie copy"))
 
-    # RESULT: «!> Failed to find 'foo/bar' while trying to do '.zombie copy'
+    # RESULT: «Failed to find 'foo/bar' while trying to do '.zombie copy'
     #          in block <unit> at my-script.p6:1»
 
 Note how the object has provided the backtrace with information about what

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -154,9 +154,9 @@ X<|Data::Dumper (FAQ)>
 Examples:
 
     my $foo="bar";
-    dd $foo;          # Str $foo = "bar"
-    say :$foo.perl;   # :foo("bar")
-    say :$foo.gist;   # foo => bar
+    dd $foo;          # OUTPUT: «Str $foo = "bar"␤»
+    say :$foo.perl;   # OUTPUT: «:foo("bar")␤»
+    say :$foo.gist;   # OUTPUT: «foo => bar␤»
 
 There are also modules in the ecosystem to do this, like
 L<Data::Dump|https://github.com/tony-o/perl6-data-dump/>, which colors the output.
@@ -193,15 +193,15 @@ languages.
 Example:
 
     my $foo;
-    say $foo;         # (Any) note the parentheses indicate type object
-    say $foo.^name;   # Any
+    say $foo;         # OUTPUT: «(Any)␤» - note the parentheses indicate type object
+    say $foo.^name;   # OUTPUT: «Any␤»
 
 (Any) shouldn't be used to check for definedness. In Perl 6, definedness is a
 property of an object. Usually, instances are defined and type objects are
 undefined.
 
-    say 1.defined;       # True
-    say (Any).defined;   # False
+    say 1.defined;       # OUTPUT: «True␤»
+    say (Any).defined;   # OUTPUT: «False␤»
 
 =head2 What is C<so>?
 
@@ -212,7 +212,7 @@ C<and> is the low-precedence version of C<&&>.
 
 Example usage:
 
-    say so 1|2 == 2;    # Bool::True
+    say so 1|2 == 2;    # OUTPUT: «True␤»
 
 In this example, the result of the comparison (which is a
 L<Junction|/type/Junction>), is
@@ -262,8 +262,8 @@ Example of a type constraint:
 Example of a definite return value:
 
     sub discard-random-number( --> 42 ) { rand }
-    say discard-random-number
-    # 42
+    say discard-random-number;
+    # OUTPUT: «42␤»
 
 In this case, the final value is thrown away because the return value is already specified.
 
@@ -304,12 +304,12 @@ references doesn't make much sense. Unlike Perl 5, scalar variables
 can also contain arrays directly:
 
     my @a = 1, 2, 3;
-    say @a;                 # "1 2 3\n"
-    say @a.WHAT;            # (Array)
+    say @a;                 # OUTPUT: «[1 2 3]␤»
+    say @a.WHAT;            # OUTPUT: «(Array)␤»
 
     my $scalar = @a;
-    say $scalar;            # "1 2 3\n"
-    say $scalar.WHAT;       # (Array)
+    say $scalar;            # OUTPUT: «[1 2 3]␤»
+    say $scalar.WHAT;       # OUTPUT: «(Array)␤»
 
 The big difference is that arrays inside a scalar act as one value in list
 context, whereas arrays will be happily iterated over.
@@ -321,10 +321,10 @@ context, whereas arrays will be happily iterated over.
     for $s { ... }          # loop body executed only once
 
     my @flat = flat @a, @a;
-    say @flat.elems;            # 6
+    say @flat.elems;            # OUTPUT: «6␤»
 
     my @nested = flat $s, $s;
-    say @nested.elems;          # 2
+    say @nested.elems;          # OUTPUT: «2␤»
 
 You can force flattening with C<@( ... )> or by calling the C<.list> method
 on an expression, and item context (not flattening) with C<$( ... )>
@@ -438,7 +438,7 @@ nothing in that value except the type).
 
     my Date $x;     # $x now contains the Date type object
     print $x;       # empty string plus warning
-    say $x;         # (Date)\n
+    say $x;         # OUTPUT: «(Date)␤»
 
 So, C<say> is optimized for debugging; display is optimized for people; and C<print>
 and C<put> are most suitable for producing output for other programs

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -236,10 +236,12 @@ $x = Int
 If you want to exclude type objects, you can append the C<:D> type smiley,
 which stands for "definite":
 
+    =begin code :skip-test
     my Int:D $x = 42;
     $x = Int;            # dies with:
                          # Type check failed in assignment to $x;
                          # expected Int:D but got Int
+    =end code
 
 Likewise, C<:U> constrains to undefined values, that is, type objects.
 
@@ -252,12 +254,14 @@ a type or a definite value.
 
 Example of a type constraint:
 
+    =begin code :skip-test
     sub divide-to-int( Int $a, Int $b --> Int ) {
             return ($a / $b).narrow;
     }
 
     divide-to-int(3, 2)
     # Type check failed for return value; expected Int but got Rat
+    =end code
 
 Example of a definite return value:
 
@@ -314,6 +318,7 @@ can also contain arrays directly:
 The big difference is that arrays inside a scalar act as one value in list
 context, whereas arrays will be happily iterated over.
 
+    =begin code :skip-test
     my @a = 1, 2, 3;
     my $s = @a;
 
@@ -325,6 +330,7 @@ context, whereas arrays will be happily iterated over.
 
     my @nested = flat $s, $s;
     say @nested.elems;          # OUTPUT: «2␤»
+    =end code
 
 You can force flattening with C<@( ... )> or by calling the C<.list> method
 on an expression, and item context (not flattening) with C<$( ... )>
@@ -350,8 +356,10 @@ There are several reasons:
 
 You likely tried to mix string interpolation and HTML.
 
+    =begin code :skip-test
     my $foo = "abc";
     say "$foo<html-tag>";
+    =end code
 
 Perl 6 thinks C<$foo> to be a Hash and C«<html-tag>» to be a string literal
 hash key. Use a closure to help it to understand you.

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -65,7 +65,7 @@ say escape 'foo#bar?'; # foo\#bar\?
 
 Subroutines don't have to be named; in this case they're called anonymous.
 
-    say sub ($a, $b) { $a ** 2 + $b ** 2 }(3, 4) # 25
+    say sub ($a, $b) { $a ** 2 + $b ** 2 }(3, 4) # OUTPUT: «25␤»
 
 But in this case, it's often desirable to use the more succinct L<block|Block>
 syntax. Subroutines and blocks can be called in place, as in the example above.
@@ -79,11 +79,11 @@ L<Block> syntax. It's used after every C<if>, C<for>, C<while>, etc.
     for 1, 2, 3, 4 -> $a, $b {
         say $a ~ $b;
     }
-    # OUTPUT«12␤34␤»
+    # OUTPUT: «12␤34␤»
 
 They can also be used on their own as anonymous blocks of code.
 
-    say { $^a ** 2 + $^b ** 2}(3, 4) # 25
+    say { $^a ** 2 + $^b ** 2}(3, 4) # OUTPUT: «25␤»
 
 For details about the syntax of blocks, see the documentation for the
 L<Block> type.
@@ -107,7 +107,7 @@ C<%_> are used in the function body, a signature with C<*@_> or C<*%_> will be
 generated. Both automatic variables can be used that the same time.
 
     sub s { dd @_, %_ };
-    dd &s.signature # OUTPUT«:(*@_, *%_)␤»
+    dd &s.signature # OUTPUT: «:(*@_, *%_)␤»
 
 =head2 Arguments
 X<|Argument>
@@ -117,7 +117,7 @@ use parentheses:
 
     sub f(&c){ c() * 2 }; # call the function reference c with empty parameter list
     sub g($p){ $p - 2 };
-    say(g(42), 45); # pass only 42 to g()
+    say(g(42), 45);       # pass only 42 to g()
 
 When calling a function, positional arguments should be supplied
 in the same order as the function's signature.  Named arguments
@@ -131,7 +131,7 @@ argument list of a function call, some special syntax is supported:
     f :35named;       # A named argument using abbreviated adverb form
     f 'named' => 35;  # Not a named argument, a Pair in a positional argument
     my \c = <a b c>.Capture;
-    f |c;            # Merge the contents of Capture $c as if they were supplied
+    f |c;             # Merge the contents of Capture $c as if they were supplied
 
 Arguments passed to a function are conceptually first collected in a
 C<Capture> container.  Details about the syntax and use of these
@@ -155,7 +155,7 @@ will become the return value. The default return value is L<Nil|/type/Nil>.
     sub a { 42 };
     sub b { say a };
     b;
-    # OUTPUT«42␤»
+    # OUTPUT: «42␤»
 
 Multiple return values are returned as a list or by creating a
 L<Capture|/type/Capture>. Destructuring can be used to untangle multiple return
@@ -163,25 +163,25 @@ values.
 
     sub a { 42, 'answer' };
     put a.perl;
-    # OUTPUT«(42, "answer")␤»
+    # OUTPUT: «(42, "answer")␤»
 
     my ($n, $s) = a;
     put [$s, $n];
-    # OUTPUT«answer 42␤»
+    # OUTPUT: «answer 42␤»
 
     sub b { <a b c>.Capture };
     put b.perl;
-    # OUTPUT«\("a", "b", "c")␤»
+    # OUTPUT: «\("a", "b", "c")␤»
 
 =head2 Return Type Constraints
 
 Perl 6 has many ways to specify a function's return type:
 
 =for code :skip-test
-sub foo(--> Int)      {}; say &foo.returns; # (Int)
-sub foo() returns Int {}; say &foo.returns; # (Int)
-sub foo() of Int      {}; say &foo.returns; # (Int)
-my Int sub foo()      {}; say &foo.returns; # (Int)
+sub foo(--> Int)      {}; say &foo.returns; # OUTPUT: «(Int)␤»
+sub foo() returns Int {}; say &foo.returns; # OUTPUT: «(Int)␤»
+sub foo() of Int      {}; say &foo.returns; # OUTPUT: «(Int)␤»
+my Int sub foo()      {}; say &foo.returns; # OUTPUT: «(Int)␤»
 
 Attempting to return values of another type will cause a compilation error.
 
@@ -209,8 +209,8 @@ each candidate with the C<multi> declarator.
         say "Happy {$age}th birthday, $name";
     }
 
-    congratulate 'Larry';       # Happy birthday, Larry
-    congratulate 'Bob', 45;     # Happy 45th birthday, Bob
+    congratulate 'Larry';       # OUTPUT: «Happy birthday, Larry␤»
+    congratulate 'Bob', 45;     # OUTPUT: «Happy 45th birthday, Bob␤»
 
 Dispatch can happen on the number of arguments (the I<arity>), but also on the
 type:
@@ -219,7 +219,7 @@ type:
     multi as-json(Real $d) { ~$d }
     multi as-json(@d)      { sprintf '[%s]', @d.map(&as-json).join(', ') }
 
-    say as-json([True, 42]);    # [true, 42]
+    say as-json([True, 42]);    # OUTPUT: «[true, 42]␤»
 
 C<multi> without any specific routine type always defaults to a C<sub>, but you
 can use it on methods as well. The candidates are all the multi methods of the
@@ -242,8 +242,8 @@ object:
 
     my $congrats = Congrats.new does BirthdayCongrats;
 
-    $congrats.congratulate('promotion','Cindy'); #-> Hooray for your promotion, Cindy
-    $congrats.congratulate('birthday','Bob');    #-> Happy birthday, Bob
+    $congrats.congratulate('promotion','Cindy'); # OUTPUT: «Hooray for your promotion, Cindy␤»
+    $congrats.congratulate('birthday','Bob');    # OUTPUT: «Happy birthday, Bob␤»
 
 =head3 X<proto|declarator>
 
@@ -271,7 +271,7 @@ fails at compile time because the proto's C<signature> becomes the common
 signature of all three, and C<42> doesn't match C<Str>.
 
 =for code :skip-test
-say &congratulate.signature #-> (Str $reason, Str $name, | is raw)
+say &congratulate.signature # OUTPUT: «(Str $reason, Str $name, | is raw)␤»
 
 You can give the C<proto> a function body, and place the C<{*}> where
 you want the dispatch to be done.
@@ -293,8 +293,8 @@ with. Parameter defaults and type coercions will work but are not be passed on.
 =for code :skip-test
 proto mistake-proto(Str() $str, Int $number = 42) {*}
 multi mistake-proto($str, $number) { say $str.WHAT }
-mistake-proto(7, 42);  #-> (Int) -- not passed on
-mistake-proto('test'); #!> fails -- not passed on
+mistake-proto(7, 42);  # OUTPUT: «(Int)␤» -- not passed on
+mistake-proto('test'); # fails -- not passed on
 
 =comment only
 
@@ -334,19 +334,19 @@ This results in the following behavior, which is known as the "single
 argument rule" and is important to understand when invoking slurpy functions:
 
 =for code :skip-test
-grab(1, 2);      # grab 1 grab 2
-grab((1, 2));    # grab 1 grab 2
-grab($(1, 2));   # grab 1 2
-grab((1, 2), 3); # grab 1 2 grab 3
+grab(1, 2);      # OUTPUT: «grab 1␤grab 2␤»
+grab((1, 2));    # OUTPUT: «grab 1␤grab 2␤»
+grab($(1, 2));   # OUTPUT: «grab 1 2␤»
+grab((1, 2), 3); # OUTPUT: «grab 1 2␤grab 3␤»
 
 This also makes user-requested flattening feel consistent whether there is
 one sublist, or many:
 
 =for code :skip-test
-grab(flat (1, 2), (3, 4));   # grab 1 grab 2 grab 3 grab 4
-grab(flat $(1, 2), $(3, 4)); # grab 1 2 grab 3 4
-grab(flat (1, 2));           # grab 1 grab 2
-grab(flat $(1, 2));          # grab 1 2
+grab(flat (1, 2), (3, 4));   # OUTPUT: «grab 1␤grab 2␤grab 3␤grab 4␤»
+grab(flat $(1, 2), $(3, 4)); # OUTPUT: «grab 1 2␤grab 3 4␤»
+grab(flat (1, 2));           # OUTPUT: «grab 1␤grab 2␤»
+grab(flat $(1, 2));          # OUTPUT: «grab 1 2␤»
 
 It is worth noting that mixing binding and sigilless variables
 in these cases requires a bit of finesse, because there is no Scalar
@@ -354,11 +354,11 @@ intermediary used during binding.
 
 =for code :skip-test
 my $a = (1, 2);  # Normal assignment, equivalent to $(1, 2)
-grab($a);       # grab 1 2
+grab($a);        # OUTPUT: «grab 1 2␤»
 my $b := (1, 2); # Binding, $b links directly to a bare (1, 2)
-grab($b);       # grab 1 grab 2
+grab($b);        # OUTPUT: «grab 1␤grab 2␤»
 my \c = (1, 2);  # Sigilless variables always bind, even with '='
-grab(c);        # grab 1 grab 2
+grab(c);         # OUTPUT: «grab 1␤grab 2␤»
 
 =head1 Functions are First-Class Objects
 
@@ -370,7 +370,7 @@ variable at the point of declaration:
 
     my $square = sub (Numeric $x) { $x * $x }
     # and then use it:
-    say $square(6);    # 36
+    say $square(6);    # OUTPUT: «36␤»
 
 X<|prefix &>
 Or you can reference an existing named function by using the C<&>-sigil in
@@ -387,7 +387,7 @@ which applies a function to each input element:
 
     sub square($x) { $x * $x };
     my @squared = map &square,  1..5;
-    say join ', ', @squared;        # 1, 4, 9, 16, 25
+    say join ', ', @squared;        # OUTPUT: «1, 4, 9, 16, 25␤»
 
 =head2 Z<>Infix Form
 
@@ -396,7 +396,7 @@ reference surrounded by C<[> and C<]>.
 
     sub plus { $^a + $^b };
     say 21 [&plus] 21;
-    # OUTPUT«42␤»
+    # OUTPUT: «42␤»
 
 =head2 Closures
 
@@ -409,7 +409,7 @@ lexical variables from an outer scope.
         #      ^^^^^^^^^^^^^^  inner sub, uses $y
     }
     my $generated = generate-sub(21);
-    $generated(); # 42
+    $generated(); # OUTPUT: «42␤»
 
 Here C<$y> is a lexical variable inside C<generate-sub>, and the inner
 subroutine that is returned uses it. By the time that the inner sub is called,
@@ -420,7 +420,7 @@ A less obvious but useful example for closures is using L<map|/type/List#routine
 to multiply a list of numbers:
 
     my $multiply-by = 5;
-    say join ', ', map { $_ * $multiply-by }, 1..5;     # 5, 10, 15, 20, 25
+    say join ', ', map { $_ * $multiply-by }, 1..5;     # OUTPUT: «5, 10, 15, 20, 25␤»
 
 Here the block passed to C<map> references the variable C<$multiply-by> from
 the outer scope, making the block a closure.
@@ -447,8 +447,8 @@ you can L<wrap|/type/Routine#method_wrap> them, and exit early with C<return>:
         False;
     }
 
-    say has-keyword 'not', 'one', 'here';       # False
-    say has-keyword 'but', 'here', 'for';       # True
+    say has-keyword 'not', 'one', 'here';       # OUTPUT: «False␤»
+    say has-keyword 'but', 'here', 'for';       # OUTPUT: «True␤»
 
 Here C<return> does not just leave the block inside which it was called, but
 the whole routine. In general, blocks are transparent to C<return>, they
@@ -473,13 +473,13 @@ pragma C<use soft;> to prevent inlining to allow wrapping at runtime.
     }
 
     my $testee-handler = wrap-to-debug(&testee);
-    # OUTPUT«wrapping testee with arguments :(Int $i, Str $s)»
+    # OUTPUT: «wrapping testee with arguments :(Int $i, Str $s)»
 
     say testee(10, "ten");
-    # OUTPUT«calling testee with \(10, "ten")␤returned from testee with return value "6.151190ten"␤6.151190ten»
+    # OUTPUT: «calling testee with \(10, "ten")␤returned from testee with return value "6.151190ten"␤6.151190ten»
     &testee.unwrap($testee-handler);
     say testee(10, "ten");
-    # OUTPUT«6.151190ten␤»
+    # OUTPUT: «6.151190ten␤»
 
 
 =comment Important ones: candidates, wrap, unwrap, assuming, arity, count
@@ -500,11 +500,11 @@ makes it available.
 =begin code
 # adding a multi candidate to an existing operator:
 multi infix:<+>(Int $x, "same") { 2 * $x };
-say 21 + "same";            # 42
+say 21 + "same";            # OUTPUT: «42␤»
 
 # defining a new operator
 sub postfix:<!>(Int $x where { $x >= 0 }) { [*] 1..$x };
-say 6!;                     # 720
+say 6!;                     # OUTPUT: «720␤»
 =end code
 
 The operator declaration becomes available as soon as possible, so you can
@@ -514,7 +514,7 @@ even recurse into a just-defined operator, if you really want to:
 sub postfix:<!>(Int $x where { $x >= 0 }) {
     $x == 0 ?? 1 !! $x * ($x - 1)!
 }
-say 6!;                     # 720
+say 6!;                     # OUTPUT: «720␤»
 =end code
 
 Circumfix and postcircumfix operators are made of two delimiters, one opening
@@ -525,7 +525,7 @@ sub circumfix:<START END>(*@elems) {
     "start", @elems, "end"
 }
 
-say START 'a', 'b', 'c' END;        # start a b c end
+say START 'a', 'b', 'c' END;        # OUTPUT: «start a b c end␤»
 =end code
 
 Postcircumfixes also receive the term after which they are parsed as
@@ -535,7 +535,7 @@ an argument:
 sub postcircumfix:<!! !!>($left, $inside) {
     "$left -> ( $inside )"
 }
-say 42!! 1 !!;      # 42 -> ( 1 )
+say 42!! 1 !!;      # OUTPUT: «42 -> ( 1 )␤»
 =end code
 
 Blocks can be assigned directly to operator names. Use a variable declarator and
@@ -543,7 +543,7 @@ prefix the operator name with a C<&>-sigil.
 
     my &infix:<ieq> = -> |l { [eq] l>>.fc };
     say "abc" ieq "Abc";
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head2 Precedence
 
@@ -561,7 +561,7 @@ sub infix:<!!>($a, $b) is tighter(&infix:<+>) {
     2 * ($a + $b)
 }
 
-say 1 + 2 * 3 !! 4;     # 21
+say 1 + 2 * 3 !! 4;     # OUTPUT: «21␤»
 =end code
 
 Here the C<1 + 2 * 3 !! 4> is parsed as C<1 + ((2 * 3) !! 4)>, because the
@@ -596,8 +596,8 @@ L<mathematically associative|https://en.wikipedia.org/wiki/Associative_property>
 But for other operators it matters a great deal. For example for the
 exponentiation/power operator, C<< infix:<**> >>:
 
-    say 2 ** (2 ** 3);      # 256
-    say (2 ** 2) ** 3;      # 64
+    say 2 ** (2 ** 3);      # OUTPUT: «256␤»
+    say (2 ** 2) ** 3;      # OUTPUT: «64␤»
 
 Perl 6 has the following possible associativity configurations:
 
@@ -622,7 +622,7 @@ sub infix:<§>(*@a) is assoc<list> {
     '(' ~ @a.join('|') ~ ')';
 }
 
-say 1 § 2 § 3;      # (1|2|3)
+say 1 § 2 § 3;      # OUTPUT: «(1|2|3)␤»
 =end code
 
 =head1 Traits
@@ -660,7 +660,7 @@ sub square($x) is doubles {
     $x * $x;
 }
 
-say square 3;       # 18
+say square 3;       # OUTPUT: «18␤»
 =end code
 
 See L<type Routine|/type/Routine> for the documentation of built-in routine
@@ -688,7 +688,7 @@ For example
         say "Back in Int with $res";
     }
 
-    a 1;        # Int 1\n Any 2\n Back in Int with 5
+    a 1;        # OUTPUT: «Int 1␤Any 2␤Back in Int with 5␤»
 
 Here C<a 1> calls the most specific C<Int> candidate first, and C<callwith>
 re-dispatches to the less specific C<Any> candidate.
@@ -706,7 +706,7 @@ received, so there is a special routine for that: C<callsame>.
         say "Back in Int with $res";
     }
 
-    a 1;        # Int 1\n Any 1\n Back in Int with 5
+    a 1;        # OUTPUT: «Int 1␤Any 1␤Back in Int with 5␤»
 
 Another common use case is to re-dispatch to the next routine in the chain,
 and not do anything else afterwards. That's why we have C<nextwith> and
@@ -727,7 +727,7 @@ multi a(Int $x) {
     say "back in a";    # never executed, because 'nextsame' doesn't return
 }
 
-a 1;        # Int 1\n Any 1
+a 1;        # OUTPUT: «Int 1␤Any 1␤»
 =end code
 
 As mentioned earlier, multi subs are not the only situation in which
@@ -746,8 +746,8 @@ sub square-root($x) { $x.sqrt }
    1i * callwith(abs($num));
 });
 
-say square-root(4);     # 2
-say square-root(-4);    # 0+2i
+say square-root(4);     # OUTPUT: «2␤»
+say square-root(-4);    # OUTPUT: «0+2i␤»
 =end code
 
 The final use case is to re-dispatch to methods from parent classes.
@@ -774,7 +774,7 @@ sub run-it-again-and-again($x) {
 }
 
 &power-it.wrap(&run-it-again-and-again);
-say power-it(5);    # 625
+say power-it(5);    # OUTPUT: «625␤»
 =end code
 
 X<|nextcallee>
@@ -801,7 +801,7 @@ sub double(Int(Cool) $x) {
     2 * $x
 }
 
-say double '21';    # 42
+say double '21';    # OUTPUT: «42␤»
 say double Any;     # Type check failed in binding $x; expected 'Cool' but got 'Any'
 =end code
 
@@ -830,8 +830,8 @@ class Bar {
 }
 
 sub print-bar(Bar() $bar) {
-   say $bar.WHAT; # (Bar)
-   say $bar.msg;  # I'm a foo! But I am now Bar.
+   say $bar.WHAT; # OUTPUT: «(Bar)␤»
+   say $bar.msg;  # OUTPUT: «I'm a foo! But I am now Bar.␤»
 }
 
 print-bar Foo.new;

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -85,18 +85,18 @@ The I<allomorph> types L<IntStr|/type/IntStr>, L<NumStr|/type/NumStr>,
 L<RatStr|/type/RatStr> and L<ComplexStr|/type/ComplexStr> may be created
 as a result of parsing a quoted string:
 
-    say <42>.WHAT;     # (IntStr)
-    say <42.1e0>.WHAT; # (NumStr)
-    say <42.1>.WHAT;   # (RatStr)
+    say <42>.WHAT;     # OUTPUT: «(IntStr)␤»
+    say <42.1e0>.WHAT; # OUTPUT: «(NumStr)␤»
+    say <42.1>.WHAT;   # OUTPUT: «(RatStr)␤»
 
 Note: if the number contains an operator (C</> or C<+>) and there are no other
 characters inside the angular brackets, you will receive a literal of that
 number:
 
-    say <42/1>.WHAT;   # (Rat)
-    say <42+0i>.WHAT;  # (Complex)
-    say < 42+0i >.WHAT;# (ComplexStr)
-    say < 42/1 >.WHAT; # (RatStr)
+    say <42/1>.WHAT;   # OUTPUT: «(Rat)␤»
+    say <42+0i>.WHAT;  # OUTPUT: «(Complex)␤»
+    say < 42+0i >.WHAT;# OUTPUT: «(ComplexStr)␤»
+    say < 42/1 >.WHAT; # OUTPUT: «(RatStr)␤»
 
 =head1 Anonymous
 X<|Anonymous>
@@ -116,8 +116,8 @@ that name:
     =begin code :skip-test
     # anonymous, but knows its own name
     my $s = anon sub triple($x) { 3 * $x }
-    say $s.name;        # triple
-    say triple(42);     # Undeclared routine: triple
+    say $s.name;        # OUTPUT: «triple␤»
+    say triple(42);     # OUTPUT: «Undeclared routine: triple␤»
     =end code
 
 =head1 API
@@ -163,7 +163,7 @@ value of the junction. The result of these calls is assembled in a new
 junction of the same type as the original junction.
 
     sub f($x) { 2 * $x };
-    say f(1|2|3) == 4;    # any(False, True, False)
+    say f(1|2|3) == 4;    # OUTPUT: «any(False, True, False)␤»
 
 Here C<f()> is a sub with one parameter, and since it has no explicit type,
 it is implicitly typed as C<Any>.  The C<Junction> argument causes the
@@ -564,11 +564,11 @@ Examples of lvalues:
 Examples of things that are not lvalues:
 
 =begin table
-    3                        # literals
-    constant x = 3;          # constants
-    has $.attrib;            # attributes; you can only assign to $!attrib
-    sub f { }; f();          # "normal" subs are not writable
-    sub f($x) { $x = 3 };    # error - parameters are read-only by default
+    3                        literals
+    constant x = 3;          constants
+    has $.attrib;            attributes; you can only assign to $!attrib
+    sub f { }; f();          "normal" subs are not writable
+    sub f($x) { $x = 3 };    error - parameters are read-only by default
 =end table
 
 These are typically called L<rvalues|#rvalue>.
@@ -580,9 +580,9 @@ The C<mainline> is the program text that is not part of any kind of block.
 
     use v6.c;     # mainline
     sub f {
-                # not in mainline, in sub f
+                  # not in mainline, in sub f
     }
-    f();        # in mainline again
+    f();          # in mainline again
 
 You can also have the mainline of any package-like declarator, such as
 class, L<module|/language/modules>, L<grammar|/language/grammars>, etc.  These are

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -183,10 +183,10 @@ that has all 3 parameters included:
     my $match = REST.parse('/product/update/7/notify');
     say $match;
 
-    # ｢/product/update/7/notify｣
-    #  subject => ｢product｣
-    #  command => ｢update｣
-    #  data => ｢7/notify｣
+    # OUTPUT: «｢/product/update/7/notify｣␤
+    #          subject => ｢product｣
+    #          command => ｢update｣
+    #          data => ｢7/notify｣»
     =end code
 
 Of course, the data can be accessed directly by using $match<subject> or
@@ -216,7 +216,7 @@ have:
     my $m = REST.parse('/product/create');
     say $m<subject>, $m<command>;
 
-    # ｢product｣｢create｣
+    # OUTPUT: «｢product｣｢create｣␤»
     =end code
 
 Let's imagine, for the sake of demonstration, that we might want to allow these
@@ -238,13 +238,13 @@ another token that allowed for spaces on either side of it.
     my $m = REST.parse('/ product / update /7 /notify');
     say $m;
 
-    # ｢/ product / update /7 /notify｣
-    #  slash => ｢/ ｣
-    #  subject => ｢product｣
-    #  slash => ｢ / ｣
-    #  command => ｢update｣
-    #  slash => ｢ /｣
-    #  data => ｢7 /notify｣
+    # OUTPUT: «｢/ product / update /7 /notify｣␤
+    #          slash => ｢/ ｣
+    #          subject => ｢product｣
+    #          slash => ｢ / ｣
+    #          command => ｢update｣
+    #          slash => ｢ /｣
+    #          data => ｢7 /notify｣»
     =end code
 
 We're getting some extra junk in our match object now, with those slashes, but
@@ -342,9 +342,9 @@ Let's look at various URIs and how they behave being passed through our grammar.
         say "Sub: $m<subject> Cmd: $m<command> Dat: $m<data>";
     }
 
-    # Sub: product Cmd: update Dat: 7/notify
-    # Sub: product Cmd: create Dat:
-    # Sub: item Cmd: delete Dat: 4
+    # OUTPUT: «Sub: product Cmd: update Dat: 7/notify␤
+    #          Sub: product Cmd: create Dat:
+    #          Sub: item Cmd: delete Dat: 4»
     =end code
 
 So with just this part of a grammar, we're getting almost everything we need.
@@ -486,8 +486,8 @@ first element of the list returned from the "data" action we "made" with "make":
 
     my $match = REST.parse($uri, actions => REST-actions.new);
 
-    say $match<data>.made[0];  # 7
-    say $match<command>.Str;   # update
+    say $match<data>.made[0];  # OUTPUT: «7␤»
+    say $match<command>.Str;   # OUTPUT: «update␤»
     =end code
 
 Here, we call "made" on our data, because we want the result of our action that
@@ -540,9 +540,9 @@ result object. From our earlier example, it now becomes
     my $match = REST.parse($uri, actions => REST-actions.new);
 
     my $rest = $match.made;
-    say $rest<data>[0];   # 7
-    say $rest<command>;   # update
-    say $rest<subject>;   # product
+    say $rest<data>[0];   # OUTPUT: «7␤»
+    say $rest<command>;   # OUTPUT: «update␤»
+    say $rest<subject>;   # OUTPUT: «product␤»
     =end code
 
 Of course you could also shorten it if you knew you wouldn't need the full
@@ -554,9 +554,9 @@ action's TOP.
 
     my $rest = REST.parse($uri, actions => REST-actions.new).made;
 
-    say $rest<data>[0];   # 7
-    say $rest<command>;   # update
-    say $rest<subject>;   # product
+    say $rest<data>[0];   # OUTPUT: «7␤»
+    say $rest<command>;   # OUTPUT: «update␤»
+    say $rest<subject>;   # OUTPUT: «product␤»
     =end code
 
 Oh, did we forget to get rid of that ugly array element number? Hmm. Let's make
@@ -584,9 +584,9 @@ Now we can do this instead
 
     my $rest = REST.parse($uri, actions => REST-actions.new).made;
 
-    say $rest<command>;    # update
-    say $rest<subject>;    # product
-    say $rest<subject-id>; # 7
+    say $rest<command>;    # OUTPUT: «update␤»
+    say $rest<subject>;    # OUTPUT: «product␤»
+    say $rest<subject-id>; # OUTPUT: «7␤»
     =end code
 
 And this is the grammar and grammar actions that got us there, to recap:

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -37,8 +37,8 @@ Being named gives us the advantage of being able to easily reuse the regex
 elsewhere:
 
     =begin code :allow<B> :skip-test
-    say so "32.51" ~~ B<&number>;                                    # True
-    say so "15 + 4.5" ~~ /B<< <number> >>\s* '+' \s*B<< <number> >>/ # True
+    say so "32.51" ~~ B<&number>;                                    # OUTPUT: «True␤»
+    say so "15 + 4.5" ~~ /B<< <number> >>\s* '+' \s*B<< <number> >>/ # OUTPUT: «True␤»
     =end code
 
 B<C<regex>> isn't the only declarator for named regexes – in fact, it's the
@@ -51,8 +51,8 @@ usually do what you want, but isn't appropriate for all cases:
     my regex works-but-slow { .+ q }
     my token fails-but-fast { .+ q }
     my $s = 'Tokens won\'t backtrack, which makes them fail quicker!';
-    say so $s ~~ &works-but-slow; # True
-    say so $s ~~ &fails-but-fast; # False, the entire string get taken by the .+
+    say so $s ~~ &works-but-slow; # OUTPUT: «True␤»
+    say so $s ~~ &fails-but-fast; # OUTPUT: «False␤», the entire string get taken by the .+
     =end code
 
 The only difference between the C<token> and C<rule> declarators is that the
@@ -62,8 +62,8 @@ into effect for the Regex:
     =begin code :allow<B>
     my token non-space-y { 'once' 'upon' 'a' 'time' }
     my rule space-y { 'once' 'upon' 'a' 'time' }
-    say so 'onceuponatime'    ~~ &non-space-y; # True
-    say so 'once upon a time' ~~ &space-y;     # True
+    say so 'onceuponatime'    ~~ &non-space-y; # OUTPUT: «True␤»
+    say so 'once upon a time' ~~ &space-y;     # OUTPUT: «True␤»
     =end code
 
 =head1 X<Creating Grammars|class,Grammar;declarator,grammar>
@@ -101,8 +101,7 @@ operations we we add:
 
     say Calculator.parse('2 + 3', actions => Calculations).made;
 
-    # OUTPUT:
-    # 5
+    # OUTPUT: «5␤»
 
 To make things better, we can use protoregexes that look like `C<< :sym<...> >>
 adverbs on tokens:
@@ -125,8 +124,7 @@ adverbs on tokens:
 
     say Calculator.parse('2 + 3', actions => Calculations).made;
 
-    # OUTPUT:
-    # 5
+    # OUTPUT: «5␤»
 
 In the grammar, the alternation has now been replaced with C<< <calc-op> >>,
 which is essentially the name of a group of values we'll create. We do so by
@@ -154,8 +152,7 @@ calculator:
 
     say BetterCalculator.parse('2 * 3', actions => BetterCalculations).made;
 
-    # OUTPUT:
-    # 6
+    # OUTPUT: «6␤»
     =end code
 
 All we had to add are additional rule and action to the C<calc-op> group and
@@ -238,8 +235,7 @@ the number for the currently parsed C<digit> digits.
     }
 
     say Digifier.parse('255 435 777', actions => Devanagari.new).made;
-    # OUTPUT:
-    # (२५५ ४३५ ७७७)
+    # OUTPUT: «(२५५ ४३५ ७७७)␤»
 
 =head2 Methods in Grammar
 
@@ -259,12 +255,10 @@ provided by parse methods:
 
     =begin code :skip-test
     say +DigitMatcher.subparse: '12७१७९०९', args => \(:full-unicode);
-    # OUTPUT:
-    # 12717909
+    # OUTPUT: «12717909␤»
 
     say +DigitMatcher.subparse: '12७१७९०९', args => \(:!full-unicode);
-    # OUTPUT:
-    # 12
+    # OUTPUT: «12␤»
     =end code
 
 =head1 Action Objects
@@ -298,8 +292,8 @@ class TestActions {
 
 my $actions = TestActions.new;
 my $match = TestGrammar.parse('40', :$actions);
-say $match;         # ｢40｣
-say $match.made;    # 42
+say $match;         # OUTPUT: «｢40｣␤»
+say $match.made;    # OUTPUT: «42␤»
 =end code
 
 An instance of C<TestActions> is passed as named argument C<actions> to the

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -138,34 +138,34 @@ directory C<lib> exist, we would obtain from the existence test method C<e>
 the same result, namely that both exist:
 
 =for code :skip-test
-say "testfile".IO.e;  # True
-say "lib".IO.e;       # True
+say "testfile".IO.e;  # OUTPUT: «True␤»
+say "lib".IO.e;       # OUTPUT: «True␤»
 
 However, since only one of them is a directory, the directory test method
 C<d> will give a different result:
 
 =for code :skip-test
-say "testfile".IO.d;  # False
-say "lib".IO.d;       # True
+say "testfile".IO.d;  # OUTPUT: «False␤»
+say "lib".IO.d;       # OUTPUT: «True␤»
 
 Naturally the tables are turned if we check to see if the path is a file via
 the file test method C<f>:
 
 =for code :skip-test
-say "testfile".IO.f;  # True
-say "lib".IO.f;       # False
+say "testfile".IO.f;  # OUTPUT: «True␤»
+say "lib".IO.f;       # OUTPUT: «False␤»
 
 =head1 Getting a directory listing
 
 To list the contents of the current directory, use the C<dir> function. It
 returns a list of L<IO::Path> objects.
 
-    say dir;    # "/path/to/testfile".IO "/path/to/lib".IO
+    say dir;          # OUTPUT: «"/path/to/testfile".IO "/path/to/lib".IO␤»
 
 To list the files and directories in a given directory, simply pass a path
 as an argument to C<dir>:
 
-    say dir "/etc/";    # "/etc/ld.so.conf".IO "/etc/shadow".IO ....
+    say dir "/etc/";  # OUTPUT: «"/etc/ld.so.conf".IO "/etc/shadow".IO ....␤»
 
 =head1 Creating and removing directories
 

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -60,8 +60,9 @@ One of the ways C<@>-sigiled variables act like lists is by always supporting
 L<positional subscripting|/language/subscripts>. Anything bound to a C<@>-sigiled
 value must support the L<Positional|/type/Positional> role which guarantees this:
 
+    =begin code :skip-test
     my @a := 1; # Type check failed in binding; expected Positional but got Int
-
+    =end code
 
 =head1 Reset a List Container
 
@@ -109,7 +110,9 @@ Although the C<Seq> class does provide some positional subscripting, it does
 not provide the full interface of C<Positional>, so an C<@>-sigiled variable
 may B<not> be bound to a C<Seq>.
 
+    =begin code :skip-test
     my @s := (loop { 42.say }); # Error expected Positional but got Seq
+    =end code
 
 This is because the C<Seq> does not keep values around after you have used them.
 This is useful behavior if you have a very long sequence, as you may want to
@@ -179,9 +182,11 @@ The lists we have talked about so far (C<List>, C<Seq> and C<Slip>)
 are all immutable.  This means you cannot remove elements from them,
 or re-bind existing elements:
 
+    =begin code :skip-test
     (1, 2, 3)[0]:delete; # Error Can not remove elements from a List
     (1, 2, 3)[0] := 0;   # Error Cannot use bind operator with this left-hand side
     (1, 2, 3)[0] = 0;    # Error Cannot modify an immutable Int
+    =end code
 
 However, if any of the elements is wrapped in a L<C<Scalar>|/type/Scalar> you
 can still change the value which that C<Scalar> points to:
@@ -281,7 +286,9 @@ of pair forms happens.
 Most C<Positional> types will enforce an integer coercion on each element
 of a slice index, so pairs appearing there will generate an error, anyway:
 
-    (1, 2, 3)[1, 2, :c(3)] # Method 'Int' not found for invocant of class 'Pair'
+    =begin code :skip-test
+    (1, 2, 3)[1, 2, :c(3)] # OUTPUT: «Method 'Int' not found for invocant of class 'Pair'␤»
+    =end code
 
 ...however this is entirely up to the type – if it defines an order
 for pairs, it could consider C<:c(3)> a valid index.
@@ -339,6 +346,7 @@ is of type C<Array[Int]> and one can create one with C<Array[Int].new>.  If
 you intend to use an C<@>-sigiled variable only for this purpose, you may
 change its type by specifying the type of the elements when declaring it:
 
+    =begin code :skip-test
     my Int @a = 1, 2, 3;              # An Array that contains only Ints
     my @b := Array[Int].new(1, 2, 3); # Same thing, but the variable is not typed
     say @b eqv @a;                    # says True.
@@ -350,15 +358,18 @@ change its type by specifying the type of the elements when declaring it:
 
     @a[0] = 42;                       # fine
     @a[0] = "foo";                    # error: Type check failed in assignment
+    =end code
 
 In the above example we bound a typed Array object to a C<@>-sigil variable for
 which no type had been specified.  The other way around does not work – you may
 not bind an Array that has the wrong type to a typed C<@>-sigiled variable:
 
+    =begin code :skip-test
     my @a := Array[Int].new(1, 2, 3);     # fine
     @a := Array[Str].new("a", "b");       # fine, can be re-bound
     my Int @b := Array[Int].new(1, 2, 3); # fine
     @b := Array.new(1, 2, 3);             # error: Type check failed in binding
+    =end code
 
 When working with typed arrays, it is important to remember that they are
 nominally typed. This means the declared type of an array is what matters.

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -29,9 +29,9 @@ Multidimensional literal C<List>s are created combining comma and semicolon.
 They can be used in routine argument lists and subscripts.
 
     say so (1,2; 3,4) eqv ((1,2), (3,4));
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
     say('foo';); # a list with one element and the empty list
-    # OUTPUT«(foo)()␤»
+    # OUTPUT: «(foo)()␤»
 
 Individual elements can be pulled out of a list using a subscript.  The
 first element of a list is at index number zero:
@@ -79,7 +79,7 @@ list to the container.
 All lists may be iterated, which means taking each element from the
 list in order and stopping after the last element:
 
-    for 1, 2, 3 { .say } # says 1, then says 2, then says 3
+    for 1, 2, 3 { .say }  # OUTPUT: «1␤2␤3␤»
 
 =head1 Testing for Elements
 
@@ -87,8 +87,8 @@ To test for elements convert the C<List> or C<Array> to a L<C<Set>|/type/Set>
 or use a Set L<operator|/language/setbagmix>.
 
     my @a = <foo bar buzz>;
-    say @a.Set<bar buzz>; # (True True)
-    say so 'bar' ∈ @a;    # True
+    say @a.Set<bar buzz>; # OUTPUT: «(True True)␤»
+    say so 'bar' ∈ @a;    # OUTPUT: «True␤»
 
 =head2 Sequences
 
@@ -96,7 +96,7 @@ Not all lists are born full of elements.  Some only create as many elements
 as they are asked for.  These are called sequences, which are of type C<Seq>.
 As it so happens, loops return C<Seq>s.
 
-    (loop { 42.say })[2] # says 42 three times
+    (loop { 42.say })[2]  # OUTPUT: «42␤42␤42␤»
 
 So, it is fine to have infinite lists in Perl 6, just so long as you never
 ask them for all their elements.  In some cases, you may want to avoid
@@ -132,9 +132,9 @@ Since this C<List> fully supports C<Positional>, you may bind it directly
 to an C<@>-sigiled variable.
 
     my @s := (loop { 42.say }).list;
-    @s[2]; # Says 42 three times
+    @s[2]; # says 42 three times
     @s[1]; # does not say anything
-    @s[4]; # Says 42 two more times
+    @s[4]; # says 42 two more times
 
 You may also use the C<.cache> method instead of C<.list>, depending
 on how you want the references handled.  See the L<page on C<Seq>|/type/Seq>
@@ -147,17 +147,17 @@ for details.
 Sometimes you want to insert the elements of a list into another list.
 This can be done with a special type of list called a L<Slip|/type/Slip>.
 
-    say (1, (2, 3), 4) eqv (1, 2, 3, 4);         # says False
-    say (1, Slip.new(2, 3), 4) eqv (1, 2, 3, 4); # says True
-    say (1, slip(2, 3), 4) eqv (1, 2, 3, 4);     # also says True
+    say (1, (2, 3), 4) eqv (1, 2, 3, 4);         # OUTPUT: «False␤»
+    say (1, Slip.new(2, 3), 4) eqv (1, 2, 3, 4); # OUTPUT: «True␤»
+    say (1, slip(2, 3), 4) eqv (1, 2, 3, 4);     # OUTPUT: «True␤»
 
 Another way to make a C<Slip> is with the C<|> prefix operator.  Note that
 this has a tighter precedence than the comma, so it only affects a single
 value, but unlike the above options, it will break L<Scalars|/type/Scalar>.
 
-    say (1, |(2, 3), 4) eqv (1, 2, 3, 4);        # says True
-    say (1, |$(2, 3), 4) eqv (1, 2, 3, 4);       # also says True
-    say (1, slip($(2, 3)), 4) eqv (1, 2, 3, 4);  # says False
+    say (1, |(2, 3), 4) eqv (1, 2, 3, 4);        # OUTPUT: «True␤»
+    say (1, |$(2, 3), 4) eqv (1, 2, 3, 4);       # OUTPUT: «True␤»
+    say (1, slip($(2, 3)), 4) eqv (1, 2, 3, 4);  # OUTPUT: «False␤»
 
 =head1 Lazy Lists
 
@@ -171,7 +171,7 @@ entire list to be computed what will fail if the list is also infinite.
 
     my @l = 1,2,4,8...Inf;
     say @l[0..16];
-    # OUTPUT«(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)␤»
+    # OUTPUT: «(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)␤»
 
 =head1 Immutability
 
@@ -188,7 +188,7 @@ can still change the value which that C<Scalar> points to:
 
     my $a = 2;
     (1, $a, 3)[1] = 42;
-    $a.say;            # says 42
+    $a.say;            # OUTPUT: «42␤»
 
 ...that is, it is only the list structure itself – how many elements there are
 and each element's identity – that is immutable.  The immutability is not
@@ -207,7 +207,7 @@ until it can produce no more elements.  This is one of the places you do not wan
 to put an infinite list, lest your program hang and, eventually, run out of memory:
 
     my $i = 3;
-    my @a = (loop { $i.say; last unless --$i }); # Says 3 2 1
+    my @a = (loop { $i.say; last unless --$i }); # OUTPUT: «3␤2␤1␤»
     say "take off!";
 
 =head2 Flattening "Context"
@@ -216,7 +216,7 @@ When you have a list that contains sub-lists, but you only want one flat list,
 you may flatten the list to produce a sequence of values as if all parentheses
 were removed. This works no matter how many levels deep the parentheses are nested.
 
-    say (1, (2, (3, 4)), 5).flat eqv (1, 2, 3, 4, 5) # says True
+    say (1, (2, (3, 4)), 5).flat eqv (1, 2, 3, 4, 5) # OUTPUT: «True␤»
 
 This is not really a syntactical "context" as much as it is a process of
 iteration, but it has the appearance of a context.
@@ -224,14 +224,14 @@ iteration, but it has the appearance of a context.
 Note that L<C<Scalar>s|/type/Scalar> around a list will make it immune to
 flattening:
 
-    for (1, (2, $(3, 4)), 5).flat { .say } # says 1, then 2, then (3 4), then 5
+    for (1, (2, $(3, 4)), 5).flat { .say } # OUTPUT: «1␤2␤(3 4)␤5␤»
 
 ...but an C<@>-sigiled variable will spill its elements.
 
     my @l := 2, (3, 4);
-    for (1, @l, 5).flat { .say };      # says 1, then 2, then 3, then 4, then 5
+    for (1, @l, 5).flat { .say };      # OUTPUT: «1␤2␤3␤4␤5␤»
     my @a = 2, (3, 4);                 # Arrays are special, see below
-    for (1, @a, 5).flat { .say };      # says 1, then 2, then (3 4), then 5
+    for (1, @a, 5).flat { .say };      # OUTPUT: «1␤2␤(3 4)␤5␤»
 
 =head2 Argument List (Capture) Context
 
@@ -291,7 +291,7 @@ neither are sublists usually coerced to C<Int>.  Instead, the list structure
 is kept intact, causing a nested slice operation that replicates the
 structure in the result:
 
-    say ("a", "b", "c")[(1, 2), (0, 1)] eqv (("b", "c"), ("a", "b")) # says True
+    say ("a", "b", "c")[(1, 2), (0, 1)] eqv (("b", "c"), ("a", "b")) # OUTPUT: «True␤»
 
 =head2 Range as Slice
 
@@ -301,11 +301,11 @@ including the bounds. For infinite upper boundaries we agree with
 mathematicians that C<Inf> equals C<Inf-1>.
 
     my @a = 1..5;
-    say @a[0..2];     # (1 2 3)
-    say @a[0..^2];    # (1 2)
-    say @a[0..*];     # (1 2 3 4 5)
-    say @a[0..^*];    # (1 2 3 4 5)
-    say @a[0..Inf-1]; # (1 2 3 4 5)
+    say @a[0..2];     # OUTPUT: «(1 2 3)␤»
+    say @a[0..^2];    # OUTPUT: «(1 2)␤»
+    say @a[0..*];     # OUTPUT: «(1 2 3 4 5)␤»
+    say @a[0..^*];    # OUTPUT: «(1 2 3 4 5)␤»
+    say @a[0..Inf-1]; # OUTPUT: «(1 2 3 4 5)␤»
 
 =head2 Array Constructor Context
 
@@ -313,10 +313,9 @@ Inside an Array Literal, the list of initialization values is not in capture
 context and is just a normal list.  It is, however, eagerly evaluated just as
 in assignment.
 
-    [ 1, 2, :c(3) ] eqv Array.new((1, 2, :c(3))); # says True
-    [while $++ < 2 { 42.say; 43 }].map: *.say;    # says 42 twice then 43 twice
-    (while $++ < 2 { 42.say; 43 }).map: *.say;    # says "42" then "43"
-                                                  # then "42" then "43"
+    [ 1, 2, :c(3) ] eqv Array.new((1, 2, :c(3))); # OUTPUT: «True␤»
+    [while $++ < 2 { 42.say; 43 }].map: *.say;    # OUTPUT: «42␤42␤43␤43␤»
+    (while $++ < 2 { 42.say; 43 }).map: *.say;    # OUTPUT: «42␤43␤42␤43␤»
 
 Which brings us to Arrays...
 
@@ -326,7 +325,7 @@ Arrays differ from lists in three major ways: Their elements may be typed,
 they automatically itemize their elements, and they are mutable.  Otherwise
 they are Lists and are accepted wherever lists are.
 
-    say Array ~~ List     # says True
+    say Array ~~ List     # OUTPUT: «True␤»
 
 A fourth, more subtle, way they differ is that when working with Arrays, it
 can sometimes be harder to maintain laziness or work with infinite sequences.
@@ -409,13 +408,13 @@ basis with the C<is default> trait.  Note that an untyped C<@>-sigiled variable 
 an element type of C<Mu>, however its default value is an undefined C<Any>:
 
     my @a;
-    @a.of.perl.say;                 # says "Mu"
-    @a.default.perl.say;            # says "Any"
-    @a[0].say;                      # says "(Any)"
+    @a.of.perl.say;                 # OUTPUT: «Mu␤»
+    @a.default.perl.say;            # OUTPUT: «Any␤»
+    @a[0].say;                      # OUTPUT: «(Any)␤»
     my Numeric @n is default(Real);
-    @n.of.perl.say;                 # says "Numeric"
-    @n.default.perl.say;            # says "Real"
-    @n[0].say;                      # says "(Real)"
+    @n.of.perl.say;                 # OUTPUT: «Numeric␤»
+    @n.default.perl.say;            # OUTPUT: «Real␤»
+    @n[0].say;                      # OUTPUT: «(Real)␤»
 
 =head2 Fixed Size Arrays
 
@@ -426,9 +425,9 @@ the C<shape> method.
 
     my @a[2,2];
     dd @a;
-    # OUTPUT«Array.new(:shape(2, 2), [Any, Any], [Any, Any])␤»
+    # OUTPUT: «Array.new(:shape(2, 2), [Any, Any], [Any, Any])␤»
     say @a.shape;
-    # OUTPUT«(2 2)␤»
+    # OUTPUT: «(2 2)␤»
 
 Assignment to a fixed size Array will promote a List of Lists to an Array of
 Arrays.
@@ -436,7 +435,7 @@ Arrays.
     my @a[2;2] = (1,2; 3,4);
     @a[1;1] = 42;
     dd @a;
-    # OUTPUT«Array.new(:shape(2, 2), [1, 2], [3, 42])␤»
+    # OUTPUT: «Array.new(:shape(2, 2), [1, 2], [3, 42])␤»
 
 =head2 Itemization
 
@@ -465,14 +464,14 @@ Second, remember that these invisible dollar signs also protect against
 flattening, so you cannot really flatten the elements inside of an Array
 with a normal call to C<flat> or C<.flat>.
 
-    ((1, 2), $(3, 4)).flat.perl.say; # (1, 2, $(3, 4)).Seq
-    [(1, 2), $(3, 4)].flat.perl.say; # ($(1, 2), $(3, 4)).Seq
+    ((1, 2), $(3, 4)).flat.perl.say; # OUTPUT: «(1, 2, $(3, 4)).Seq␤»
+    [(1, 2), $(3, 4)].flat.perl.say; # OUTPUT: «($(1, 2), $(3, 4)).Seq␤»
 
 Since the square brackets do not themselves protect against flattening,
 you can still spill the elements out of an Array into a surrounding list
 using C<flat>.
 
-    (0, [(1, 2), $(3, 4)], 5).flat.perl.say; # (0, $(1, 2), $(3, 4), 5).Seq
+    (0, [(1, 2), $(3, 4)], 5).flat.perl.say; # OUTPUT: «(0, $(1, 2), $(3, 4), 5).Seq␤»
 
 ...the elements themselves, however, stay in one piece.
 
@@ -480,7 +479,7 @@ This can irk users of data you provide if you have deeply nested Arrays
 where they want flat data.  Currently they have to deeply map the structure
 by hand to undo the nesting:
 
-    say gather [0, [(1, 2), [3, 4]], $(5, 6)].deepmap: *.take; # (1 2 3 4 5 6)
+    say gather [0, [(1, 2), [3, 4]], $(5, 6)].deepmap: *.take; # OUTPUT: «(1 2 3 4 5 6)␤»
 
 ...future versions of Perl 6 might find a way to make this easier.  However,
 not returning Arrays or itemized lists from functions, when non-itemized lists
@@ -511,13 +510,13 @@ spill due to the itemization.
 Unlike lists, Arrays are mutable.  Elements may deleted, added, or changed.
 
     my @a = "a", "b", "c";
-    @a.say;                  # [a b c]
-    @a.pop.say;              # says "c"
-    @a.say;                  # says "[a b]"
+    @a.say;                  # OUTPUT: «[a b c]␤»
+    @a.pop.say;              # OUTPUT: «c␤»
+    @a.say;                  # OUTPUT: «[a b]␤»
     @a.push("d");
-    @a.say;                  # says "[a b d]"
+    @a.say;                  # OUTPUT: «[a b d]␤»
     @a[1, 3] = "c", "c";
-    @a.say;                  # says "[a c d c]"
+    @a.say;                  # OUTPUT: «[a c d c]␤»
 
 
 =head3 Assigning
@@ -529,7 +528,7 @@ which may be finite:
 
     my @a;
     @a[0, 1, 2] = (loop { 42 });
-    @a.say;                     # says "[42 42 42]"
+    @a.say;                     # OUTPUT: «[42 42 42]␤»
 
 During assignment, each value will be typechecked to ensure it is a permitted
 type for the C<Array>.  Any C<Scalar> will be stripped from each value and a
@@ -542,9 +541,9 @@ Individual Array slots may be bound the same way C<$>-sigiled variables are:
     my $b = "foo";
     my @a = 1, 2, 3;
     @a[2] := $b;
-    @a.say;          # says '[1 2 "foo"]'
+    @a.say;          # OUTPUT: «[1 2 "foo"]␤»
     $b = "bar";
-    @a.say;          # says '[1 2 "bar"]'
+    @a.say;          # OUTPUT: «[1 2 "bar"]␤»
 
 ...but binding Array slots directly to values is strongly discouraged.  If you do,
 expect surprises with built-in functions.  The only time this would be done is if

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -255,8 +255,8 @@ dynamically. For example:
     =begin code
     # main.pl
     use MyModule;
-    say sqrt-of-four; # -> 2
-    say log-of-zero;  # -> -Inf
+    say sqrt-of-four; # OUTPUT: «2␤»
+    say log-of-zero;  # OUTPUT: «-Inf␤»
     =end code
 
 =head3 EXPORT
@@ -291,7 +291,7 @@ the values are the desired values. The names should include the sigil
     say @array;
     say %hash;
     doit();
-    say ShortName.new; # -> MyModule::Class.new
+    say ShortName.new; # OUTPUT: «MyModule::Class.new␤»
     =end code
 
 Note, C<EXPORT> can't be declared inside a package because
@@ -347,7 +347,7 @@ L<Cool>s.
 
     =begin code
     use MakeQuestionable Cool;
-    say 0?, 1?, {}?, { a => "b" }?; # False True False True
+    say 0?, 1?, {}?, { a => "b" }?; # OUTPUT: «False True False True␤»
     =end code
 
 =head2 Introspection
@@ -357,12 +357,12 @@ the module.
 
     use URI::Escape;
     dd URI::Escape::EXPORT::.keys;
-    # OUTPUT«("DEFAULT", "ALL").Seq»
+    # OUTPUT: «("DEFAULT", "ALL").Seq»
 
 Then use the tag you like and pick the symbol by its name.
 
     dd URI::Escape::EXPORT::DEFAULT::.keys;
-    # OUTPUT«("\&uri-escape", "\&uri_escape", "\&uri-unescape", "\&uri_unescape").Seq»
+    # OUTPUT: «("\&uri-escape", "\&uri_escape", "\&uri-unescape", "\&uri_unescape").Seq»
     my &escape-uri = URI::Escape::EXPORT::DEFAULT::<&uri_escape>;
 
 =head2 Finding Modules

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -97,10 +97,10 @@ Returns the underlying C<Scalar> object, if there is one.
 
 The presence of a C<Scalar> object indicates that the object is "itemized".
 
-    .say for (1, 2, 3);  # not itemized, so "1\n2\n3\n"
-    .say for $(1, 2, 3); # itemized, so "(1 2 3)\n"
-    say (1, 2, 3).VAR ~~ Scalar;  # False
-    say $(1, 2, 3).VAR ~~ Scalar; # True
+    .say for (1, 2, 3);           # OUTPUT: «1␤2␤3␤», not itemized
+    .say for $(1, 2, 3);          # OUTPUT: «(1 2 3)␤», itemized
+    say (1, 2, 3).VAR ~~ Scalar;  # OUTPUT: «False␤»
+    say $(1, 2, 3).VAR ~~ Scalar; # OUTPUT: «True␤»
 
 =head1 Structure of the meta object system
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -24,7 +24,7 @@ To call a method on an object, add a dot, followed by the method name:
 
 =for code :allow<B L>
 L<say> "abc"B<.L<uc>>;
-# ABC
+# OUTPUT: «ABC␤»
 
 This calls the L<C<uc>|uc> method on C<"abc">, which is an object of type
 L<C<Str>|Str>. To supply arguments to the method, add arguments inside parentheses
@@ -45,15 +45,15 @@ Multiple arguments can be specified by separating the argument list with a colon
 
 =for code :allow<B L> :skip-test
 say @words.L<join>: '--';
-# Abe--Lincoln--said--Fourscore--and--seven--years--ago
+# OUTPUT: «Abe--Lincoln--said--Fourscore--and--seven--years--ago␤»
 
 Since you have to put a C<:> after the method if you want to pass arguments
 without parentheses, a method call without a colon or parentheses is
 unambiguously a method call without an argument list:
 
-    say 4.log:   ; # 1.38629436111989 ( natural logarithm of 4 )
-    say 4.log: +2; # 2                ( base-2 logarithm of 4 )
-    say 4.log  +2; # 3.38629436111989 ( natural logarithm of 4, plus 2 )
+    say 4.log:   ; # OUTPUT: «1.38629436111989␤» ( natural logarithm of 4 )
+    say 4.log: +2; # OUTPUT: «2␤» ( base-2 logarithm of 4 )
+    say 4.log  +2; # OUTPUT: «3.38629436111989␤» ( natural logarithm of 4, plus 2 )
 
 Many operations that don't look like method calls (for example, smart
 matching, or interpolating an object into a string) result in method calls
@@ -261,7 +261,7 @@ Method names can be resolved at runtime with the C<.""> operator.
     class A { has $.b };
     my $name = 'b';
     A.new."$name"().say;
-    # OUTPUT«(Any)␤»
+    # OUTPUT: «(Any)␤»
 
 =head2 self
 
@@ -285,7 +285,7 @@ attributes in initializers.
         has $.x = self.local
     };
     say C.new.x
-    # OUTPUT«42␤»
+    # OUTPUT: «42␤»
 
 =head2 Private Methods
 
@@ -619,7 +619,7 @@ objects and roles are meant for managing behavior and code reuse.
     my $p = Point.new(:x(1), :y(2));
     my $serialized = $p.serialize;      # method provided by the role
     my $clone-of-p = Point.deserialize($serialized);
-    say $clone-of-p.x;      # 1
+    say $clone-of-p.x;      # OUTPUT: «1␤»
     =end code
 
 Roles are immutable as soon as the compiler parses the closing curly brace of
@@ -658,7 +658,7 @@ C<Automobile>, for things that you can drive.
     class Taurus is Bull is Automobile { }
 
     my $t = Taurus.new;
-    $t.steer; # Castrates $t
+    $t.steer; # OUTPUT: «Castrates $t␤»
 
 With this setup, your poor customers will find themselves unable to turn
 their Taurus and you won't be able to make more of your product!  In this
@@ -761,7 +761,7 @@ that role to inherit from another class.  So if you write:
     =begin code
     role A is Exception { }
     class X::Ouch does A { }
-    X::Ouch.^parents.say # ((Exception))
+    X::Ouch.^parents.say # OUTPUT: «((Exception))␤»
     =end code
 
 ...then C<X::Ouch> will inherit directly from Exception, as we can see above
@@ -834,8 +834,8 @@ role BinaryTree[::Type] {
 }
 
 my $t = BinaryTree[Int].new-from-list(4, 5, 6);
-$t.visit-preorder(&say);    # 5 \n 4 \n 6
-$t.visit-postorder(&say);   # 4 \n 6 \n 5
+$t.visit-preorder(&say);    # OUTPUT: «5␤4␤6␤»
+$t.visit-postorder(&say);   # OUTPUT: «4␤6␤5␤»
 =end code
 
 Here the signature consists only of a type capture, but any signature will do:
@@ -851,7 +851,7 @@ role Logging[$filehandle = $*ERR] {
     }
 }
 
-Logging[$*OUT].log(debug, 'here we go');        # [DEBUG] here we go
+Logging[$*OUT].log(debug, 'here we go');        # OUTPUT: «[DEBUG] here we go␤»
 =end code
 
 You can have multiple roles of the same name, but with different signatures;
@@ -866,7 +866,7 @@ anonymous roles are supported.
     role R { method Str() {'hidden!'} };
     my $i = 2 but R;
     sub f(\bound){ put bound };
-    f($i); # hidden!
+    f($i); # OUTPUT: «hidden!␤»
 
 Note that the object got the role mixed in, not the object's class or the
 container. Thus, @-sigiled containers will require binding to make the role
@@ -887,18 +887,18 @@ Mixins can be used at any point in your object's life.
     }
 
     my Num $toc-counter = NaN;     # don't do maths with Not A Number
-    say $toc-counter; # NaN
+    say $toc-counter;              # OUTPUT: «NaN␤»
     $toc-counter does TOC-Counter; # now we mix the role in
     $toc-counter.inc(1).inc(2).inc(2).inc(1).inc(2).inc(2).inc(3).inc(3);
-    put $toc-counter / 1;          # NaN (because that's numerical context)
-    put $toc-counter;              # 2.2.2 (put will call TOC-Counter::Str)
+    put $toc-counter / 1;          # OUTPUT: «NaN␤» (because that's numerical context)
+    put $toc-counter;              # OUTPUT: «2.2.2␤» (put will call TOC-Counter::Str)
 
 Roles can be anonymous.
 
     my %seen of Int is default(0 but role :: { method Str() {'NULL'} });
-    say %seen<not-there>;          # NULL
-    say %seen<not-there>.defined;  # True (0 may be False but is well defined)
-    say Int.new(%seen<not-there>); # 0
+    say %seen<not-there>;          # OUTPUT: «NULL␤»
+    say %seen<not-there>.defined;  # OUTPUT: «True␤» (0 may be False but is well defined)
+    say Int.new(%seen<not-there>); # OUTPUT: «0␤»
 
 =head1 Meta-Object Programming and Introspection
 
@@ -914,9 +914,9 @@ it. Note that although this looks like a method call, it works more like a macro
 So, what can you do with the meta object? For one you can check if two
 objects have the same meta class by comparing them for equality:
 
-    say 1.HOW ===   2.HOW;      # True
-    say 1.HOW === Int.HOW;      # True
-    say 1.HOW === Num.HOW;      # False
+    say 1.HOW ===   2.HOW;      # OUTPUT: «True␤»
+    say 1.HOW === Int.HOW;      # OUTPUT: «True␤»
+    say 1.HOW === Num.HOW;      # OUTPUT: «False␤»
 
 Perl 6 uses the word I<HOW>, Higher Order Workings, to refer to the meta
 object system. Thus it should be no surprise that in Rakudo, the class name
@@ -932,10 +932,10 @@ of an object, you could write:
 
     my $object = 1;
     my $metaobject = 1.HOW;
-    say $metaobject.name($object);      # Int
+    say $metaobject.name($object);      # OUTPUT: «Int␤»
 
     # or shorter:
-    say 1.HOW.name(1);                  # Int
+    say 1.HOW.name(1);                  # OUTPUT: «Int␤»
 
 (The motivation is that Perl 6 also wants to allow a more prototype-based
 object system, where it's not necessary to create a new meta object for
@@ -943,9 +943,9 @@ every type).
 
 There's a shortcut to keep from using the same object twice:
 
-    say 1.^name;                        # Int
+    say 1.^name;                        # OUTPUT: «Int␤»
     # same as
-    say 1.HOW.name(1);                  # Int
+    say 1.HOW.name(1);                  # OUTPUT: «Int␤»
 
 See L<Metamodel::ClassHOW|/type/Metamodel::ClassHOW> for documentation on
 the meta class of C<class> and also the L<general documentation on the meta

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -132,7 +132,7 @@ different semantics as explained, next.
 
     my $str = 'old string';
     $str ~~ s/o .+ d/new/;
-    say $str; # OUTPUT«new string␤»
+    say $str; # OUTPUT: «new string␤»
 
 Operates on C<$_> topical variable, changing it in place. Uses the given
 L«C<Regex>|/type/Regex» to find portions to replace and changes them to the
@@ -156,14 +156,14 @@ and the opening C</>, separated with optional whitespace:
     # and lower-cased version of that stuff:
     $str ~~ s :g :i/<[ML]> (\S+)/d{lc $0}/;
 
-    say $str; # OUTPUT«fox ducked into the den␤»
+    say $str; # OUTPUT: «fox ducked into the den␤»
 
 You can also use a different delimiter:
 
     my $str = 'foober';
     $str ~~ s!foo!fox!;
     $str ~~ s{b(.)r} = " d$0n";
-    say $str; # OUTPUT«fox den␤»
+    say $str; # OUTPUT: «fox den␤»
 
 Non-paired characters can simply replace the original slashes. Paired
 characters, like braces, are used only on the match portion, with the
@@ -171,8 +171,8 @@ substitution given by assignment (of anything: a string, a routine call, etc.).
 
 =head2 C<S///> non-destructive substitution
 
-    say S/o .+ d/new/ with 'old string';      # OUTPUT«new string␤»
-    S:g/« (.)/$0.uc()/.say for <foo bar ber>; # OUTPUT«Foo␤Bar␤Ber␤»
+    say S/o .+ d/new/ with 'old string';      # OUTPUT: «new string␤»
+    S:g/« (.)/$0.uc()/.say for <foo bar ber>; # OUTPUT: «Foo␤Bar␤Ber␤»
 
 Same semantics as the C<s///> operator, except leaves the original string intact
 and I<returns the resultant string> instead of C<$/> (C<$/> still being set
@@ -205,13 +205,13 @@ This behavior is automatically extended to include custom-defined infix operator
 
     sub infix:<space-concat> ($a, $b) { $a ~ " " ~ $b };
     my $a = 'word1';
-    $a space-concat= 'word2';     # 'word1 word2'
+    $a space-concat= 'word2';     # RESULT: «'word1 word2'»
 
 Although not strictly operators, methods can be used in the same fashion.
 
     my Real $a = 1/2;
     $a = 3.14;
-    $a .= round;      # 3
+    $a .= round;      # RESULT: «3»
 
 =head1 Negated Relational Operators
 
@@ -222,12 +222,12 @@ you may not modify any operator already beginning with C<!>.
 There are shortcuts for C<!==> and C<!eq>, namely C<!=> and C<ne>.
 
     my $a = True;
-    say so $a != True;    # False
+    say so $a != True;    # OUTPUT: «False␤»
     my $i = 10;
 
     my $release = Date.new(:2015year, :12month, :24day);
     my $today = Date.today;
-    say so $release !before $today;     # False
+    say so $release !before $today;     # OUTPUT: «False␤»
 
 =head1 Reversed Operators
 X<|R,reverse meta operator>
@@ -235,8 +235,8 @@ X<|R,reverse meta operator>
 Any infix operator may be called with its two arguments reversed by prefixing
 with C<R>. Associativity of operands is reversed as well.
 
-    say 4 R/ 12;        # 3
-    say [R/] 2, 4, 16;  # 2
+    say 4 R/ 12;        # OUTPUT: «3␤»
+    say [R/] 2, 4, 16;  # OUTPUT: «2␤»
 
 =head1 X<<<Hyper Operators|hyper,<<;hyper,>>;hyper,«;hyper,»>>>
 
@@ -246,27 +246,27 @@ point to the shorter list. A list with just one element is fine too. If one of
 the lists is shorter then the other, the operator will cycle over the shorter
 list until all elements of the longer list are processed.
 
-    say (1, 2, 3) »*» 2;          # (2 4 6)
-    say (1, 2, 3, 4) »~» <a b>;   # (1a 2b 3a 4b)
-    say (1, 2, 3) »+« (4, 5, 6);  # (5 7 9)
+    say (1, 2, 3) »*» 2;          # OUTPUT: «(2 4 6)␤»
+    say (1, 2, 3, 4) »~» <a b>;   # OUTPUT: «(1a 2b 3a 4b)␤»
+    say (1, 2, 3) »+« (4, 5, 6);  # OUTPUT: «(5 7 9)␤»
 
 Assignment meta operators can be hyped.
 
     my @a = 1, 2, 3;
-    say @a »+=» 1;    # [2 3 4]
+    say @a »+=» 1;    # OUTPUT: «[2 3 4]␤»
 
 Hyper forms of unary operators have the pointy bit point to the operator and
 the blunt end at the list to be operated on.
 
     my @wisdom = True, False, True;
-    say !« @wisdom;     # [False True False]
+    say !« @wisdom;     # OUTPUT: «[False True False]␤»
 
     my @a = 1, 2, 3;
-    @a»++;              # (2, 3, 4)
+    @a»++;              # OUTPUT: «(2, 3, 4)␤»
 
 Hyper operators are defined recursively on nested arrays.
 
-    say -« [[1, 2], 3]; # [[-1 -2] -3]
+    say -« [[1, 2], 3]; # OUTPUT: «[[-1 -2] -3]␤»
 
 Also, methods can be called in an out of order, concurrent fashion. The resulting
 list is in order. Note that all hyper operators are candidates for
@@ -295,7 +295,7 @@ all values that have keys in both hashes.
 
     my %outer = 1, 2, 3 Z=> <a b c>;
     my %inner = 1, 2 Z=> <x z>;
-    say %outer «~» %inner;          # {"1" => "ax", "2" => "bz"}
+    say %outer «~» %inner;          # OUTPUT: «{"1" => "ax", "2" => "bz"}␤»
 
 Hyper operators can take user defined operators as its operator argument.
 
@@ -320,21 +320,21 @@ Hyper operators can take user defined operators as its operator argument.
         print pretty-file-site(a.Int) xx 2, ' ';
     }
 
-    # OUTPUT: «10 EB 4 EB 2 PB 5 PB 0.5 PB 4 TB 300 GB 4.5 GB 50 MB 200 MB 9 KB 0.6 MB»
+    # OUTPUT: «10 EB 4 EB 2 PB 5 PB 0.5 PB 4 TB 300 GB 4.5 GB 50 MB 200 MB 9 KB 0.6 MB␤»
 
 Whether hyperoperators descend into child lists depends on the
 L<nodality|/language/typesystem#trait_is_nodal> of the inner operator of a
 chain. For the hyper method call operator (».) the nodality of the target
 method is significant.
 
-    say (<a b>, <c d e>)».elems;        # (2 3)
-    say (<a b>, <c d e>)».&{ .elems };  # ((1 1) (1 1 1))
+    say (<a b>, <c d e>)».elems;        # OUTPUT: «(2 3)␤»
+    say (<a b>, <c d e>)».&{ .elems };  # OUTPUT: «((1 1) (1 1 1))␤»
 
 You can chain hyper operators to destructure a List of Lists.
 
     my $neighbors = ((-1, 0), (0, -1), (0, 1), (1, 0));
     my $p = (2, 3);
-    say $neighbors »>>+<<» ($p, *);   # ((1 3) (2 2) (2 4) (3 3))
+    say $neighbors »>>+<<» ($p, *);   # OUTPUT: «((1 3) (2 2) (2 4) (3 3))␤»
 
 =head1 Reduction Operators
 X<|[] (reduction meta operators)>X<|[+] (reduction meta operators)>
@@ -344,19 +344,19 @@ operator. It gives the same result as the L<reduce> routine - see there for
 details.
 
     # These two are equivalent:
-    say [+] 1, 2, 3;                # 6
-    say reduce &infix:<+>, 1, 2, 3; # 6
+    say [+] 1, 2, 3;                # OUTPUT: «6␤»
+    say reduce &infix:<+>, 1, 2, 3; # OUTPUT: «6␤»
 
 No whitespace is allowed between the brackets and the operator. To wrap a
 function instead of an operator, provide an additional layer of brackets:
 
     sub plus { $^a + $^b };
-    say [[&plus]] 1, 2, 3;      # 6
+    say [[&plus]] 1, 2, 3;          # OUTPUT: «6␤»
 
 The argument list is iterated without flattening. This means that you can pass
 a nested list to the reducing form of a list infix operator:
 
-    say [X~] (1, 2), <a b>;     # 1, 2 X~ <a b>
+    say [X~] (1, 2), <a b>;         # OUTPUT: «1, 2 X~ <a b>␤»
 
 By default, only the final result of the reduction is returned. Prefix the
 wrapped operator with a C<\>, to return a lazy list of all intermediate values
@@ -365,7 +365,7 @@ If the non-meta part contains a C<\> already,
 quote it with C<[]> (e.g. C<[\[\x]]>).
 
     my @n = [\~] 1..*;
-    say @n[^5];         # (1 12 123 1234 12345)
+    say @n[^5];         # OUTPUT: «(1 12 123 1234 12345)␤»
 
 =head1 Cross Operators
 X<|X (cross meta operator)>
@@ -374,8 +374,7 @@ The cross metaoperator, C<X>, will apply a given infix operator in order of
 cross product to all lists, such that the rightmost operator varies most
 quickly.
 
-    1..3 X~ <a b>
-    # produces <1a, 1b, 2a, 2b, 3a, 3b>
+    1..3 X~ <a b> # RESULT: «<1a, 1b, 2a, 2b, 3a, 3b>␤»
 
 =head1 Zip Operators
 X<|Z (zip meta operator)>
@@ -384,18 +383,18 @@ The zip metaoperator, (which is not the same thing as L<Z|#infix_Z>), will
 apply a given infix operator to pairs taken one left, one right, from its
 arguments. The resulting list is returned.
 
-    my @l = <a b c> Z~ 1, 2, 3;     # [a1 b2 c3]
+    my @l = <a b c> Z~ 1, 2, 3;     # RESULT: «[a1 b2 c3]␤»
 
 If one of the operands runs out of elements prematurely, the zip operator will
 stop. An infinite list can be used to repeat elements. A list with a final
 element of C<*> will repeat its 2nd last element indefinitely.
 
-    my @l = <a b c d> Z~ ':' xx *;  # <a: b: c: d:>
-       @l = <a b c d> Z~ 1, 2, *;   # <a1 b2 c2 d2>
+    my @l = <a b c d> Z~ ':' xx *;  # RESULT: «<a: b: c: d:>»
+       @l = <a b c d> Z~ 1, 2, *;   # RESULT: «<a1 b2 c2 d2>»
 
 If infix operator is not given, C<,> (comma operator) will be used by default:
 
-    my @l = 1 Z 2;  # [(1 2)]
+    my @l = 1 Z 2;  # RESULT: «[(1 2)]»
 
 =head1 Sequential Operators
 X<|S,sequential meta operator>
@@ -403,7 +402,7 @@ X<|S,sequential meta operator>
 The sequential metaoperator, C<S>, will suppress any concurrency or reordering
 done by the optimizer. Most simple infix operators are supported.
 
-    say so 1 S& 2 S& 3;  # True
+    say so 1 S& 2 S& 3;  # OUTPUT: «True␤»
 
 =head1 Nesting of Meta Operators
 
@@ -413,7 +412,7 @@ compiler understand you.
     my @a = 1, 2, 3;
     my @b = 5, 6, 7;
     @a X[+=] @b;
-    say @a;         # [19 20 21]
+    say @a;         # OUTPUT: «[19 20 21]␤»
 
 =head1 Z<>Term Precedence
 
@@ -424,7 +423,7 @@ a L<List|/type/List> of the words. If a word
 looks like a number literal or a C<Pair> literal, it's converted to the
 appropriate number.
 
-    say <a b c>[1];   # b
+    say <a b c>[1];   # OUTPUT: «b␤»
 
 =head2 term C«( )»
 
@@ -439,8 +438,8 @@ being interpreted as a named argument.
 
     multi sub p(:$a!) { say 'named'      }
     multi sub p($a)   { say 'positional' }
-    p a => 1;           # named
-    p (a => 1);         # positional
+    p a => 1;           # OUTPUT: «named␤»
+    p (a => 1);         # OUTPUT: «positional␤»
 
 =head2 term C«{ }»
 
@@ -474,15 +473,15 @@ Universal interface for positional access to zero or more elements of a
 @container, a.k.a. "X<array indexing operator|array indexing operator;array subscript operator>".
 
     my @alphabet = 'a' .. 'z';
-    say @alphabet[0];                   # -> a
-    say @alphabet[1];                   # -> b
-    say @alphabet[*-1];                 # -> z
-    say @alphabet[100]:exists;          # -> False
-    say @alphabet[15, 4, 17, 11].join;  # -> perl
-    say @alphabet[23 .. *].perl;        # -> ("x", "y", "z")
+    say @alphabet[0];                   # OUTPUT: «a␤»
+    say @alphabet[1];                   # OUTPUT: «b␤»
+    say @alphabet[*-1];                 # OUTPUT: «z␤»
+    say @alphabet[100]:exists;          # OUTPUT: «False␤»
+    say @alphabet[15, 4, 17, 11].join;  # OUTPUT: «perl␤»
+    say @alphabet[23 .. *].perl;        # OUTPUT: «("x", "y", "z")␤»
 
     @alphabet[1, 2] = "B", "C";
-    say @alphabet[0..3].perl            # -> ("a", "B", "C", "d")
+    say @alphabet[0..3].perl            # OUTPUT: «("a", "B", "C", "d")␤»
 
 See L<Subscripts|/language/subscripts>, for a more detailed explanation of this
 operator's behavior, and how to implement support for it in custom types.
@@ -498,13 +497,13 @@ Universal interface for associative access to zero or more elements of a
 %container, a.k.a. "X<hash indexing operator|hash indexing operator;hash subscript operator>".
 
     my %color = kiwi => "green", banana => "yellow", cherry => "red";
-    say %color{"banana"};                 # -> yellow
-    say %color{"cherry", "kiwi"}.perl;    # -> ("red", "green")
-    say %color{"strawberry"}:exists;      # -> False
+    say %color{"banana"};                 # OUTPUT: «yellow␤»
+    say %color{"cherry", "kiwi"}.perl;    # OUTPUT: «("red", "green")␤»
+    say %color{"strawberry"}:exists;      # OUTPUT: «False␤»
 
     %color{"banana", "lime"} = "yellowish", "green";
     %color{"cherry"}:delete;
-    say %color;             #-> banana => yellowish, kiwi => green, lime => green
+    say %color;             # OUTPUT: «banana => yellowish, kiwi => green, lime => green␤»
 
 See L«C«postcircumfix < >»|/routine/< >#(Operators)_postcircumfix_<_>» and
 L<C<postcircumfix « »>|/routine/« »#(Operators)_postcircumfix_«_»> for convenient
@@ -519,9 +518,9 @@ its argument using the same rules as the L«quote-words operator|
 /routine/< >#circumfix_<_>» of the same name.
 
     my %color = kiwi => "green", banana => "yellow", cherry => "red";
-    say %color<banana>;               # -> yellow
-    say %color<cherry kiwi>.perl;     # -> ("red", "green")
-    say %color<strawberry>:exists;    # -> False
+    say %color<banana>;               # OUTPUT: «yellow␤»
+    say %color<cherry kiwi>.perl;     # OUTPUT: «("red", "green")␤»
+    say %color<strawberry>:exists;    # OUTPUT: «False␤»
 
 This is not a real operator, just syntactic sugar that is turned into the
 C<{ }> postcircumfix operator at compile-time.
@@ -534,7 +533,7 @@ its argument using the same rules as the L<interpolating quote-words operator|
 
     my %color = kiwi => "green", banana => "yellow", cherry => "red";
     my $fruit = "kiwi";
-    say %color«cherry $fruit».perl;   #-> ("red", "green")
+    say %color«cherry $fruit».perl;   # OUTPUT: «("red", "green")␤»
 
 This is not a real operator, just syntactic sugar that is turned into the
 C<{ }> postcircumfix operator at compile-time.
@@ -567,9 +566,9 @@ Technically this is not an operator, but syntax special-cased in the compiler.
     my sub f($invocant){ dd $invocant; }
     my $i = 42;
     42.&f;
-    # OUTPUT«Int $invocant = 42␤»
+    # OUTPUT: «Int $invocant = 42␤»
     42.&(-> $invocant { dd $invocant });
-    # OUTPUT«Int $invocant = 42␤»
+    # OUTPUT: «Int $invocant = 42␤»
 
 =head2 postfix C«.=»
 
@@ -618,7 +617,7 @@ X<|postfix ».>X«|postfix >>.»
 X<Hyper method call operator>. Will call a method on all elements of a C<List> out of order and return the list of return values in order.
 
     my @a = <a b c>;
-    my @b = @a».ord;                  # [97, 98, 99]
+    my @b = @a».ord;                  # OUTPUT: «[97, 98, 99]␤»
     sub foo(Str:D $c){ $c.ord * 2 };  # The first parameter of a method is the invocant.
     say @a».&foo;                     # So we can pretend to have a method call with a sub that got a good first positional argument.
     say @a».&{ .ord};                 # Blocks have an implicit positional arguments that lands in $_. The latter can be omitted for method calls.
@@ -650,9 +649,9 @@ call.
         has &.function;
     }
     my $addition = Operation.new(:symbol<+>, :function{ $^a + $^b });
-    say $addition.function()(1, 2);   # 3
+    say $addition.function()(1, 2);   # OUTPUT: «3␤»
     # OR
-    say $addition.function.(1, 2);    # 3
+    say $addition.function.(1, 2);    # OUTPUT: «3␤»
 
 If the postfix is an identifier, however, it will be interpreted as a normal
 method call.
@@ -669,8 +668,8 @@ X<|postfix call>
 A prefix can be called like a method using colonpair notation. For example:
 
     my $a = 1;
-    say ++$a;       # 2
-    say $a.:<++>;   # 3
+    say ++$a;       # OUTPUT: «2␤»
+    say $a.:<++>;   # OUTPUT: «3␤»
 
 Technically this is not an operator, but syntax special-cased in the compiler.
 X<|prefix call>
@@ -686,7 +685,7 @@ class or role, even after it has been redefined in the child class.
     class Foo is Bar {
         method baz { "nope" }
     }
-    say Foo.Bar::baz;       # 42
+    say Foo.Bar::baz;       # OUTPUT: «42␤»
 
 =head1 Autoincrement Precedence
 
@@ -697,8 +696,8 @@ class or role, even after it has been redefined in the child class.
 Increments its argument by one, and returns the updated value.X<|increment operator>
 
     my $x = 3;
-    say ++$x;   # 4
-    say $x;     # 4
+    say ++$x;   # OUTPUT: «4␤»
+    say $x;     # OUTPUT: «4␤»
 
 It works by calling the L<succ> method (for I<successor>) on its argument,
 which gives custom types the freedom to implement their own increment
@@ -711,8 +710,8 @@ semantics.
 Decrements its argument by one, and returns the updated value.X<|decrement operator>
 
     my $x = 3;
-    say --$x;   # 2
-    say $x;     # 2
+    say --$x;   # OUTPUT: «2␤»
+    say $x;     # OUTPUT: «2␤»
 
 It works by calling the L<pred> method (for I<predecessor>) on its argument,
 which gives custom types the freedom to implement their own decrement
@@ -726,8 +725,8 @@ semantics.
 Increments its argument by one, and returns the original value.X<|increment operator>
 
     my $x = 3;
-    say $x++;   # 3
-    say $x;     # 4
+    say $x++;   # OUTPUT: «3␤»
+    say $x;     # OUTPUT: «4␤»
 
 It works by calling the L<succ> method (for I<successor>) on its argument,
 which gives custom types the freedom to implement their own increment
@@ -737,15 +736,15 @@ Note that this does not necessarily return its argument; e.g., for
 undefined values, it returns 0:
 
     my $x;
-    say $x++;   # 0
-    say $x;     # 1
+    say $x++;   # OUTPUT: «0␤»
+    say $x;     # OUTPUT: «1␤»
 
 Increment on L<Str|/type/Str> will increment the number part of a string and
 assign the resulting string to the container. A C<is rw>-container is required.
 
     my $filename = "somefile-001.txt";
     say $filename++ for 1..3;
-    # OUTPUT«somefile-001.txt␤somefile-002.txt␤somefile-003.txt␤»
+    # OUTPUT: «somefile-001.txt␤somefile-002.txt␤somefile-003.txt␤»
 
 =head2 postfix C«--»
 
@@ -754,8 +753,8 @@ assign the resulting string to the container. A C<is rw>-container is required.
 Decrements its argument by one, and returns the original value.X<|decrement operator>
 
     my $x = 3;
-    say $x--;   # 3
-    say $x;     # 2
+    say $x--;   # OUTPUT: «3␤»
+    say $x;     # OUTPUT: «2␤»
 
 It works by calling the L<pred> method (for I<predecessor>) on its argument,
 which gives custom types the freedom to implement their own decrement
@@ -765,8 +764,8 @@ Note that this does not necessarily return its argument;e.g., for
 undefined values, it returns 0:
 
     my $x;
-    say $x--;   # 0
-    say $x;     # -1
+    say $x--;   # OUTPUT: «0␤»
+    say $x;     # OUTPUT: «-1␤»
 
 Decrement on L<Str|/type/Str> will decrement the number part of a string and
 assign the resulting string to the container. A C<is rw>-container is required.
@@ -774,7 +773,7 @@ Crossing 0 is prohibited and throws C<X::AdHoc>.
 
     my $filename = "somefile-003.txt";
     say $filename-- for 1..3;
-    # OUTPUT«somefile-003.txt␤somefile-002.txt␤somefile-001.txt␤»
+    # OUTPUT: «somefile-003.txt␤somefile-002.txt␤somefile-001.txt␤»
 
 =head1 Exponentiation Precedence
 
@@ -882,7 +881,7 @@ I<upto> operator.X<|upto operator>
 Coerces the argument to L<Numeric>, and generates a range from 0 up to (but
 excluding) the argument.
 
-    say ^5;         # 0..^5
+    say ^5;         # OUTPUT: «0..^5␤»
     for ^5 { }      # 5 iterations
 
 =head1 Multiplicative Precedence
@@ -1056,12 +1055,12 @@ X<String repetition operator>.
 Repeats the string C<$a> C<$b> times, if necessary coercing C<$a> to L«C<Str>|/type/Str»
 and C<$b> L«C<Int>|/type/Int». Returns an empty string if C<< $b <= 0 >>.
 
-    say 'ab' x 3;           # ababab
-    say 42 x 3;             # 424242
+    say 'ab' x 3;           # OUTPUT: «ababab␤»
+    say 42 x 3;             # OUTPUT: «424242␤»
 
     my $a = 'a'.IO;
     my $b = 3.5;
-    say $a x $b;            # aaa
+    say $a x $b;            # OUTPUT: «aaa␤»
 
 =head2 infix C«xx»
 
@@ -1075,7 +1074,7 @@ to L<Int>). If C<< $b <= 0 >>, the empty list is returned.
 The left-hand side is evaluated for each repetition, so
 
     say [1, 2] xx 5;
-    # OUTPUT«([1 2] [1 2] [1 2] [1 2] [1 2])␤»
+    # OUTPUT: «([1 2] [1 2] [1 2] [1 2] [1 2])␤»
 
 returns five distinct arrays (but with the same content each time), and
 
@@ -1097,7 +1096,7 @@ X<String concatenation operator>.
 
 Coerces both arguments to L<Str> and concatenates them.
 
-    say 'ab' ~ 'c';     # abc
+    say 'ab' ~ 'c';     # OUTPUT: «abc␤»
 
 =head1 Junctive AND (all) Precedence
 
@@ -1142,14 +1141,14 @@ new values in this scope. Upon exiting the scope, the variable will be
 restored to its original value.
 
     my $a = "three";
-    say $a; # three
+    say $a; # OUTPUT: «three␤»
     {
         temp $a;
-        say $a; # three
+        say $a; # OUTPUT: «three␤»
         $a = "four";
-        say $a; # four
+        say $a; # OUTPUT: «four␤»
     }
-    say $a; # three
+    say $a; # OUTPUT: «three␤»
 
 Note that you can also assign immediately as part of the call to temp:
 
@@ -1210,11 +1209,11 @@ Instead of a role, you can provide an instantiated object. In this case,
 the operator will create a role for you automatically. The role will contain
 a single method named the same as C<$obj.^name> and that returns C<$obj>:
 
-    say 42 but 'forty two'; # 'forty two'
+    say 42 but 'forty two'; # OUTPUT: «forty two␤»
 
     my $s = 12 but class Warbles { method hi { 'hello' } }.new;
-    say $s.Warbles.hi;    # hello
-    say $s + 42;          # 54
+    say $s.Warbles.hi;    # OUTPUT: «hello␤»
+    say $s + 42;          # OUTPUT: «54␤»
 
 If methods of the same name are present already, the last mixed in role takes
 precedence. A list of methods can be provided in parentheses separated by
@@ -1234,9 +1233,9 @@ with number semantics, L<Pair> objects first by key and then by value etc.
 
 if C<$a eqv $b>, then C<$a cmp $b> always returns C<Order::Same>.
 
-    say (a => 3) cmp (a => 4);   # Less
-    say 4        cmp 4.0;        # Same
-    say 'b'      cmp 'a';        # More
+    say (a => 3) cmp (a => 4);   # OUTPUT: «Less␤»
+    say 4        cmp 4.0;        # OUTPUT: «Same␤»
+    say 'b'      cmp 'a';        # OUTPUT: «More␤»
 
 =head2 infix C«leg»
 
@@ -1247,9 +1246,9 @@ X<String three-way comparator>. Short for I<less, equal or greater?>.
 
 Coerces both arguments to L<Str>, and then does a lexicographic comparison.
 
-    say 'a' leg 'b';       # Less
-    say 'a' leg 'a';       # Same
-    say 'b' leg 'a';       # More
+    say 'a' leg 'b';       # OUTPUT: «Less␤»
+    say 'a' leg 'a';       # OUTPUT: «Same␤»
+    say 'b' leg 'a';       # OUTPUT: «More␤»
 
 =head2 infix C«<=>»
 
@@ -1465,10 +1464,10 @@ Returns C<True> if the first argument is larger than the second.
 X<Equivalence operator>. Returns C<True> if the two arguments are structurally
 the same, i.e. from the same type and (recursively) contain the same values.
 
-    say [1, 2, 3] eqv [1, 2, 3];    # True
-    say Any eqv Any;                # True
-    say 1 eqv 2;                    # False
-    say 1 eqv 1.0;                  # False
+    say [1, 2, 3] eqv [1, 2, 3];    # OUTPUT: «True␤»
+    say Any eqv Any;                # OUTPUT: «True␤»
+    say 1 eqv 2;                    # OUTPUT: «False␤»
+    say 1 eqv 1.0;                  # OUTPUT: «False␤»
 
 The default C<eqv> operator even works with arbitrary objects. E.g., C<eqv>
 will consider two instances of the same object as being structurally
@@ -1477,7 +1476,7 @@ equivalent:
     my class A {
         has $.a;
     }
-    say A.new(a => 5) eqv A.new(a => 5);  # => True
+    say A.new(a => 5) eqv A.new(a => 5);  # OUTPUT: «True␤»
 
 Although the above example works as intended the C<eqv> code has to fall back
 to a slower code path in in order to do its job. One way to avoid this is to
@@ -1487,7 +1486,7 @@ implement an appropriate infix C<eqv> operator:
         has $.a;
     }
     multi infix:<eqv>(A $l, A $r) { $l.a eqv $r.a }
-    say A.new(a => 5) eqv A.new(a => 5);            # => True
+    say A.new(a => 5) eqv A.new(a => 5);            # OUTPUT: «True␤»
 
 =head2 infix C«===»
 
@@ -1497,17 +1496,17 @@ X<Value identity operator>. Returns C<True> if both arguments are the same objec
 
     my class A { };
     my $a = A.new;
-    say $a === $a;              # True
-    say A.new === A.new;        # False
-    say A === A;                # True
+    say $a === $a;              # OUTPUT: «True␤»
+    say A.new === A.new;        # OUTPUT: «False␤»
+    say A === A;                # OUTPUT: «True␤»
 
 For value types, C<===> behaves like C<eqv>:
 
-    say 'a' === 'a';            # True
-    say 'a' === 'b';            # False
+    say 'a' === 'a';            # OUTPUT: «True␤»
+    say 'a' === 'b';            # OUTPUT: «False␤»
 
     # different types
-    say 1 === 1.0;              # False
+    say 1 === 1.0;              # OUTPUT: «False␤»
 
 C<===> uses the L<WHICH|/routine/WHICH> method to obtain the object identity, so all value
 types must override method C<WHICH>.
@@ -1521,13 +1520,13 @@ container. If it returns C<True>, it generally means that modifying one will
 also modify the other.
 
     my ($a, $b) = (1, 3);
-    say $a =:= $b;      # False
+    say $a =:= $b;      # OUTPUT: «False␤»
     $b = 2;
-    say $a;             # 1
+    say $a;             # OUTPUT: «1␤»
     $b := $a;
-    say $a =:= $b;      # True
+    say $a =:= $b;      # OUTPUT: «True␤»
     $a = 5;
-    say $b;             # 5
+    say $b;             # OUTPUT: «5␤»
 
 =head2 infix C«~~»
 
@@ -1567,8 +1566,8 @@ then it checks that the absolute difference between the sides is less than $*TOL
 Note that this operator is not arithmetically symmetrical (doesn't do ± Δ):
 
     my $x = 1;
-    say ($x + $*TOLERANCE) =~= $x;   # False
-    say ($x - $*TOLERANCE) =~= $x;   # True
+    say ($x + $*TOLERANCE) =~= $x;   # OUTPUT: «False␤»
+    say ($x - $*TOLERANCE) =~= $x;   # OUTPUT: «True␤»
 
 The tolerance is supposed to be modifiable via an adverb:
 
@@ -1583,14 +1582,14 @@ assigning to $*TOLERANCE.
 
     {
         my $*TOLERANCE = .1;
-        say 11 =~= 10;        # True
+        say 11 =~= 10;        # OUTPUT: «True␤»
     }
 
 Note that setting $*TOLERANCE = 0 will cause all comparisons to fail.
 
     {
         my $*TOLERANCE = 0;
-        say 1 =~= 1;          # False
+        say 1 =~= 1;          # OUTPUT: «False␤»
     }
 
 =head1 Tight AND Precedence
@@ -1606,7 +1605,7 @@ false value, the arguments to the right of are never evaluated.
     sub a { 1 }
     sub b { 0 }
     sub c { die "never called" };
-    say a() && b() && c();      # 0
+    say a() && b() && c();      # OUTPUT: «0␤»
 
 =head1 Tight OR Precedence
 
@@ -1621,7 +1620,7 @@ true value, the arguments to the right of are never evaluated.
     sub a { 0 }
     sub b { 1 }
     sub c { die "never called" };
-    say a() || b() || c();      # 1
+    say a() || b() || c();      # OUTPUT: «1␤»
 
 =head2 infix C«^^»
 
@@ -1632,9 +1631,9 @@ Returns C<Nil> otherwise (when more than one argument is true).
 This operator short-circuits in the sense that it does not evaluate
 any arguments after a 2nd true result.
 
-    say 0 ^^ 42;                # 42
-    say '' ^^ 0;                # 0
-    say 0 ^^ 42 ^^ 1 ^^ die "never called";  # (empty line)
+    say 0 ^^ 42;                             # OUTPUT: «42␤»
+    say '' ^^ 0;                             # OUTPUT: «0␤»
+    say 0 ^^ 42 ^^ 1 ^^ die "never called";  # OUTPUT: «␤»
 
 Note that the semantics of this operator may not be what you assume: infix C«^^»
 flips to first true value it finds, and then flips to Nil I<forever> after the
@@ -1646,7 +1645,7 @@ second, no matter how many more true values there are. (In other words, it has
 X<Defined-or operator>. Returns the first defined operand or else the last
 operand. Short-circuits.
 
-    say Any // 0 // 42;         # 0
+    say Any // 0 // 42;         # OUTPUT: «0␤»
 
 =head2 infix C«min»
 
@@ -1710,14 +1709,14 @@ to the stop condition, and act accordingly if successful. In this example, only
 the first element is printed:
 
     for <AB C D B E F> {
-        say $_ if /A/ ff /B/;  # prints only "AB"
+        say $_ if /A/ ff /B/;  # OUTPUT: «AB␤»
     }
 
 If you only want to test against a start condition, and have no stop condition,
 C<*> can be used as the "stop" condition.
 
     for <A B C D E> {
-        say $_ if /C/ ff *; # prints C, D, and E
+        say $_ if /C/ ff *;    # OUTPUT: «C␤D␤E␤»
     }
 
 For the sed-like version, which does I<not> try C<$_> on the stop condition
@@ -1735,8 +1734,8 @@ start condition (including items also matching the stop condition).
 A comparison:
 
     my @list = <A B C>;
-    say $_ if /A/ ff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ ^ff /C/ for @list; # prints B and C
+    say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ ^ff /C/ for @list;   # OUTPUT: «B␤C␤»
 
 The sed-like version can be found in L<C<^fff>|/routine/^fff>.
 
@@ -1750,8 +1749,8 @@ Works like L<C<ff>>, except it does not return C<True> for items matching the
 stop condition (including items that first matched the start condition).
 
     my @list = <A B C>;
-    say $_ if /A/ ff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ ff^ /C/ for @list; # prints A and B
+    say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ ff^ /C/ for @list;   # OUTPUT: «A␤B␤»
 
 The sed-like version can be found in L<C<fff^>>.
 
@@ -1765,8 +1764,8 @@ Works like L<C<ff>>, except it does not return C<True> for items matching either
 the stop or start condition (or both).
 
     my @list = <A B C>;
-    say $_ if /A/ ff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ ^ff^ /C/ for @list; # prints B
+    say $_ if /A/ ff /C/ for @list;    # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ ^ff^ /C/ for @list;  # OUTPUT: «B␤»
 
 The sed-like version can be found in L<C<^fff^>|/routine/^fff^>.
 
@@ -1785,7 +1784,7 @@ invocation. That is, if C<$_> smartmatches the left argument, C<fff> will B<not>
 then try to match that same C<$_> against the right argument.
 
     for <AB C D B E F> {
-        say $_ if /A/ fff /B/;  # Prints "AB", "C", "D", and "B"
+        say $_ if /A/ fff /B/;         # OUTPUT: «AB␤C␤D␤B␤»
     }
 
 The non-sed-like flipflop (which after successfully matching the left argument
@@ -1801,8 +1800,8 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Like L<C<fff>>, except it does not return true for matches to the left argument.
 
     my @list = <A B C>;
-    say $_ if /A/ fff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ ^fff /C/ for @list; # prints B and C
+    say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ ^fff /C/ for @list;  # OUTPUT: «B␤C␤»
 
 For the non-sed version, see L<C<^ff>|/routine/^ff>.
 
@@ -1815,8 +1814,8 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 Like L<C<fff>>, except it does not return true for matches to the right argument.
 
     my @list = <A B C>;
-    say $_ if /A/ fff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ fff^ /C/ for @list; # prints A and B
+    say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ fff^ /C/ for @list;  # OUTPUT: «A␤B␤»
 
 For the non-sed version, see L<C<ff^>>.
 
@@ -1830,8 +1829,8 @@ Like L<C<fff>>, except it does not return true for matches to either the left or
 right argument.
 
     my @list = <A B C>;
-    say $_ if /A/ fff /C/ for @list;  # prints A, B, and C
-    say $_ if /A/ ^fff^ /C/ for @list; # prints B
+    say $_ if /A/ fff /C/ for @list;   # OUTPUT: «A␤B␤C␤»
+    say $_ if /A/ ^fff^ /C/ for @list; # OUTPUT: «B␤»
 
 For the non-sed version, see L<C<^ff^>|/routine/^ff^>.
 
@@ -1867,8 +1866,8 @@ Note that the C<< => >> operator is syntactically special-cased, in that
 it allows unquoted identifier on the left-hand side.
 
     my $p = a => 1;
-    say $p.key;         # a
-    say $p.value;       # 1
+    say $p.key;         # OUTPUT: «a␤»
+    say $p.value;       # OUTPUT: «1␤»
 
 A L<Pair> within an argument list with an unquoted identifier on the left
 is interpreted as a named argument.
@@ -1926,7 +1925,7 @@ Interleaves the lists passed to C<Z> like a zipper, stopping as soon as the
 first input list is exhausted. The returned C<Seq> contains a nested list with
 values for all C<Z> operators in a chain.
 
-    say (1, 2 Z <a b c> Z <+ ->).perl;  # => ((1, "a", "+"), (2, "b", "-")).Seq
+    say (1, 2 Z <a b c> Z <+ ->).perl;  # OUTPUT: «((1, "a", "+"), (2, "b", "-")).Seq␤»
     for <a b c> Z <1 2 3> -> [$l, $r] {
         say "$l:$r"
     }
@@ -1936,8 +1935,8 @@ The C<Z> operator also exists as a meta operator, in which case the inner
 lists are replaced by the value from applying the operator to the
 list:
 
-    say 100, 200 Z+ 42, 23;             # => (142 223)
-    say 1..3 Z~ <a b c> Z~ 'x' xx 3;    # => (1ax 2bx 3cx)
+    say 100, 200 Z+ 42, 23;             # OUTPUT: «(142 223)␤»
+    say 1..3 Z~ <a b c> Z~ 'x' xx 3;    # OUTPUT: «(1ax 2bx 3cx)␤»
 
 =head2 infix C«X»
 
@@ -1976,27 +1975,27 @@ generated elements.
 The default generator is C<*.>L<succ> or C<*.>L<pred>, depending on how
 the end points compare:
 
-    say 1 ... 4;        # 1 2 3 4
-    say 4 ... 1;        # 4 3 2 1
-    say 'a' ... 'e';    # a b c d e
-    say 'e' ... 'a';    # e d c b a
+    say 1 ... 4;        # OUTPUT: «(1 2 3 4)␤»
+    say 4 ... 1;        # OUTPUT: «(4 3 2 1)␤»
+    say 'a' ... 'e';    # OUTPUT: «(a b c d e)␤»
+    say 'e' ... 'a';    # OUTPUT: «(e d c b a)␤»
 
 An endpoint of C<*> (L<Whatever>) generates an infinite sequence,
 with a default generator of *.succ
 
-    say (1 ... *)[^5];  # 1 2 3 4 5
+    say (1 ... *)[^5];  # OUTPUT: «(1 2 3 4 5)␤»
 
 
 Custom generators are the last argument before the '...' operator.
 This one takes two arguments, and generates the Fibonacci numbers
 
-    say (1, 1, -> $a, $b { $a + $b } ... *)[^8];    # 1 1 2 3 5 8 13 21
+    say (1, 1, -> $a, $b { $a + $b } ... *)[^8];    # OUTPUT: «(1 1 2 3 5 8 13 21)␤»
     # same but shorter
-    say (1, 1, *+* ... *)[^8];                      # 1 1 2 3 5 8 13 21
+    say (1, 1, *+* ... *)[^8];                      # OUTPUT: «(1 1 2 3 5 8 13 21)␤»
 
 Of course the generator can also take only one argument.
 
-    say 5, { $_ * 2 } ... 40;                       # 5 10 20 40
+    say 5, { $_ * 2 } ... 40;                       # OUTPUT: «5 10 20 40␤»
 
 There must be at least as many initial elements as arguments to the generator.
 
@@ -2004,8 +2003,8 @@ Without a generator, and more than one initial element, and all initial
 elements numeric, the sequence operator tries to deduce the generator. It
 knows about arithmetic and geometric sequences.
 
-    say 2, 4, 6 ... 12;     # 2 4 6 8 10 12
-    say 1, 2, 4 ... 32;     # 1 2 4 8 16 32
+    say 2, 4, 6 ... 12;     # OUTPUT: «(2 4 6 8 10 12)␤»
+    say 1, 2, 4 ... 32;     # OUTPUT: «(1 2 4 8 16 32)␤»
 
 If the endpoint is not C<*>, it's smart-matched against each generated
 element, and the sequence is terminated when the smart-match succeeded.
@@ -2023,7 +2022,7 @@ well, so the are also checked against the endpoint:
 
     my $end = 4;
     say 1, 2, 4, 8, 16 ... $end;
-    # outputs 1 2 4
+    # OUTPUT: «(1 2 4)␤»
 
 =head1 List Prefix Precedence
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -692,9 +692,7 @@ class or role, even after it has been redefined in the child class.
 
 =head2 prefix X<C«++»|++>
 
-=begin code :skip-test
-multi sub prefix:<++>($x is rw) is assoc<non>
-=end code
+    multi sub prefix:<++>($x is rw) is assoc<non>
 
 Increments its argument by one, and returns the updated value.X<|increment operator>
 
@@ -708,9 +706,7 @@ semantics.
 
 =head2 prefix X<C«--»|-->
 
-=begin code :skip-test
-multi sub prefix:<-->($x is rw) is assoc<non>
-=end code
+    multi sub prefix:<-->($x is rw) is assoc<non>
 
 Decrements its argument by one, and returns the updated value.X<|decrement operator>
 
@@ -725,9 +721,7 @@ semantics.
 
 =head2 postfix X<C«++»|++>
 
-=begin code :skip-test
-multi sub postfix:<++>($x is rw) is assoc<non>
-=end code
+    multi sub postfix:<++>($x is rw) is assoc<non>
 
 Increments its argument by one, and returns the original value.X<|increment operator>
 
@@ -755,9 +749,7 @@ assign the resulting string to the container. A C<is rw>-container is required.
 
 =head2 postfix C«--»
 
-=begin code :skip-test
-multi sub postfix:<-->($x is rw) is assoc<non>
-=end code
+    multi sub postfix:<-->($x is rw) is assoc<non>
 
 Decrements its argument by one, and returns the original value.X<|decrement operator>
 
@@ -788,9 +780,7 @@ Crossing 0 is prohibited and throws C<X::AdHoc>.
 
 =head2 infix C«**»
 
-=begin code :skip-test
-multi sub infix:<**>(Any, Any) returns Numeric:D is assoc<right>
-=end code
+    multi sub infix:<**>(Any, Any --> Numeric:D) is assoc<right>
 
 The X<exponentiation operator> coerces both arguments to L<Numeric>
 and calculates the left-hand-side raised to the power of the right-hand side.
@@ -803,9 +793,7 @@ is carried out without loss of precision.
 
 =head2 prefix C«?»
 
-=begin code :skip-test
-multi sub prefix:<?>(Mu) returns Bool:D
-=end code
+    multi sub prefix:<?>(Mu --> Bool:D)
 
 X<Boolean context operator>.
 
@@ -814,9 +802,7 @@ Note that this collapses L<Junction>s.
 
 =head2 prefix C«!»
 
-=begin code :skip-test
-multi sub prefix:<!>(Mu) returns Bool:D
-=end code
+    multi sub prefix:<!>(Mu --> Bool:D)
 
 X<Negated boolean context operator>.
 
@@ -826,9 +812,7 @@ Note that this collapses L<Junction>s.
 
 =head2 prefix C«+»
 
-=begin code :skip-test
-multi sub prefix:<+>(Any) returns Numeric:D
-=end code
+    multi sub prefix:<+>(Any --> Numeric:D)
 
 X<Numeric context operator>.
 
@@ -836,9 +820,7 @@ Coerces the argument to L<Numeric> by calling the C<Numeric> method on it.
 
 =head2 prefix C«-»
 
-=begin code :skip-test
-multi sub prefix:<->(Any) returns Numeric:D
-=end code
+    multi sub prefix:<->(Any --> Numeric:D)
 
 X<Negative numeric context operator>.
 
@@ -847,9 +829,7 @@ and then negates the result.
 
 =head2 prefix C«~»
 
-=begin code :skip-test
-multi sub prefix:<~>(Any) returns Str:D
-=end code
+    multi sub prefix:<~>(Any --> Str:D)
 
 X<String context operator>.
 
@@ -870,9 +850,7 @@ TODO
 
 =head2 prefix C«+^»
 
-=begin code :skip-test
-multi sub prefix:<+^>(Any) returns Int:D
-=end code
+    multi sub prefix:<+^>(Any --> Int:D)
 
 X<Integer bitwise negation operator>.
 
@@ -888,9 +866,7 @@ Please note that this has not yet been implemented.
 
 =head2 prefix C«?^»
 
-=begin code :skip-test
-multi sub prefix:<?^>(Mu) returns Bool:D
-=end code
+    multi sub prefix:<?^>(Mu --> Bool:D)
 
 X<Boolean bitwise negation operator>.
 
@@ -899,9 +875,7 @@ same as C<< prefix:<!> >>.
 
 =head2 prefix C«^»
 
-=begin code :skip-test
-multi sub prefix:<^>(Any) returns Range:D
-=end code
+    multi sub prefix:<^>(Any --> Range:D)
 
 I<upto> operator.X<|upto operator>
 
@@ -915,9 +889,7 @@ excluding) the argument.
 
 =head2 infix C«*»
 
-=begin code :skip-test
-multi sub infix:<*>(Any, Any) returns Numeric:D
-=end code
+    multi sub infix:<*>(Any, Any --> Numeric:D)
 
 X<Multiplication operator>.
 
@@ -926,9 +898,7 @@ is of the wider type. See L<Numeric> for details.
 
 =head2 infix C«/»
 
-=begin code :skip-test
-multi sub infix:</>(Any, Any) returns Numeric:D
-=end code
+    multi sub infix:</>(Any, Any --> Numeric:D)
 
 X<Division operator>.
 
@@ -938,17 +908,13 @@ rule described in L<Numeric> holds.
 
 =head2 infix C«div»
 
-=begin code :skip-test
-multi sub infix:<div>(Int:D, Int:D) returns Int:D
-=end code
+    multi sub infix:<div>(Int:D, Int:D --> Int:D)
 
 X<Integer division operator>. Rounds down.
 
 =head2 infix C«%»
 
-=begin code :skip-test
-multi sub infix:<%>($x, $y) return Numeric:D
-=end code
+    multi sub infix:<%>($x, $y --> Numeric:D)
 
 X<Modulo operator>. Coerces to L<Numeric> first.
 
@@ -959,42 +925,32 @@ Generally the following identity holds:
 
 =head2 infix C«%%»
 
-=begin code :skip-test
-multi sub infix:<%%>($a, $b) returns Bool:D
-=end code
+    multi sub infix:<%%>($a, $b --> Bool:D)
 
 X<Divisibility operator>. Returns C<True> if C<$a %  $b == 0>.
 
 =head2 infix C«mod»
 
-=begin code :skip-test
-multi sub infix:<mod>(Int:D $a, Int:D $b) returns Int:D
-=end code
+    multi sub infix:<mod>(Int:D $a, Int:D $b --> Int:D)
 
 X<Integer modulo operator>. Returns the remainder of an integer modulo operation.
 
 =head2 infix C«+&»
 
-=begin code :skip-test
-multi sub infix:<+&>($a, $b) returns Int:D
-=end code
+    multi sub infix:<+&>($a, $b --> Int:D)
 
 Numeric bitwise I<AND> operator. Coerces both arguments to L<Int> and does a bitwise
 I<AND> operation assuming two's complement.X<|Numeric bitwise AND operator>
 
 =head2 infix C«+<»
 
-=begin code :skip-test
-multi sub infix:<< +< >>($a, $b) returns Int:D
-=end code
+    multi sub infix:<< +< >>($a, $b --> Int:D)
 
 Integer bit shift to the left.X<|integer bit shift operator,left>
 
 =head2 infix C«+>»
 
-=begin code :skip-test
-multi sub infix:<< +> >>($a, $b) returns Int:D
-=end code
+    multi sub infix:<< +> >>($a, $b --> Int:D)
 
 Integer bit shift to the right.X<|integer bit shift operator,right>
 
@@ -1020,17 +976,13 @@ Please note that this has not yet been implemented.
 
 =head2 infix C«gcd»
 
-=begin code :skip-test
-multi sub infix:<gcd>($a, $b) returns Int:D
-=end code
+    multi sub infix:<gcd>($a, $b --> Int:D)
 
 Coerces both arguments to L<Int> and returns the greatest common divisor.X<|greatest common divisor operator>
 
 =head2 infix C«lcm»
 
-=begin code :skip-test
-multi sub infix:<lcm>($a, $b) returns Int:D
-=end code
+    multi sub infix:<lcm>($a, $b --> Int:D)
 
 Coerces both arguments to L<Int> and returns the least common multiple, that is
 the smallest integer that is evenly divisible by both arguments.X<|least common multiple operator>
@@ -1039,9 +991,7 @@ the smallest integer that is evenly divisible by both arguments.X<|least common 
 
 =head2 infix C«+»
 
-=begin code :skip-test
-multi sub infix:<+>($a, $b) returns Numeric:D
-=end code
+    multi sub infix:<+>($a, $b --> Numeric:D)
 
 X<Addition operator>.
 
@@ -1049,9 +999,7 @@ Coerces both arguments to L<Numeric> and adds them.
 
 =head2 infix C«-»
 
-=begin code :skip-test
-multi sub infix:<->($a, $b) returns Numeric:D
-=end code
+    multi sub infix:<->($a, $b --> Numeric:D)
 
 X<Subtraction operator>.
 
@@ -1060,9 +1008,7 @@ first.
 
 =head2 infix C«+|»
 
-=begin code :skip-test
-multi sub infix:<+|>($a, $b) returns Int:D
-=end code
+    multi sub infix:<+|>($a, $b --> Int:D)
 
 X<Integer bitwise OR operator>.
 
@@ -1071,9 +1017,7 @@ operation.
 
 =head2 infix C«+^»
 
-=begin code :skip-test
-multi sub infix:<+^>($a, $b) returns Int:D
-=end code
+    multi sub infix:<+^>($a, $b --> Int:D)
 
 X<Integer bitwise XOR operator>.
 
@@ -1094,9 +1038,7 @@ shorter buffer with zeroes.
 
 =head2 infix C«?|»
 
-=begin code :skip-test
-multi sub infix:<?|>($a, $b) returns Bool:D
-=end code
+    multi sub infix:<?|>($a, $b --> Bool:D)
 
 X<Boolean logical OR operator>.
 
@@ -1107,9 +1049,7 @@ operation.
 
 =head2 infix C«x»
 
-=begin code :skip-test
-sub infix:<x>($a, $b) returns Str:D
-=end code
+    sub infix:<x>($a, $b --> Str:D)
 
 X<String repetition operator>.
 
@@ -1125,9 +1065,7 @@ and C<$b> L«C<Int>|/type/Int». Returns an empty string if C<< $b <= 0 >>.
 
 =head2 infix C«xx»
 
-=begin code :skip-test
-multi sub infix:<xx>($a, $b) returns List:D
-=end code
+    multi sub infix:<xx>($a, $b --> List:D)
 
 X<List repetition operator>.
 
@@ -1152,11 +1090,8 @@ is returned.
 
 =head2 infix C«~»
 
-=begin code :skip-test
-proto sub infix:<~>(Any, Any) returns Str:D
-multi sub infix:<~>(Any,   Any)
-multi sub infix:<~>(Str:D, Str:D)
-=end code
+    multi sub infix:<~>(Any,   Any)
+    multi sub infix:<~>(Str:D, Str:D)
 
 X<String concatenation operator>.
 
@@ -1168,9 +1103,7 @@ Coerces both arguments to L<Str> and concatenates them.
 
 =head2 infix C«&»
 
-=begin code :skip-test
-multi sub infix:<&>($a, $b) returns Junction:D is assoc<list>
-=end code
+    multi sub infix:<&>($a, $b --> Junction:D) is assoc<list>
 
 X<All junction operator>.
 
@@ -1181,9 +1114,7 @@ details.
 
 =head2 infix C«|»
 
-=begin code :skip-test
-multi sub infix:<|>($a, $b) returns Junction:D is assoc<list>
-=end code
+    multi sub infix:<|>($a, $b --> Junction:D) is assoc<list>
 
 X<Any junction operator>.
 
@@ -1192,9 +1123,7 @@ details.
 
 =head2 infix C«^»
 
-=begin code :skip-test
-multi sub infix:<^>($a, $b) returns Junction:D is assoc<list>
-=end code
+    multi sub infix:<^>($a, $b --> Junction:D) is assoc<list>
 
 X<One junction operator>.
 
@@ -1205,9 +1134,7 @@ details.
 
 =head2 prefix C«temp»
 
-=begin code :skip-test
-sub prefix:<temp>(Mu $a is rw)
-=end code
+    sub prefix:<temp>(Mu $a is rw)
 
 "temporizes" the variable passed as the argument. The variable begins
 with the same value as it had in the outer scope, but can be assigned
@@ -1232,9 +1159,7 @@ Note that you can also assign immediately as part of the call to temp:
 
 =head2 prefix C«let»
 
-=begin code :skip-test
-sub prefix:<let>(Mu $a is rw)
-=end code
+    sub prefix:<let>(Mu $a is rw)
 
 Restores the previous value if the block exits unsuccessfully. A
 successful exit means the block returned a defined value or a list.
@@ -1263,9 +1188,7 @@ unsuccessfully, resetting the answer to 42.
 
 =head2 infix C«does»
 
-=begin code :skip-test
-sub infix:<does>(Mu $obj, Mu $role) is assoc<non>
-=end code
+    sub infix:<does>(Mu $obj, Mu $role) is assoc<non>
 
 Mixes C<$role> into C<$obj> at run time. Requires C<$obj> to be mutable.
 
@@ -1277,10 +1200,8 @@ precedence.
 
 =head2 infix C«but»
 
-=begin code :skip-test
-sub infix:<but>(Mu $obj, Mu  $role) is assoc<non>
-sub infix:<but>(Mu $obj, Mu:D $obj) is assoc<non>
-=end code
+    multi sub infix:<but>(Mu $obj1, Mu   $role) is assoc<non>
+    multi sub infix:<but>(Mu $obj1, Mu:D $obj2) is assoc<non>
 
 Creates a copy of C<$obj> with C<$role> mixed in. Since C<$obj> is not
 modified, C<but> can be used to created immutable values with mixins.
@@ -1301,13 +1222,10 @@ comma. In this case conflicts will be reported at runtime.
 
 =head2 infix C«cmp»
 
-=begin code :skip-test
-proto sub infix:<cmp>(Any, Any) returns Order:D is assoc<non>
-multi sub infix:<cmp>(Any,       Any)
-multi sub infix:<cmp>(Real:D,    Real:D)
-multi sub infix:<cmp>(Str:D,     Str:D)
-multi sub infix:<cmp>(Version:D, Version:D)
-=end code
+    multi sub infix:<cmp>(Any,       Any)
+    multi sub infix:<cmp>(Real:D,    Real:D)
+    multi sub infix:<cmp>(Str:D,     Str:D)
+    multi sub infix:<cmp>(Version:D, Version:D)
 
 X<Generic, "smart" three-way comparator>.
 
@@ -1322,27 +1240,20 @@ if C<$a eqv $b>, then C<$a cmp $b> always returns C<Order::Same>.
 
 =head2 infix C«leg»
 
-=begin code :skip-test
-proto sub infix:<leg>($a, $b) returns Order:D is assoc<non>
-multi sub infix:<leg>(Any,   Any)
-multi sub infix:<leg>(Str:D, Str:D)
-=end code
+    multi sub infix:<leg>(Any,   Any)
+    multi sub infix:<leg>(Str:D, Str:D)
 
 X<String three-way comparator>. Short for I<less, equal or greater?>.
 
 Coerces both arguments to L<Str>, and then does a lexicographic comparison.
 
-=begin code :skip-test
-say 'a' leg 'b';        Less
-say 'a' leg 'a';        Same
-say 'b' leg 'a';        More
-=end code
+    say 'a' leg 'b';       # Less
+    say 'a' leg 'a';       # Same
+    say 'b' leg 'a';       # More
 
 =head2 infix C«<=>»
 
-=begin code :skip-test
-multi sub infix:«<=>»($a, $b) returns Order:D is assoc<non>
-=end code
+    multi sub infix:«<=>»($a, $b --> Order:D) is assoc<non>
 
 X<Numeric three-way comparator>.X<|spaceship operator>
 
@@ -1350,9 +1261,7 @@ Coerces both arguments to L<Real>, and then does a numeric comparison.
 
 =head2 infix C«..»
 
-=begin code :skip-test
-multi sub infix:<..>($a, $b) returns Range:D is assoc<non>
-=end code
+    multi sub infix:<..>($a, $b --> Range:D) is assoc<non>
 
 X<Range operator>
 
@@ -1360,9 +1269,7 @@ Constructs a L<Range> from the arguments.
 
 =head2 infix C«..^»
 
-=begin code :skip-test
-multi sub infix:<..^>($a, $b) returns Range:D is assoc<non>
-=end code
+    multi sub infix:<..^>($a, $b --> Range:D) is assoc<non>
 
 X<Right-open range operator>.
 
@@ -1370,9 +1277,7 @@ Constructs a L<Range> from the arguments, excluding the end point.
 
 =head2 infix C«^..»
 
-=begin code :skip-test
-multi sub infix:<^..>($a, $b) returns Range:D is assoc<non>
-=end code
+    multi sub infix:<^..>($a, $b --> Range:D) is assoc<non>
 
 X<Left-open range operator>.
 
@@ -1380,9 +1285,7 @@ Constructs a L<Range> from the arguments, excluding the start point.
 
 =head2 infix C«^..^»
 
-=begin code :skip-test
-multi sub infix:<^..^>($a, $b) returns Range:D is assoc<non>
-=end code
+    multi sub infix:<^..^>($a, $b --> Range:D) is assoc<non>
 
 X<Open range operator>
 
@@ -1392,16 +1295,13 @@ Constructs a L<Range> from the arguments, excluding both start and end point.
 
 =head2 infix C«==»
 
-=begin code :skip-test
-proto sub infix:<==>($, $) returns Bool:D is assoc:<chain>
-multi sub infix:<==>(Any, Any)
-multi sub infix:<==>(Int:D, Int:D)
-multi sub infix:<==>(Num:D, Num:D)
-multi sub infix:<==>(Rational:D, Rational:D)
-multi sub infix:<==>(Real:D, Real:D)
-multi sub infix:<==>(Complex:D, Complex:D)
-multi sub infix:<==>(Numeric:D, Numeric:D)
-=end code
+    multi sub infix:<==>(Any, Any)
+    multi sub infix:<==>(Int:D, Int:D)
+    multi sub infix:<==>(Num:D, Num:D)
+    multi sub infix:<==>(Rational:D, Rational:D)
+    multi sub infix:<==>(Real:D, Real:D)
+    multi sub infix:<==>(Complex:D, Complex:D)
+    multi sub infix:<==>(Numeric:D, Numeric:D)
 
 X<Numeric equality operator>.
 
@@ -1410,9 +1310,7 @@ if they are equal.
 
 =head2 infix C«!=»
 
-=begin code :skip-test
-proto sub infix:<!=>(Mu, Mu) returns Bool:D is assoc<chain>
-=end code
+    sub infix:<!=>(Mu, Mu --> Bool:D)
 
 X<Numeric inequality operator>.
 
@@ -1421,12 +1319,9 @@ distinct.
 
 =head2 infix C«<»
 
-=begin code :skip-test
-proto sub infix:«<»(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:«<»(Int:D, Int:D)
-multi sub infix:«<»(Num:D, Num:D)
-multi sub infix:«<»(Real:D, Real:D)
-=end code
+    multi sub infix:«<»(Int:D, Int:D)
+    multi sub infix:«<»(Num:D, Num:D)
+    multi sub infix:«<»(Real:D, Real:D)
 
 X<Numeric less than operator>.
 
@@ -1435,13 +1330,9 @@ is smaller than the second.
 
 =head2 infix C«<=»
 
-=begin code :skip-test
-proto sub infix:«<=»(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:«<=»(Int:D, Int:D)
-multi sub infix:«<=»(Num:D, Num:D)
-multi sub infix:«<=»(Real:D, Real:D)
-=end code
-
+    multi sub infix:«<=»(Int:D, Int:D)
+    multi sub infix:«<=»(Num:D, Num:D)
+    multi sub infix:«<=»(Real:D, Real:D)
 
 X<Numeric less than or equal to operator>.
 
@@ -1451,12 +1342,9 @@ is smaller than or equal to the second.
 
 =head2 infix C«>»
 
-=begin code :skip-test
-proto sub infix:«>»(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:«>»(Int:D, Int:D)
-multi sub infix:«>»(Num:D, Num:D)
-multi sub infix:«>»(Real:D, Real:D)
-=end code
+    multi sub infix:«>»(Int:D, Int:D)
+    multi sub infix:«>»(Num:D, Num:D)
+    multi sub infix:«>»(Real:D, Real:D)
 
 X<Numeric greater than operator>.
 
@@ -1465,12 +1353,9 @@ is larger than the second.
 
 =head2 infix C«>=»
 
-=begin code :skip-test
-proto sub infix:«>=»(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:«>=»(Int:D, Int:D)
-multi sub infix:«>=»(Num:D, Num:D)
-multi sub infix:«>=»(Real:D, Real:D)
-=end code
+    multi sub infix:«>=»(Int:D, Int:D)
+    multi sub infix:«>=»(Num:D, Num:D)
+    multi sub infix:«>=»(Real:D, Real:D)
 
 X<Numeric greater than or equal to operator>.
 
@@ -1479,11 +1364,8 @@ the first argument is larger than or equal to the second.
 
 =head2 infix C«eq»
 
-=begin code :skip-test
-proto sub infix:<eq>(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:<eq>(Any,   Any)
-multi sub infix:<eq>(Str:D, Str:D)
-=end code
+    multi sub infix:<eq>(Any,   Any)
+    multi sub infix:<eq>(Str:D, Str:D)
 
 X<String equality operator>.
 
@@ -1494,11 +1376,8 @@ Mnemonic: I<equal>
 
 =head2 infix C«ne»
 
-=begin code :skip-test
-proto sub infix:<ne>(Mu, Mu) returns Bool:D is assoc<chain>
-multi sub infix:<ne>(Mu,    Mu)
-multi sub infix:<ne>(Str:D, Str:D)
-=end code
+    multi sub infix:<ne>(Mu,    Mu)
+    multi sub infix:<ne>(Str:D, Str:D)
 
 X<String inequality operator>.
 
@@ -1509,11 +1388,8 @@ Mnemonic: I<not equal>
 
 =head2 infix C«gt»
 
-=begin code :skip-test
-proto sub infix:<gt>(Mu, Mu) returns Bool:D is assoc<chain>
-multi sub infix:<gt>(Mu,    Mu)
-multi sub infix:<gt>(Str:D, Str:D)
-=end code
+    multi sub infix:<gt>(Mu,    Mu)
+    multi sub infix:<gt>(Str:D, Str:D)
 
 X<String greater than operator>.
 
@@ -1525,11 +1401,8 @@ Mnemonic: I<greater than>
 
 =head2 infix C«ge»
 
-=begin code :skip-test
-proto sub infix:<ge>(Mu, Mu) returns Bool:D is assoc<chain>
-multi sub infix:<ge>(Mu,    Mu)
-multi sub infix:<ge>(Str:D, Str:D)
-=end code
+    multi sub infix:<ge>(Mu,    Mu)
+    multi sub infix:<ge>(Str:D, Str:D)
 
 X<String greater than or equal to operator>.
 
@@ -1541,11 +1414,8 @@ Mnemonic: I<greater or equal>
 
 =head2 infix C«lt»
 
-=begin code :skip-test
-proto sub infix:<lt>(Mu, Mu) returns Bool:D is assoc<chain>
-multi sub infix:<lt>(Mu,    Mu)
-multi sub infix:<lt>(Str:D, Str:D)
-=end code
+    multi sub infix:<lt>(Mu,    Mu)
+    multi sub infix:<lt>(Str:D, Str:D)
 
 X<String less than operator>.
 
@@ -1557,11 +1427,8 @@ Mnemonic: I<less than>
 
 =head2 infix C«le»
 
-=begin code :skip-test
-proto sub infix:<le>(Mu, Mu) returns Bool:D is assoc<chain>
-multi sub infix:<le>(Mu,    Mu)
-multi sub infix:<le>(Str:D, Str:D)
-=end code
+    multi sub infix:<le>(Mu,    Mu)
+    multi sub infix:<le>(Str:D, Str:D)
 
 X<String less than or equal to operator>.
 
@@ -1573,36 +1440,27 @@ Mnemonic: I<less or equal>
 
 =head2 infix C«before»
 
-=begin code :skip-test
-proto sub infix:<before>(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:<before>(Any,       Any)
-multi sub infix:<before>(Real:D,    Real:D)
-multi sub infix:<before>(Str:D,     Str:D)
-multi sub infix:<before>(Version:D, Version:D)
-=end code
+    multi sub infix:<before>(Any,       Any)
+    multi sub infix:<before>(Real:D,    Real:D)
+    multi sub infix:<before>(Str:D,     Str:D)
+    multi sub infix:<before>(Version:D, Version:D)
 
 Generic ordering, uses the same semantics as L<cmp|#infix cmp>.
 Returns C<True> if the first argument is smaller than the second.
 
 =head2 infix C«after»
 
-=begin code :skip-test
-proto sub infix:<after>(Any, Any) returns Bool:D is assoc<chain>
-multi sub infix:<after>(Any,       Any)
-multi sub infix:<after>(Real:D,    Real:D)
-multi sub infix:<after>(Str:D,     Str:D)
-multi sub infix:<after>(Version:D, Version:D)
-=end code
+    multi sub infix:<after>(Any,       Any)
+    multi sub infix:<after>(Real:D,    Real:D)
+    multi sub infix:<after>(Str:D,     Str:D)
+    multi sub infix:<after>(Version:D, Version:D)
 
 Generic ordering, uses the same semantics as L<cmp|#infix cmp>.
 Returns C<True> if the first argument is larger than the second.
 
 =head2 infix C«eqv»
 
-=begin code :skip-test
-proto sub infix:<eqv>(Any, Any) returns Bool:D is assoc<chain>
-proto sub infix:<eqv>(Any, Any)
-=end code
+    sub infix:<eqv>(Any, Any)
 
 X<Equivalence operator>. Returns C<True> if the two arguments are structurally
 the same, i.e. from the same type and (recursively) contain the same values.
@@ -1633,10 +1491,7 @@ implement an appropriate infix C<eqv> operator:
 
 =head2 infix C«===»
 
-=begin code :skip-test
-proto sub infix:<===>(Any, Any) returns Bool:D is assoc<chain>
-proto sub infix:<===>(Any, Any)
-=end code
+    sub infix:<===>(Any, Any)
 
 X<Value identity operator>. Returns C<True> if both arguments are the same object.
 
@@ -1659,10 +1514,7 @@ types must override method C<WHICH>.
 
 =head2 infix C«=:=»
 
-=begin code :skip-test
-proto sub infix:<=:=>(Mu \a, Mu \b) returns Bool:D is assoc<chain>
-multi sub infix:<=:=>(Mu \a, Mu \b)
-=end code
+    multi sub infix:<=:=>(Mu \a, Mu \b)
 
 X<Container identity operator>. Returns C<True> if both arguments are bound to the same
 container. If it returns C<True>, it generally means that modifying one will
@@ -1700,16 +1552,13 @@ Here is an excerpt of built-in smart-matching functionality:
 
 =head2 infix C<=~=>
 
-=begin code :skip-test
-proto sub infix:<=~=>($, $) returns Bool:D is assoc:<chain>
-multi sub infix:<=~=>(Any, Any)
-multi sub infix:<=~=>(Int:D, Int:D)
-multi sub infix:<=~=>(Num:D, Num:D)
-multi sub infix:<=~=>(Rational:D, Rational:D)
-multi sub infix:<=~=>(Real:D, Real:D)
-multi sub infix:<=~=>(Complex:D, Complex:D)
-multi sub infix:<=~=>(Numeric:D, Numeric:D)
-=end code
+    multi sub infix:<=~=>(Any, Any)
+    multi sub infix:<=~=>(Int:D, Int:D)
+    multi sub infix:<=~=>(Num:D, Num:D)
+    multi sub infix:<=~=>(Rational:D, Rational:D)
+    multi sub infix:<=~=>(Real:D, Real:D)
+    multi sub infix:<=~=>(Complex:D, Complex:D)
+    multi sub infix:<=~=>(Numeric:D, Numeric:D)
 
 The X<approximately-equal operator|infix, ≅>. Calculates the relative difference between
 the left-hand and right-hand sides and returns C<True> if the difference is
@@ -1825,9 +1674,7 @@ returns the C<$false> branch.
 
 =head2 infix C«ff»
 
-=begin code :skip-test
-sub infix:<ff>(Mu $a, Mu $b)
-=end code
+    sub infix:<ff>(Mu $a, Mu $b)
 
 X<Flipflop operator>.
 
@@ -1880,9 +1727,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«^ff»
 
-=begin code :skip-test
-sub infix:<^ff>(Mu $a, Mu $b)
-=end code
+    sub infix:<^ff>(Mu $a, Mu $b)
 
 Works like L<C<ff>>, except it does not return C<True> for items matching the
 start condition (including items also matching the stop condition).
@@ -1899,9 +1744,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«ff^»
 
-=begin code :skip-test
-sub infix:<ff^>(Mu $a, Mu $b)
-=end code
+    sub infix:<ff^>(Mu $a, Mu $b)
 
 Works like L<C<ff>>, except it does not return C<True> for items matching the
 stop condition (including items that first matched the start condition).
@@ -1916,9 +1759,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«^ff^»
 
-=begin code :skip-test
-sub infix:<^ff^>(Mu $a, Mu $b)
-=end code
+    sub infix:<^ff^>(Mu $a, Mu $b)
 
 Works like L<C<ff>>, except it does not return C<True> for items matching either
 the stop or start condition (or both).
@@ -1933,9 +1774,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«fff»
 
-=begin code :skip-test
-sub infix:<fff>(Mu $a, Mu $b)
-=end code
+    sub infix:<fff>(Mu $a, Mu $b)
 
 Performs a sed-like flipflop operation, wherein it returns C<False> until the
 left argument smartmatches against C<$_>, and after that returns C<True> until
@@ -1957,9 +1796,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«^fff»
 
-=begin code :skip-test
-sub infix:<^fff>(Mu $a, Mu $b)
-=end code
+    sub infix:<^fff>(Mu $a, Mu $b)
 
 Like L<C<fff>>, except it does not return true for matches to the left argument.
 
@@ -1973,9 +1810,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«fff^»
 
-=begin code :skip-test
-sub infix:<fff^>(Mu $a, Mu $b)
-=end code
+    sub infix:<fff^>(Mu $a, Mu $b)
 
 Like L<C<fff>>, except it does not return true for matches to the right argument.
 
@@ -1989,9 +1824,7 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 
 =head2 infix C«^fff^»
 
-=begin code :skip-test
-sub infix:<^fff^>(Mu $a, Mu $b)
-=end code
+    sub infix:<^fff^>(Mu $a, Mu $b)
 
 Like L<C<fff>>, except it does not return true for matches to either the left or
 right argument.
@@ -2023,9 +1856,7 @@ C<=> is parsed as item assignment or list assignment operator).
 
 =head2 infix C«=>»
 
-=begin code :skip-test
-sub infix:«=>»($key, Mu $value) returns Pair:D
-=end code
+    sub infix:«=>»($key, Mu $value --> Pair:D)
 
 L<Pair> constructor.X<|pair constructor>
 
@@ -2049,9 +1880,7 @@ create C<Pair> objects.
 
 =head2 prefix C«not»
 
-=begin code :skip-test
-multi sub prefix:<not>(Mu $x) returns Bool:D
-=end code
+    multi sub prefix:<not>(Mu $x --> Bool:D)
 
 Evaluates its argument in boolean context (and thus collapses L<Junction>s),
 and negates the result. Please note that C<not> is easy to misuse, see
@@ -2060,9 +1889,7 @@ L<traps|/language/traps#Loose_boolean_operators>.
 
 =head2 prefix C«so»
 
-=begin code :skip-test
-multi sub prefix:<so>(Mu $x) returns Bool:D
-=end code
+    multi sub prefix:<so>(Mu $x --> Bool:D)
 
 Evaluates its argument in boolean context (and thus collapses L<Junction>s),
 and returns the result.
@@ -2071,9 +1898,7 @@ and returns the result.
 
 =head2 infix C«,»
 
-=begin code :skip-test
-sub infix:<,>(*@a) is assoc<list> returns List:D
-=end code
+    sub infix:<,>(*@a --> List:D) is assoc<list>
 
 Constructs a L<List> from its arguments. Also used syntactically as the
 separator of arguments in calls.
@@ -2084,9 +1909,7 @@ Used as an argument separator just like infix C<,> and marks the argument to
 its left as the invocant. That turns what would otherwise be a function call
 into a method call.
 
-=begin code :skip-test
-substr('abc': 1);       # same as 'abc'.substr(1)
-=end code
+    substr('abc': 1);       # same as 'abc'.substr(1)
 
 Infix C<:> is only allowed after the first argument of a non-method call. In
 other positions it's a syntax error.
@@ -2095,9 +1918,7 @@ other positions it's a syntax error.
 
 =head2 infix C«Z»
 
-=begin code :skip-test
-sub infix:<Z>(**@lists) returns Seq:D is assoc<chain>
-=end code
+    sub infix:<Z>(**@lists --> Seq:D) is assoc<chain>
 
 X<Zip operator>.
 
@@ -2120,9 +1941,7 @@ list:
 
 =head2 infix C«X»
 
-=begin code :skip-test
-sub infix:<X>(**@lists) returns List:D is assoc<chain>
-=end code
+    sub infix:<X>(**@lists --> List:D)
 
 Creates a cross product from all the lists, order so that the rightmost
 elements vary most rapidly:X<|cross product operator>
@@ -2142,10 +1961,8 @@ list:
 =head2 infix C«...»
 X<|...,operators>X<|…,operators>X<|lazy list,…>
 
-=begin code :skip-test
-multi sub infix:<...>(**@) is assoc<list>
-multi sub infix:<...^>(**@) is assoc<list>
-=end code
+    multi sub infix:<...>(**@) is assoc<list>
+    multi sub infix:<...^>(**@) is assoc<list>
 
 The X<sequence operator> is a generic operator to produce lazy lists.
 
@@ -2291,12 +2108,8 @@ that reduces using that operation.
 
 Reduction operators have the same associativity as the operators they are based on.
 
-=begin code
-
-say [-] 4, 3, 2;      # 4-3-2 = (4-3)-2 = -1
-say [**] 4, 3, 2;     # 4**3**2 = 4**(3**2) = 262144
-
-=end code
+    say [-] 4, 3, 2;      # 4-3-2 = (4-3)-2 = -1
+    say [**] 4, 3, 2;     # 4**3**2 = 4**(3**2) = 262144
 
 =head1 Loose AND precedence
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1209,11 +1209,13 @@ Instead of a role, you can provide an instantiated object. In this case,
 the operator will create a role for you automatically. The role will contain
 a single method named the same as C<$obj.^name> and that returns C<$obj>:
 
+    =begin code :skip-test
     say 42 but 'forty two'; # OUTPUT: «forty two␤»
 
     my $s = 12 but class Warbles { method hi { 'hello' } }.new;
     say $s.Warbles.hi;    # OUTPUT: «hello␤»
     say $s + 42;          # OUTPUT: «54␤»
+    =end code
 
 If methods of the same name are present already, the last mixed in role takes
 precedence. A list of methods can be provided in parentheses separated by

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -173,11 +173,13 @@ Interpolation of undefined values will raise a control exception that can be
 caught in the current block with
 L<CONTROL|https://docs.perl6.org/syntax/CONTROL>.
 
+    =begin code :skip-test
     sub niler {Nil};
     my Str $a = niler;
     say("$a.html", "sometext");
     say "alive"; # this line is dead code
     CONTROL { .die };
+    =end code
 
 =head2 Word quoting: qw
 X<|qw word quote>

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -145,29 +145,29 @@ To call a subroutine use the C<&>-sigil.
 X<|& (interpolation)>
 
     say "abc&uc("def")ghi";
-    # OUTPUT«abcDEFghi␤»
+    # OUTPUT: «abcDEFghi␤»
 
 Postcircumfix operators and therefore L<subscripts|/language/subscripts> are
 interpolated as well.
 
     my %h = :1st; say "abc%h<st>ghi";
-    # OUTPUT«abc1ghi␤»
+    # OUTPUT: «abc1ghi␤»
 
 To enter unicode sequences use C<\x> or C<\x[]> with the hex-code of the
 character or a list of characters.
 
     my $s = "I \x[2665] Perl 6!";
     dd $s;
-    # OUTPUT«Str $s = "I ♥ Perl 6!"␤»
+    # OUTPUT: «Str $s = "I ♥ Perl 6!"␤»
     my $s = "I really \x[2661,2665,2764,1f495] Perl 6!";
     dd $s;
-    # OUTPUT«Str $s = "I really ♡♥❤💕 Perl 6!"␤»
+    # OUTPUT: «Str $s = "I really ♡♥❤💕 Perl 6!"␤»
 
 You can also use unicode names with C<\c[]>.
 
     my $s = "Camelia \c[BROKEN HEART] my \c[HEAVY BLACK HEART]!";
     dd $s;
-    # OUTPUT«Str $s = "Str $s = "Camelia 💔 my ❤!"␤»
+    # OUTPUT: «Str $s = "Str $s = "Camelia 💔 my ❤!"␤»
 
 Interpolation of undefined values will raise a control exception that can be
 caught in the current block with
@@ -207,25 +207,25 @@ It's easier to write and to read this:
 X«|< > word quote»
 
 =for code :allow<B L> :skip-test
-B«<»a b cB«>» L<eqv> ('a', 'b', 'c');   # True
-B«<»a b 42B«>» L<eqv> ('a', 'b', '42'); # False, the 42 become an IntStr allomorph
-say < 42 > ~~ Int; # True
-say < 42 > ~~ Str; # Also True
+B«<»a b cB«>» L<eqv> ('a', 'b', 'c');   # OUTPUT: «True␤»
+B«<»a b 42B«>» L<eqv> ('a', 'b', '42'); # OUTPUT: «False␤», the 42 become an IntStr allomorph
+say < 42 > ~~ Int; # OUTPUT: «True␤»
+say < 42 > ~~ Str; # OUTPUT: «True␤»
 
 The angle brackets quoting is like C<qw>, but with extra feature that lets you
 construct L<allomorphs|/language/glossary#index-entry-Allomorph> or literals
 of certain numbers:
 
     say <42 4/2 1e6 1+1i abc>.perl;
-    # OUTPUT«(IntStr.new(42, "42"), RatStr.new(2.0, "4/2"), NumStr.new(1000000e0, "1e6"), ComplexStr.new(<1+1i>, "1+1i"), "abc")␤»
+    # OUTPUT: «(IntStr.new(42, "42"), RatStr.new(2.0, "4/2"), NumStr.new(1000000e0, "1e6"), ComplexStr.new(<1+1i>, "1+1i"), "abc")␤»
 
 To construct a L«C<Rat>|/type/Rat» or L«C<Complex>|/type/Complex» literal, use angle
 brackets around the number, without any extra spaces:
 
-    say <42/10>.^name;   # Rat
-    say <1+42i>.^name;   # Complex
-    say < 42/10 >.^name; # RatStr
-    say < 1+42i >.^name; # ComplexStr
+    say <42/10>.^name;   # OUTPUT: «Rat␤»
+    say <1+42i>.^name;   # OUTPUT: «Complex␤»
+    say < 42/10 >.^name; # OUTPUT: «RatStr␤»
+    say < 1+42i >.^name; # OUTPUT: «ComplexStr␤»
 
 Compared to C<42/10> and C<1+42i>, there's no division (or addition) operation
 involved. This is useful for literals in routine signatures, for example:
@@ -234,7 +234,7 @@ involved. This is useful for literals in routine signatures, for example:
     sub close-enough-π (<355/113>) {
         say "Your π is close enough!"
     }
-    close-enough-π 710/226; # Your π is close enough!
+    close-enough-π 710/226; # OUTPUT: «Your π is close enough!␤»
 
     # WRONG: can't do this, since it's a division operation
 
@@ -246,56 +246,56 @@ involved. This is useful for literals in routine signatures, for example:
 The C<qw> form of word quoting will treat quote characters literally, leaving them in the
 resulting words:
 
-    say qw{"a b" c}.perl; # ("\"a", "b\"", "c")
+    say qw{"a b" c}.perl; # OUTPUT: «("\"a", "b\"", "c")␤»
 
 Thus, if you wish to preserve quoted sub-strings as single items in the resulting words
 you need to use the C<qww> variant:
 
-    say qww{"a b" c}.perl; # ("a b", "c")
+    say qww{"a b" c}.perl; # OUTPUT: «("a b", "c")␤»
 
 =head2 X<Word quoting with interpolation: qqw|quote,qqw>
 
 The C<qw> form of word quoting doesn't interpolate variables:
 
-    my $a = 42; say qw{$a b c};  # $a b c
+    my $a = 42; say qw{$a b c};  # OUTPUT: «$a b c␤»
 
 Thus, if you wish for variables to be interpolated within the quoted string,
 you need to use the C<qqw> variant:
 
     my $a = 42;
     my @list = qqw{$a b c};
-    say @list;                # 42 b c
+    say @list;                # OUTPUT: «42 b c␤»
 
 Note that variable interpolation happens before word splitting:
 
     my $a = "a b";
     my @list = qqw{$a c};
-    .say for @list; # says "a", says "b", then says "c"
+    .say for @list; # OUTPUT: «a␤b␤c␤»
 
 =head2 X<<<Word quoting with interpolation and quote protection: qqww|quote,qqww;quote,<< >>;quote,« »>>>
 
 The C<qqw> form of word quoting will treat quote characters literally, leaving them in the
 resulting words:
 
-    my $a = 42; say qqw{"$a b" c}.perl; # ("\"42", "b\"", "c")
+    my $a = 42; say qqw{"$a b" c}.perl;  # OUTPUT: «("\"42", "b\"", "c")␤»
 
 Thus, if you wish to preserve quoted sub-strings as single items in the resulting words
 you need to use the C<qqww> variant:
 
-    my $a = 42; say qqww{"$a b" c}.perl; # ("42 b", "c")
+    my $a = 42; say qqww{"$a b" c}.perl; # OUTPUT: «("42 b", "c")␤»
 
 or equivalently:
 
-    my $a = 42; say <<"$a b" c>>.perl; # ("42 b", "c")
-    my $a = 42; say «"$a b" c».perl; # ("42 b", "c")
+    my $a = 42; say <<"$a b" c>>.perl;   # OUTPUT: «("42 b", "c")␤»
+    my $a = 42; say «"$a b" c».perl;     # OUTPUT: «("42 b", "c")␤»
 
 Quote protection happens before interpolation, and interpolation happens before word splitting,
 so quotes coming from inside interpolated variables are just literal quote characters:
 
     my $a = "1 2";
-    say qqww{"$a" $a}.perl; # ("1 2", "1", "2")
+    say qqww{"$a" $a}.perl; # OUTPUT: «("1 2", "1", "2")␤»
     my $b = "1 \"2 3\"";
-    say qqww{"$b" $b}.perl; # ("1 \"2 3\"", "1", "\"2", "3\"")
+    say qqww{"$b" $b}.perl; # OUTPUT: «("1 \"2 3\"", "1", "\"2", "3\"")␤»
 
 =head2 X<Shell quoting: qx|quote,qx>
 
@@ -324,7 +324,7 @@ The result of calling C<qx> is returned, so this information can be assigned
 to a variable for later use:
 
     my $output = qx{echo "hello!"};
-    say $output;    # hello!
+    say $output;    # OUTPUT: «hello!␤»
 
 See also L<shell|/routine/shell>, L<run|/routine/run> and L<Proc::Async> for
 other ways to execute external commands.
@@ -336,7 +336,7 @@ command, then the C<qqx> shell quoting construct should be used (this
 corresponds to Perl 5's C<qx>):
 
     my $world = "there";
-    say qqx{echo "hello $world"};  # hello there
+    say qqx{echo "hello $world"};  # OUTPUT: «hello there␤»
 
 Again, the output of the external command can be kept in a variable:
 
@@ -345,7 +345,7 @@ Again, the output of the external command can be kept in a variable:
     my $file = "/usr/share/dict/words";
     my $output = qqx{grep $option $word $file};
     # runs the command: grep -i cool /usr/share/dict/words
-    say $output;      # Cooley␤Cooley's␤Coolidge␤Coolidge's␤cool␤ ...
+    say $output;      # OUTPUT: «Cooley␤Cooley's␤Coolidge␤Coolidge's␤cool␤...»
 
 See also L<shell|/routine/shell> and L<run|/routine/run> for other ways to
 execute external commands.

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -44,9 +44,9 @@ Alphanumeric characters and the underscore C<_> are matched literally. All
 other characters must either be escaped with a backslash (for example, C<\:>
 to match a colon), or be within quotes:
 
-    / 'two words' /     # matches 'two words' including the blank
-    / "a:b"       /     # matches 'a:b' including the colon
-    / '#' /             # matches a hash character
+    / 'two words' /;     # matches 'two words' including the blank
+    / "a:b"       /;     # matches 'a:b' including the colon
+    / '#' /;             # matches a hash character
 
 Strings are searched left to right, so it's enough if only
 part of the string matches the regex:

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -52,11 +52,11 @@ Strings are searched left to right, so it's enough if only
 part of the string matches the regex:
 
     if 'abcdef' ~~ / de / {
-        say ~$/;            # de
-        say $/.prematch;    # abc
-        say $/.postmatch;   # f
-        say $/.from;        # 3
-        say $/.to;          # 5
+        say ~$/;            # OUTPUT: «de␤»
+        say $/.prematch;    # OUTPUT: «abc␤»
+        say $/.postmatch;   # OUTPUT: «f␤»
+        say $/.from;        # OUTPUT: «3␤»
+        say $/.to;          # OUTPUT: «5␤»
     };
 
 Match results are stored in the C<$/> variable and are also returned from
@@ -92,8 +92,8 @@ written with an upper-case letter, C<\W>.
 C<\d> matches a single digit (Unicode property C<N>) and C<\D> matches a
 single character that is not a digit.
 
-    'ab42' ~~ /\d/ and say ~$/;     # 4
-    'ab42' ~~ /\D/ and say ~$/;     # a
+    'ab42' ~~ /\d/ and say ~$/;     # OUTPUT: «4␤»
+    'ab42' ~~ /\D/ and say ~$/;     # OUTPUT: «a␤»
 
 Note that not only the Arabic digits (commonly used in the Latin alphabet)
 match C<\d>, but also digits from other scripts.
@@ -137,7 +137,7 @@ C<\s> matches a single whitespace character. C<\S> matches a single
 character that is not whitespace.
 
     if 'contains a word starting with "w"' ~~ / w \S+ / {
-        say ~$/;        # word
+        say ~$/;        # OUTPUT: «word␤»
     }
 
 =item X<\t and \T|regex,\t;regex,\T>
@@ -209,9 +209,9 @@ Category name. These use pair syntax.
 
 To match against a Unicode Property:
 
-    "a".uniprop('Script');                 # Latin
+    "a".uniprop('Script');                 # OUTPUT: «Latin␤»
     "a" ~~ / <:Script<Latin>> /;
-    "a".uniprop('Block');                  # Basic Latin
+    "a".uniprop('Block');                  # OUTPUT: «Basic Latin␤»
     "a" ~~ / <:Block('Basic Latin')> /;
 
 The following list of Unicode General Categories is stolen from the Perl 5
@@ -289,7 +289,7 @@ C<< <:Ll+:N> >> or C<< <:Ll+:Number> >> or C<< <+ :Lowercase_Letter + :Number> >
 It's also possible to group categories and sets of categories with
 parentheses; for example:
 
-    'perl6' ~~ m{\w+(<:Ll+:N>)}  # 0 => ｢6｣
+    'perl6' ~~ m{\w+(<:Ll+:N>)}  # OUTPUT: «0 => ｢6｣␤»
 
 =head2 X«Enumerated character classes and ranges|regex,<[ ]>;regex,<-[ ]>»
 
@@ -371,34 +371,34 @@ To quantify an atom an arbitrary number of times, you can write something like
 C<a ** 2..5> to match the character C<a> at least twice and at most 5 times.
 
 =begin code
-say so 'a' ~~ /a ** 2..5/;        # False
-say so  'aaa' ~~ /a ** 2..5/;     # True
+say so 'a' ~~ /a ** 2..5/;        # OUTPUT: «False␤»
+say so  'aaa' ~~ /a ** 2..5/;     # OUTPUT: «True␤»
 =end code
 
 If the minimal and maximal number of matches are the same, a single integer
 is possible: C<a ** 5> matches C<a> exactly five times.
 
 =begin code
-say so 'aaaaa' ~~ /a ** 5/;       # True
+say so 'aaaaa' ~~ /a ** 5/;       # OUTPUT: «True␤»
 =end code
 
 It's also possible to use non inclusive ranges using a caret:
 
 =begin code
-say so 'a'    ~~ /a ** 1^..^6/;   # False -- there are 2 to 5 'a's in a row
-say so 'aaaa' ~~ /a ** 1^..^6/;   # True
+say so 'a'    ~~ /a ** 1^..^6/;   # OUTPUT: «False␤» -- there are 2 to 5 'a's in a row
+say so 'aaaa' ~~ /a ** 1^..^6/;   # OUTPUT: «True␤»
 =end code
 
 This includes the numeric ranges starting from 0:
 
 =begin code
-say so 'aaa' ~~ /a ** ^6/;        # True -- there are 0 to 5 'a's in a row
+say so 'aaa' ~~ /a ** ^6/;        # OUTPUT: «True␤» -- there are 0 to 5 'a's in a row
 =end code
 
 or a Whatever C<*> operator for an infinite range with a non inclusive minimum:
 
 =begin code
-say so 'aaaa' ~~ /a ** 1^..*/;    # True -- there are 2 or more 'a's in a row
+say so 'aaaa' ~~ /a ** 1^..*/;    # OUTPUT: «True␤» -- there are 2 or more 'a's in a row
 =end code
 
 =head2 X<Modified quantifier: C<%>|regex,%;regex,%%>
@@ -414,14 +414,14 @@ To match those as well, use C<%%> instead of C<%>.
 By default, quantifiers request a greedy match:
 
 =begin code
-'abababa' ~~ /a .* a/ && say ~$/;   # abababa
+'abababa' ~~ /a .* a/ && say ~$/;   # OUTPUT: «abababa␤»
 =end code
 
 You can attach a C<?> modifier to the quantifier to enable frugal
 matching:
 
 =begin code
-'abababa' ~~ /a .*? a/ && say ~$/;   # aba
+'abababa' ~~ /a .*? a/ && say ~$/;   # OUTPUT: «aba␤»
 =end code
 
 You can also explicitly request greedy matching with the C<!> modifier.
@@ -432,8 +432,8 @@ You can prevent backtracking in regexes by attaching a C<:> modifier
 to the quantifier:
 
 =begin code
-say so 'abababa' ~~ /a .* aba/;    # True
-say so 'abababa' ~~ /a .*: aba/;   # False
+say so 'abababa' ~~ /a .* aba/;    # OUTPUT: «True␤»
+say so 'abababa' ~~ /a .*: aba/;   # OUTPUT: «False␤»
 =end code
 
 =head1 X<Alternation: C<||>|regex,||>
@@ -464,14 +464,14 @@ string of non-whitespace characters.
 In regexes branches separated by C<|>, the longest match wins, independent of
 the lexical ordering in the regexes.
 
-    say ('abc' ~~ / a | .b /).Str;    # ab
+    say ('abc' ~~ / a | .b /).Str;    # OUTPUT: «ab␤»
 
 =head1 Anchors
 
 The regex engine tries to find a match inside a string by searching from
 left to right.
 
-    say so 'properly' ~~ / perl/;   # True
+    say so 'properly' ~~ / perl/;   # OUTPUT: «True␤»
     #          ^^^^
 
 But sometimes this is not what you want. Instead, you may only want to
@@ -485,21 +485,21 @@ they do not use up characters while matching.
 
 The C<^> assertion only matches at the start of the string:
 
-    say so 'properly' ~~ /  perl/;    # True
-    say so 'properly' ~~ /^ perl/;    # False
-    say so 'perly'    ~~ /^ perl/;    # True
-    say so 'perl'     ~~ /^ perl/;    # True
+    say so 'properly' ~~ /  perl/;    # OUTPUT: «True␤»
+    say so 'properly' ~~ /^ perl/;    # OUTPUT: «False␤»
+    say so 'perly'    ~~ /^ perl/;    # OUTPUT: «True␤»
+    say so 'perl'     ~~ /^ perl/;    # OUTPUT: «True␤»
 
 The C<$> assertion only matches at the end of the string:
 
-    say so 'use perl' ~~ /  perl  /;   # True
-    say so 'use perl' ~~ /  perl $/;   # True
-    say so 'perly'    ~~ /  perl $/;   # False
+    say so 'use perl' ~~ /  perl  /;   # OUTPUT: «True␤»
+    say so 'use perl' ~~ /  perl $/;   # OUTPUT: «True␤»
+    say so 'perly'    ~~ /  perl $/;   # OUTPUT: «False␤»
 
 You can combine both assertions:
 
-    say so 'use perl' ~~ /^ perl $/;   # False
-    say so 'perl'     ~~ /^ perl $/;   # True
+    say so 'use perl' ~~ /^ perl $/;   # OUTPUT: «False␤»
+    say so 'perl'     ~~ /^ perl $/;   # OUTPUT: «True␤»
 
 Keep in mind that C<^> matches the start of a B<string>, not the start of a B<line>.
 Likewise, C<$> matches the end of a B<string>, not the end of a B<line>.
@@ -511,10 +511,10 @@ The following is a multi-line string:
        and keep it safe
        EOS
 
-    say so $str ~~ /safe   $/;   # True  -- 'safe' is at the end of the string
-    say so $str ~~ /secret $/;   # False -- 'secret' is at the end of a line -- not the string
-    say so $str ~~ /^Keep   /;   # True  -- 'Keep' is at the start of the string
-    say so $str ~~ /^and    /;   # False -- 'and' is at the start of a line -- not the string
+    say so $str ~~ /safe   $/;   # OUTPUT: «True␤»  -- 'safe' is at the end of the string
+    say so $str ~~ /secret $/;   # OUTPUT: «False␤» -- 'secret' is at the end of a line -- not the string
+    say so $str ~~ /^Keep   /;   # OUTPUT: «True␤»  -- 'Keep' is at the start of the string
+    say so $str ~~ /^and    /;   # OUTPUT: «False␤» -- 'and' is at the start of a line -- not the string
 
 =head2 X«C<^^>, Start of Line and C<$$>, End of Line|regex,^^;regex,$$»
 
@@ -540,16 +540,16 @@ my $str = q:to/EOS/;
     I always try to fit as many syllables into the last line as ever I possibly can."
     EOS
 
-say so $str ~~ /^^ There/;        # True  -- start of string
-say so $str ~~ /^^ limericks/;    # False -- not at the start of a line
-say so $str ~~ /^^ I/;            # True  -- start of the last line
-say so $str ~~ /^^ When/;         # False -- there are blanks between
-                                  #          start of line and the "When"
+say so $str ~~ /^^ There/;        # OUTPUT: «True␤»  -- start of string
+say so $str ~~ /^^ limericks/;    # OUTPUT: «False␤» -- not at the start of a line
+say so $str ~~ /^^ I/;            # OUTPUT: «True␤»  -- start of the last line
+say so $str ~~ /^^ When/;         # OUTPUT: «False␤» -- there are blanks between
+                                  #                       start of line and the "When"
 
-say so $str ~~ / Japan $$/;       # True  -- end of first line
-say so $str ~~ / scan $$/;        # False -- there's a . between "scan"
-                                  #          and the end of line
-say so $str ~~ / '."' $$/;        # True  -- at the last line
+say so $str ~~ / Japan $$/;       # OUTPUT: «True␤»  -- end of first line
+say so $str ~~ / scan $$/;        # OUTPUT: «False␤» -- there's a . between "scan"
+                                  #                      and the end of line
+say so $str ~~ / '."' $$/;        # OUTPUT: «True␤»  -- at the last line
 =end code
 
 
@@ -571,18 +571,18 @@ is a word character at the left and a non-word character at the right (or
 the end of the string).
 
     my $str = 'The quick brown fox';
-    say so $str ~~ /br/;              # True
-    say so $str ~~ /<< br/;           # True
-    say so $str ~~ /br >>/;           # False
-    say so $str ~~ /own/;             # True
-    say so $str ~~ /<< own/;          # False
-    say so $str ~~ /own >>/;          # True
+    say so $str ~~ /br/;              # OUTPUT: «True␤»
+    say so $str ~~ /<< br/;           # OUTPUT: «True␤»
+    say so $str ~~ /br >>/;           # OUTPUT: «False␤»
+    say so $str ~~ /own/;             # OUTPUT: «True␤»
+    say so $str ~~ /<< own/;          # OUTPUT: «False␤»
+    say so $str ~~ /own >>/;          # OUTPUT: «True␤»
 
 You can also use the variants C<«> and C<»> :
 
     my $str = 'The quick brown fox';
-    say so $str ~~ /« own/;          # False
-    say so $str ~~ /own »/;          # True
+    say so $str ~~ /« own/;          # OUTPUT: «False␤»
+    say so $str ~~ /own »/;          # OUTPUT: «True␤»
 
 =head1 X«Grouping and Capturing|regex,( );regex,[ ];regex,$<capture> =»
 
@@ -590,7 +590,7 @@ In regular (non-regex) Perl 6, you can use parentheses to group things
 together, usually to override operator precedence:
 
     say 1 + 4 * 2;      # 9, parsed as 1 + (4 * 2)
-    say (1 + 4) * 2;    # 10
+    say (1 + 4) * 2;    # OUTPUT: «10␤»
 
 The same grouping facility is available in regexes:
 
@@ -623,7 +623,7 @@ an element of the resulting L<Match|/type/Match> object:
 Pairs of parentheses are numbered left to right, starting from zero.
 
     if 'abc' ~~ /(a) b (c)/ {
-        say "0: $0; 1: $1";             # 0: a; 1: c
+        say "0: $0; 1: $1";             # OUTPUT: «0: a; 1: c␤»
     }
 
 The C<$0> and C<$1> etc. syntax is shorthand. These captures
@@ -634,7 +634,7 @@ Coercing the match object to a list gives an easy way to programmatically
 access all elements:
 
     if 'abc' ~~ /(a) b (c)/ {
-        say $/.list.join: ', '  # a, c
+        say $/.list.join: ', '  # OUTPUT: «a, c␤»
     }
 
 =head2 Non-capturing grouping
@@ -646,7 +646,7 @@ To get only the grouping behavior, you can use square brackets C<[ ... ]>
 instead.
 
     if 'abc' ~~ / [a||b] (c) / {
-        say ~$0;                # c
+        say ~$0;                # OUTPUT: «c␤»
     }
 
 If you do not need the captures, using non-capturing groups provides three
@@ -699,7 +699,7 @@ Instead of numbering captures, you can also give them names. The generic --
 and slightly verbose -- way of naming captures is like this:
 
     if 'abc' ~~ / $<myname> = [ \w+ ] / {
-        say ~$<myname>      # abc
+        say ~$<myname>      # OUTPUT: «abc␤»
     }
 
 The access to the named capture, C<< $<myname> >>, is a shorthand for indexing
@@ -708,8 +708,8 @@ the match object as a hash, in other words: C<$/{ 'myname' }> or C<< $/<myname> 
 Named captures can also be nested using regular capture group syntax:
 
     if 'abc-abc-abc' ~~ / $<string>=( [ $<part>=[abc] ]* % '-' ) / {
-        say ~$<string>;         # abc-abc-abc
-        say ~$<string><part>;   # [abc, abc, abc]
+        say ~$<string>;         # OUTPUT: «abc-abc-abc␤»
+        say ~$<string><part>;   # OUTPUT: «[abc, abc, abc]␤»
     }
 
 Coercing the match object to a hash gives you easy programmatic access to
@@ -717,8 +717,8 @@ all named captures:
 
     if 'count=23' ~~ / $<variable>=\w+ '=' $<value>=\w+ / {
         my %h = $/.hash;
-        say %h.keys.sort.join: ', ';        # value, variable
-        say %h.values.sort.join: ', ';      # 23, count
+        say %h.keys.sort.join: ', ';        # OUTPUT: «value, variable␤»
+        say %h.values.sort.join: ', ';      # OUTPUT: «23, count␤»
         for %h.kv -> $k, $v {
             say "Found value '$v' with key '$k'";
             # outputs two lines:
@@ -778,7 +778,7 @@ you want to replace it with goes on the right-hand side; for example:
 
     $_ = 'The Replacements';
     s/Replace/Entrap/;
-    .say;                    # The Entrapments
+    .say;                    # OUTPUT: «The Entrapments␤»
 
 Alphanumeric characters and the underscore are literal matches, just as in its
 cousin the C<m//> operator. All other characters must be escaped with a
@@ -786,7 +786,7 @@ backslash C<\> or included in quotes:
 
     $_ = 'Space: 1999';
     s/Space\:/Party like it's/;
-    .say                        # Party like it's 1999
+    .say                        # OUTPUT: «Party like it's 1999␤»
 
 Note that the matching restrictions only apply to the left-hand side of the
 substitution expression.
@@ -795,7 +795,7 @@ By default, substitutions are only done on the first match:
 
     $_ = 'There can be twly two';
     s/tw/on/;                     # replace 'tw' with 'on' once
-    .say;                         # there can be only two
+    .say;                         # OUTPUT: «there can be only two␤»
 
 =head2 Wildcards and character classes
 
@@ -806,7 +806,7 @@ a number in the middle of a string:
 
     $_ = "Blake's 9";
     s/\d+/7/;         # replace any sequence of digits with '7'
-    .say;             # Blake's 7
+    .say;             # OUTPUT: «Blake's 7␤»
 
 Of course, you can use any of the C<+>, C<*> and C<?> modifiers, and they'll
 behave just as they would in the C<m//> operator's context.
@@ -819,9 +819,9 @@ C<$/> object:
 
     $_ = '2016-01-23 18:09:00';
     s/ (\d+)\-(\d+)\-(\d+) /today/;   # replace YYYY-MM-DD with 'today'
-    .say;                             # today 18:09:00
-    "$1-$2-$0".say;                   # 01-23-2016
-    "$/[1]-$/[2]-$/[0]".say;          # 01-23-2016
+    .say;                             # OUTPUT: «today 18:09:00␤»
+    "$1-$2-$0".say;                   # OUTPUT: «01-23-2016␤»
+    "$/[1]-$/[2]-$/[0]".say;          # OUTPUT: «01-23-2016␤»
 
 Any of these variables C<$0>, C<$1>, C<$/> can be used on the right-hand side
 of the operator as well, so you can manipulate what you've just matched. This
@@ -830,14 +830,14 @@ reformat them into C<MM-DD-YYYY> order:
 
     $_ = '2016-01-23 18:09:00';
     s/ (\d+)\-(\d+)\-(\d+) /$1-$2-$0/;    # transform YYYY-MM-DD to MM-DD-YYYY
-    .say;                                 # 01-23-2016 18:09:00
+    .say;                                 # OUTPUT: «01-23-2016 18:09:00␤»
 
 Since the right-hand side is effectively a regular Perl 6 interpolated string,
 you can reformat the time from C<HH:MM> to C<h:MM {AM,PM}> like so:
 
     $_ = '18:38';
     s/(\d+)\:(\d+)/{$0 % 12}\:$1 {$0 < 12 ?? 'AM' !! 'PM'}/;
-    .say;                                                    # 6:38 PM
+    .say;                                                    # OUTPUT: «6:38 PM␤»
 
 Using the modulo C<%> operator above keeps the sample code under 80 characters,
 but is otherwise the same as C« $0 < 12 ?? $0 !! $0 - 12 ». When combined with
@@ -859,7 +859,7 @@ everywhere possible. Substitutions are non-recursive; for example:
 
     $_ = q{I can say "banana" but I don't know when to stop};
     s:g/na/nana,/;    # substitute 'nana,' for 'na'
-    .say;             # I can say "banana,nana," but I don't ...
+    .say;             # OUTPUT: «I can say "banana,nana," but I don't ...␤»
 
 Here, C<na> was found twice in the original string and each time there was a
 substitution. The substitution only
@@ -873,10 +873,10 @@ case-insensitive.
 
     $_ = 'Fruit';
     s/fruit/vegetable/;
-    .say;                          # Fruit
+    .say;                          # OUTPUT: «Fruit␤»
 
     s:i/fruit/vegetable/;
-    .say;                          # vegetable
+    .say;                          # OUTPUT: «vegetable␤»
 
 For more information on what these adverbs are actually
 doing, refer to the L<section Adverbs|#Adverbs> section of this document.
@@ -899,7 +899,7 @@ pieces of regex into named rules.
 
     my regex line { \N*\n }
     if "abc\ndef" ~~ /<line> def/ {
-        say "First line: ", $<line>.chomp;      # First line: abc
+        say "First line: ", $<line>.chomp;      # OUTPUT: «First line: abc␤»
     }
 
 A named regex can be declared with C<my regex regex_name { body here }>, and
@@ -942,8 +942,8 @@ files:
         }
     }
     say %config.perl;
-    # ("passwords" => {"jack" => "password1", "joy" => "muchmoresecure123"},
-    #    "quotas" => {"jack" => "123", "joy" => "42"}).hash
+    # OUTPUT: «("passwords" => {"jack" => "password1", "joy" => "muchmoresecure123"},␤
+    #          "quotas" => {"jack" => "123", "joy" => "42"}).hash»
 
 Named regexes can and should be grouped in L<grammars|/language/grammars>. A
 list of predefined subrules is listed in
@@ -977,9 +977,7 @@ like C<:overlap> are appended to the match call:
     for 'baA'.match($regex, :overlap) -> $m {
         say ~$m;
     }
-    # output:
-    #     ba
-    #     aA
+    # OUTPUT: «ba␤aA␤»
 
 =head2 X<Regex Adverbs|regex adverb,:ignorecase;regex adverb,:i>
 
@@ -1022,8 +1020,8 @@ matching only C<ab>, and the C<.> can successfully match the string C<c>.
 This process of giving up characters (or in the case of alternations, trying
 a different branch) is known as backtracking.
 
-    say so 'abc' ~~ / \w+ . /;        # True
-    say so 'abc' ~~ / :r \w+ . /;     # False
+    say so 'abc' ~~ / \w+ . /;        # OUTPUT: «True␤»
+    say so 'abc' ~~ / :r \w+ . /;     # OUTPUT: «False␤»
 
 Ratcheting can be an optimization, because backtracking is costly. But more
 importantly, it closely corresponds to how humans parse a text. If you have
@@ -1053,9 +1051,9 @@ The B<C<:sigspace>> or B<C<:s>> adverb makes whitespace significant in a
 regex.
 
     =begin code :allow<B> :skip-test
-    say so "I used Photoshop®"   ~~ m:i/   photo shop /;      # True
-    say so "I used a photo shop" ~~ m:iB<:s>/ photo shop /;   # True
-    say so "I used Photoshop®"   ~~ m:iB<:s>/ photo shop /;   # False
+    say so "I used Photoshop®"   ~~ m:i/   photo shop /;      # OUTPUT: «True␤»
+    say so "I used a photo shop" ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «True␤»
+    say so "I used Photoshop®"   ~~ m:iB<:s>/ photo shop /;   # OUTPUT: «False␤»
     =end code
 
 C<m:s/ photo shop /> acts the same as
@@ -1131,12 +1129,12 @@ Grammars provide an easy way to override what C«<.ws>» matches:
     }
 
     # doesn't parse, whitespace required between a and b
-    say so Demo.parse("ab.");                 # False
-    say so Demo.parse("a b.");                # True
-    say so Demo.parse("a\tb .");              # True
+    say so Demo.parse("ab.");                 # OUTPUT: «False␤»
+    say so Demo.parse("a b.");                # OUTPUT: «True␤»
+    say so Demo.parse("a\tb .");              # OUTPUT: «True␤»
 
     # \n is vertical whitespace, so no match
-    say so Demo.parse("a\tb\n.");             # False
+    say so Demo.parse("a\tb\n.");             # OUTPUT: «False␤»
 
 When parsing file formats where some whitespace (for example, vertical
 whitespace) is significant, it's advisable to override C<ws>.
@@ -1158,15 +1156,15 @@ specified for C<:c>, it will default to C<0> unless C<$/> is set, in which
 case, it defaults to C<$/.to>.
 
     given 'a1xa2' {
-        say ~m/a./;         # a1
-        say ~m:c(2)/a./;    # a2
+        say ~m/a./;         # OUTPUT: «a1␤»
+        say ~m:c(2)/a./;    # OUTPUT: «a2␤»
     }
 
 I<Note:> unlike C<:pos>, a match with :continue() will attempt to
 match further in the string, instead of failing:
 
-    say "abcdefg" ~~ m:c(3)/e.+/; # OUTPUT«｢efg｣␤»
-    say "abcdefg" ~~ m:p(3)/e.+/; # OUTPUT«False␤»
+    say "abcdefg" ~~ m:c(3)/e.+/; # OUTPUT: «｢efg｣␤»
+    say "abcdefg" ~~ m:p(3)/e.+/; # OUTPUT: «False␤»
 
 =head3 X<Exhaustive|matching adverb,:exhaustive;matching adverb,:ex>
 
@@ -1204,8 +1202,8 @@ adverb:
 
     given 'several words here' {
         my @matches = m:global/\w+/;
-        say @matches.elems;         # 3
-        say ~@matches[2];           # here
+        say @matches.elems;         # OUTPUT: «3␤»
+        say ~@matches[2];           # OUTPUT: «here␤»
     }
 
 C<:g> is shorthand for C<:global>.
@@ -1216,8 +1214,8 @@ Anchor the match at a specific position in the string:
 
     given 'abcdef' {
         my $match = m:pos(2)/.*/;
-        say $match.from;        # 2
-        say ~$match;            # cdef
+        say $match.from;        # OUTPUT: «2␤»
+        say ~$match;            # OUTPUT: «cdef␤»
     }
 
 C<:p> is shorthand for C<:pos>.
@@ -1225,8 +1223,8 @@ C<:p> is shorthand for C<:pos>.
 I<Note:> unlike C<:continue>, a match anchored with :pos() will fail,
 instead of attempting to match further down the string:
 
-    say "abcdefg" ~~ m:c(3)/e.+/; # OUTPUT«｢efg｣␤»
-    say "abcdefg" ~~ m:p(3)/e.+/; # OUTPUT«False␤»
+    say "abcdefg" ~~ m:c(3)/e.+/; # OUTPUT: «｢efg｣␤»
+    say "abcdefg" ~~ m:p(3)/e.+/; # OUTPUT: «False␤»
 
 =head3 X<Overlap|regex adverb,:overlap;regex adverb,:ov>
 
@@ -1265,7 +1263,7 @@ string C<bar>, use the following regexp:
 
 For example:
 
-    say "foobar" ~~ rx{ foo <?before bar> };   #->  foo
+    say "foobar" ~~ rx{ foo <?before bar> };   # OUTPUT: «foo␤»
 
 However, if you want to search for a pattern which is B<not> immediately
 followed by some pattern, then you need to use a negative lookahead
@@ -1292,7 +1290,7 @@ string C<foo>, use the following regexp:
 
 For example:
 
-    say "foobar" ~~ rx{ <?after foo> bar };   #->  bar
+    say "foobar" ~~ rx{ <?after foo> bar };   # OUTPUT: «bar␤»
 
 However, if you want to search for a pattern which is B<not> immediately
 preceded by some pattern, then you need to use a negative lookbehind

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -28,9 +28,9 @@ collection by their position. Index 0 refers to the first element, index 1 to
 the second, and so on:
 
     my @chores = "buy groceries", "feed dog", "wash car";
-    say @chores[0];  #-> buy groceries
-    say @chores[1];  #-> feed dog
-    say @chores[2];  #-> wash car
+    say @chores[0];  # OUTPUT: «buy groceries␤»
+    say @chores[1];  # OUTPUT: «feed dog␤»
+    say @chores[2];  # OUTPUT: «wash car␤»
 =end item1
 
 =begin item1
@@ -46,7 +46,7 @@ allows arbitrary objects as keys, etc.:
     say %grade{"Ben"};  # OUTPUT: «B+␤»
 
     my $stats = ( Date.today => 4.18, Date.new(2015,  4,  5) => 17.253 ).Mix;
-    say $stats{ Date.new(2015, 4, 4) + 1 };  #-> 17.253
+    say $stats{ Date.new(2015, 4, 4) + 1 };  # OUTPUT: «17.253␤»
 
 For passing single-word string keys to C<{ }>, you can also use the
 L<angle-bracketed word quoting constructs|/language/quoting#Word_quoting:_qw>

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -42,8 +42,8 @@ question: For example a standard L<Hash> uses string keys, whereas a L<Mix>
 allows arbitrary objects as keys, etc.:
 
     my %grade = Zoe => "C", Ben => "B+";
-    say %grade{"Zoe"};  #-> C
-    say %grade{"Ben"};  #-> B+
+    say %grade{"Zoe"};  # OUTPUT: «C␤»
+    say %grade{"Ben"};  # OUTPUT: «B+␤»
 
     my $stats = ( Date.today => 4.18, Date.new(2015,  4,  5) => 17.253 ).Mix;
     say $stats{ Date.new(2015, 4, 4) + 1 };  #-> 17.253
@@ -53,8 +53,8 @@ L<angle-bracketed word quoting constructs|/language/quoting#Word_quoting:_qw>
 as if they were postcircumfix operators:
 
     my %grade = Zoe => "C", Ben => "B+";
-    say %grade<Zoe>;    #-> C
-    say %grade<Ben>;    #-> B+
+    say %grade<Zoe>;    # OUTPUT: «C␤»
+    say %grade<Ben>;    # OUTPUT: «B+␤»
 
 This is really just syntactic sugar that gets turned into the corresponding
 C<{ }> form at compile-time:
@@ -80,12 +80,12 @@ default C<Hash>, subscripts coerce keys into strings, as long as
 those keys produce something C<Cool>.  You can use C<.perl> on a
 collection to be sure whether the keys are strings or objects:
 
-    ( 1  => 1 ).perl.say;            #-> 1 => 1
-    my %h; %h{1}   = 1; say %h.perl; #-> { "1" => 1 }
-    ( 1/2 => 1 ).perl.say;           #-> 0.5 => 1
-    my %h; %h{1/2} = 1; say %h.perl; #-> { "0.5" => 1 }
-    ( pi => 1 ).perl.say;            #-> :pi(1)
-    my %h; %h{pi}  = 1; say %h.perl; #-> { "3.14159265358979" => 1 }
+    ( 1  => 1 ).perl.say;            # OUTPUT: «1 => 1␤»
+    my %h; %h{1}   = 1; say %h.perl; # OUTPUT: «{ "1" => 1 }␤»
+    ( 1/2 => 1 ).perl.say;           # OUTPUT: «0.5 => 1␤»
+    my %h; %h{1/2} = 1; say %h.perl; # OUTPUT: «{ "0.5" => 1 }␤»
+    ( pi => 1 ).perl.say;            # OUTPUT: «:pi(1)␤»
+    my %h; %h{pi}  = 1; say %h.perl; # OUTPUT: «{ "3.14159265358979" => 1 }␤»
 
 While the invisible quotes around single names is built into C<< => >>,
 string conversion is not built into the curly braces: it is a behavior
@@ -93,7 +93,7 @@ of the default C<Hash>.  Not all types of hashes or collections
 do so:
 
     my %h := MixHash.new;
-    %h{pi} = 1; %h.perl.say;         #-> (3.14159265358979e0=>1).MixHash
+    %h{pi} = 1; %h.perl.say;         # OUTPUT: «(3.14159265358979e0=>1).MixHash␤»
 
 (Any name that C<< => >> would convert to a string can also be used to build
 a pair using "adverbial notation" and will appear that way when viewed
@@ -104,7 +104,7 @@ through C<.perl>, which is why we see C<:pi(1)> above.)
 Subscripts can be applied to any expression that returns a subscriptable
 object, not just to variables:
 
-    say "__Hello__".match(/__(.*)__/)[0];   #-> ｢Hello｣
+    say "__Hello__".match(/__(.*)__/)[0];   # OUTPUT: «｢Hello｣␤»
     say "__Hello__".match(/__(.*)__/).[0];  # same, in method notation
 
 Positional and associative subscripting are not mutually exclusive - for
@@ -115,7 +115,7 @@ invocant as a list of one element. (But there's no such fallback for
 associative subscripts, so they throw a run-time error when applied to an
 object that does not implement support for them.)
 
-    say 42[0];    #-> 42
+    say 42[0];    # OUTPUT: «42␤»
     say 42<foo>;  # ERROR: postcircumfix { } not defined for type Int
 
 =head1 Nonexistent elements
@@ -125,18 +125,18 @@ to the collection type in question. Standard L<Array> and L<Hash> collections
 return the type object of their L<value type constraint|of> (which, by default,
 is L<Any>):
 
-    my @array1;     say @array1[10];  #-> (Any)
-    my Int @array2; say @array2[10];  #-> (Int)
+    my @array1;     say @array1[10];  # OUTPUT: «(Any)␤»
+    my Int @array2; say @array2[10];  # OUTPUT: «(Int)␤»
 
-    my %hash1;      say %hash1<foo>;  #-> (Any)
-    my Int %hash2;  say %hash2<foo>;  #-> (Int)
+    my %hash1;      say %hash1<foo>;  # OUTPUT: «(Any)␤»
+    my Int %hash2;  say %hash2<foo>;  # OUTPUT: «(Int)␤»
 
 However, other types of collections may react differently to subscripts that
 address nonexistent elements:
 
-    say (0, 10, 20)[3];           #-> Nil
-    say bag(<a a b b b>)<c>;      #-> 0
-    say array[uint8].new(1, 2)[2] #-> 0
+    say (0, 10, 20)[3];           # OUTPUT: «Nil␤»
+    say bag(<a a b b b>)<c>;      # OUTPUT: «0␤»
+    say array[uint8].new(1, 2)[2] # OUTPUT: «0␤»
 
 To silently skip nonexistent elements in a subscripting operation, see
 L<#Truncating slices> and the L<#:v> adverb.
@@ -149,9 +149,9 @@ C<*-1> refers to the last element, C<*-2> to the second-to-last element, and so
 on.
 
     my @alphabet = 'A' .. 'Z';
-    say @alphabet[*-1];  #-> Z
-    say @alphabet[*-2];  #-> Y
-    say @alphabet[*-3];  #-> X
+    say @alphabet[*-1];  # OUTPUT: «Z␤»
+    say @alphabet[*-2];  # OUTPUT: «Y␤»
+    say @alphabet[*-3];  # OUTPUT: «X␤»
 
 Note: The asterisk is important. Passing a bare negative integer (e.g.
 C<@alphabet[-1]>) like you would do in many other programming languages, throws
@@ -183,14 +183,14 @@ For positional slices, you can mix normal indices with
 L<from-the-end|#From the end> ones:
 
     my @alphabet = 'a' .. 'z';
-    dd @alphabet[15, 4, *-9, 11];  #-> ("p", "e", "r", "l")
+    dd @alphabet[15, 4, *-9, 11];  # OUTPUT: «("p", "e", "r", "l")␤»
 
 For associative slices, the angle-brackets form often comes in handy:
 
     my %color = kiwi => "green", banana => "yellow", cherry => "red";
-    dd %color{"cherry", "kiwi"};  #-> ("red", "green")
-    dd %color<cherry kiwi>;       #-> ("red", "green")
-    dd %color{*};                 #-> ("green", "red", "yellow")
+    dd %color{"cherry", "kiwi"};  # OUTPUT: «("red", "green")␤»
+    dd %color<cherry kiwi>;       # OUTPUT: «("red", "green")␤»
+    dd %color{*};                 # OUTPUT: «("green", "red", "yellow")␤»
 
 Be aware that slices are controlled by the I<type> of what is passed to
 (L<one dimension of|#Multiple dimensions>) the subscript, not its length:
@@ -217,8 +217,8 @@ Be aware that slices are controlled by the I<type> of what is passed to
 So even a one-element list returns a slice, whereas a bare scalar value doesn't:
 
     =begin code :skip-test
-    dd @alphabet[2,];  #-> ("c",)
-    dd @alphabet[2];   #-> "c"
+    dd @alphabet[2,];  # OUTPUT: «("c",)␤»
+    dd @alphabet[2];   # OUTPUT: «"c"␤»
     =end code
 
 (The angle-bracket form for associative subscripts works out because
@@ -230,10 +230,10 @@ dimensions>) the subscript is preserved across the slice operation
 (but the kind of Iterable is not – the result is always just lists.)
 
     =begin code :skip-test
-    dd @alphabet[0, (1..2, (3,))];  #-> ("a", (("b", "c"), ("d",)))
-    dd @alphabet[0, (1..2, [3,])];  #-> ("a", (("b", "c"), ("d",)))
-    dd @alphabet[flat 0, (1..2, (3,))];  #-> ("a", "b", "c", "d")
-    dd flat @alphabet[0, (1..2, (3,))];  #-> ("a", "b", "c", "d")
+    dd @alphabet[0, (1..2, (3,))];  # OUTPUT: «("a", (("b", "c"), ("d",)))␤»
+    dd @alphabet[0, (1..2, [3,])];  # OUTPUT: «("a", (("b", "c"), ("d",)))␤»
+    dd @alphabet[flat 0, (1..2, (3,))];  # OUTPUT: «("a", "b", "c", "d")␤»
+    dd flat @alphabet[0, (1..2, (3,))];  # OUTPUT: «("a", "b", "c", "d")␤»
     =end code
 
 =head2 Truncating slices
@@ -247,8 +247,8 @@ L<Range>, it will be automatically truncated to the actual size of the
 collection:
 
     my @letters = <a b c d e f>;
-    dd @letters[3, 4, 5, 6, 7];  #-> ("d", "e", "f", Any, Any)
-    dd @letters[3 .. 7];         #-> ("d", "e", "f")
+    dd @letters[3, 4, 5, 6, 7];  # OUTPUT: «("d", "e", "f", Any, Any)␤»
+    dd @letters[3 .. 7];         # OUTPUT: «("d", "e", "f")␤»
 
 L<From-the-end|#From the end> indices are allowed as range end-points.
 
@@ -276,8 +276,8 @@ than used for effect:
 
     =begin code :skip-test
     my @a = 2, 3 ... *;
-    dd flat @letters[0, 7, @a]; #-> ("a", Any, "c", "d", "e", "f")
-    dd flat @letters[0, 7, @a]; #-> ("a", Any, "c", "d", "e", "f", Any)
+    dd flat @letters[0, 7, @a]; # OUTPUT: «("a", Any, "c", "d", "e", "f")␤»
+    dd flat @letters[0, 7, @a]; # OUTPUT: «("a", Any, "c", "d", "e", "f", Any)␤»
     =end code
 
 The runaway protection is not perfect.  The indices are eagerly evaluated,
@@ -312,16 +312,16 @@ always returns a List of elements no matter the type of the original object)
 and from passing an empty list (which returns an empty slice):
 
     my %bag := ("orange" => 1, "apple" => 3).Bag;
-    dd %bag<>;    #-> ("orange"=>1,"apple"=>3).Bag
-    dd %bag{};    #-> ("orange"=>1,"apple"=>3).Bag
-    dd %bag{*};   #-> (1, 3)
-    dd %bag{()};  #-> ()
+    dd %bag<>;    # OUTPUT: «("orange"=>1,"apple"=>3).Bag␤»
+    dd %bag{};    # OUTPUT: «("orange"=>1,"apple"=>3).Bag␤»
+    dd %bag{*};   # OUTPUT: «(1, 3)␤»
+    dd %bag{()};  # OUTPUT: «()␤»
 
 It is usually used to L<interpolate|/language/quoting#Interpolation:_qq>
 entire arrays / hashes into strings:
 
     my @words = "cruel", "world";
-    say "Hello, @words[]!"  #-> Hello, cruel world!
+    say "Hello, @words[]!"  # OUTPUT: «Hello, cruel world!␤»
 
 =head1 Multiple dimensions
 
@@ -330,27 +330,27 @@ elements and dimensions.
 
     my @twodim = (<a b c>, (1, 2, 3));
     dd @twodim;
-    # OUTPUT«Array @twodim = [("a", "b", "c"), (1, 2, 3)]␤»
+    # OUTPUT: «Array @twodim = [("a", "b", "c"), (1, 2, 3)]␤»
     dd @twodim[0,1;1]; # 2nd element of both lists
-    # OUTPUT«("b", 2)␤»
+    # OUTPUT: «("b", 2)␤»
 
 Multidimensional subscripts can be used to flatten nested lists.
 
     my @toomany = [[<a b>], [1, 2]];
     dd @toomany;
-    # OUTPUT«Array @toomany = [["a", "b"], [1, 2]]␤»
+    # OUTPUT: «Array @toomany = [["a", "b"], [1, 2]]␤»
     dd @toomany[*;*];
-    # OUTPUT«("a", "b", 1, 2)␤»
+    # OUTPUT: «("a", "b", 1, 2)␤»
 
 You can use L<Whatever|/type/Whatever> to select ranges or "rows" in
 multidimensional subscripts.
 
     my @a = [[1,2], [3,4]];
     say @a[*;1]; # 2nd element of each sub list
-    # OUTPUT«(2 4)␤»
+    # OUTPUT: «(2 4)␤»
     my @a = (<1 c 6>, <2 a 4>, <5 b 3>);
     say @a.sort(*[1]); # sort by 2nd column
-    # OUTPUT«((2 a 4) (5 b 3) (1 c 6))␤»
+    # OUTPUT: «((2 a 4) (5 b 3) (1 c 6))␤»
 
 =head1 Modifying elements
 
@@ -367,7 +367,7 @@ at each level:
 
     $beatles{"White Album"}[0] = "Back in the U.S.S.R.";  # autovivification!
 
-    say $beatles.perl;  #-> {"White Album" => ["Back in the U.S.S.R."]}
+    say $beatles.perl;  # OUTPUT: «{"White Album" => ["Back in the U.S.S.R."]}␤»
 
 C<$beatles> started out undefined, but became a L<Hash> object because it was
 subscripted with C<{ }> in the assignment. Similarly, C<$beatles{"White Album"}>
@@ -400,8 +400,8 @@ building complex linked data structures:
 
     $x++; @a[2]++;
 
-    dd @a;  #-> [10, 11, 3, 13]<>
-    dd $x;  #-> 3
+    dd @a;  # OUTPUT: «[10, 11, 3, 13]<>␤»
+    dd $x;  # OUTPUT: «3␤»
 
 =comment TODO: Come up with a more practical/motivational example snippet.
 
@@ -434,21 +434,21 @@ element's actual value. This can be used to distinguish between elements with
 an undefined value, and elements that aren't part of the collection at all:
 
     my @foo = Any, 10;
-    dd @foo[0].defined;    #-> False
-    dd @foo[0]:exists;     #-> True
-    dd @foo[2]:exists;     #-> False
-    dd @foo[0, 2]:exists;  #-> (True, False)
+    dd @foo[0].defined;    # OUTPUT: «False␤»
+    dd @foo[0]:exists;     # OUTPUT: «True␤»
+    dd @foo[2]:exists;     # OUTPUT: «False␤»
+    dd @foo[0, 2]:exists;  # OUTPUT: «(True, False)␤»
 
     my %fruit = apple => Any, orange => 10;
-    dd %fruit<apple>.defined;       #-> False
-    dd %fruit<apple>:exists;        #-> True
-    dd %fruit<banana>:exists;       #-> False
-    dd %fruit<apple banana>:exists; #-> (True, False)
+    dd %fruit<apple>.defined;       # OUTPUT: «False␤»
+    dd %fruit<apple>:exists;        # OUTPUT: «True␤»
+    dd %fruit<banana>:exists;       # OUTPUT: «False␤»
+    dd %fruit<apple banana>:exists; # OUTPUT: «(True, False)␤»
 
 May also be negated to test for non-existence:
 
     =begin code :skip-test
-    dd %fruit<apple banana>:!exists; #-> (False, True)
+    dd %fruit<apple banana>:!exists; # OUTPUT: «(False, True)␤»
     =end code
 
 To check if I<all> elements of a slice exist, use an L<all> junction:
@@ -471,13 +471,13 @@ Delete the element from the collection or, if supported by the collection,
 creates a hole at the given index, in addition to returning its value.
 
     my @tens = 0, 10, 20, 30;
-    dd @tens[3]:delete;     #-> 30
-    dd @tens;               #-> [0, 10, 20]<>
+    dd @tens[3]:delete;     # OUTPUT: «30␤»
+    dd @tens;               # OUTPUT: «[0, 10, 20]<>␤»
 
     my %fruit = apple => 5, orange => 10, banana => 4, peach => 17;
-    dd %fruit<apple>:delete;         #-> 5
-    dd %fruit<peach orange>:delete;  #-> (17, 10)
-    dd %fruit;                       #-> {banana => 4}<>
+    dd %fruit<apple>:delete;         # OUTPUT: «5␤»
+    dd %fruit<peach orange>:delete;  # OUTPUT: «(17, 10)␤»
+    dd %fruit;                       # OUTPUT: «{banana => 4}<>␤»
 
 Note that assigning C<Nil> will revert the container at the given index to it's
 default value. It will not create a hole. The created holes can be tested for
@@ -487,9 +487,9 @@ instead.
     my @a = 1, 2, 3;
     @a[1]:delete;
     say @a[1]:exists;
-    # OUTPUT«False␤»
+    # OUTPUT: «False␤»
     .say for @a;
-    # OUTPUT«1␤(Any)␤3␤»
+    # OUTPUT: «1␤(Any)␤3␤»
 
 With the negated form of the adverb, the element is not actually deleted. This
 means you can pass a flag to make it conditional:
@@ -512,17 +512,17 @@ Return both the index/key and the value of the element, in the form of a
 L<Pair>, and silently skip nonexistent elements:
 
     my @tens = 0, 10, 20, 30;
-    dd @tens[1]:p;        #-> 1 => 10
-    dd @tens[0, 4, 2]:p;  #-> (0 => 0, 2 => 20)
+    dd @tens[1]:p;        # OUTPUT: «1 => 10␤»
+    dd @tens[0, 4, 2]:p;  # OUTPUT: «(0 => 0, 2 => 20)␤»
 
     my %month = Jan => 1, Feb => 2, Mar => 3;
-    dd %month<Feb>:p;          #-> "Feb" => 2
-    dd %month<Jan Foo Mar>:p;  #-> ("Jan" => 1, "Mar" => 3)
+    dd %month<Feb>:p;          # OUTPUT: «"Feb" => 2␤»
+    dd %month<Jan Foo Mar>:p;  # OUTPUT: «("Jan" => 1, "Mar" => 3)␤»
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
     =begin code :skip-test
-    dd %month<Jan Foo Mar>:!p;  #-> ("Jan" => 1, "Foo" => Any, "Mar" => 3)
+    dd %month<Jan Foo Mar>:!p;  # OUTPUT: «("Jan" => 1, "Foo" => Any, "Mar" => 3)␤»
     =end code
 
 Can be combined with the L<#:exists> and L<#:delete> adverbs.
@@ -537,17 +537,17 @@ L<slice|#Slices>, the return value is a single flat list of interleaved keys
 and values:
 
     my @tens = 0, 10, 20, 30;
-    dd @tens[1]:kv;        #-> (1, 10)
-    dd @tens[0, 4, 2]:kv;  #-> (0, 0, 2, 20)
+    dd @tens[1]:kv;        # OUTPUT: «(1, 10)␤»
+    dd @tens[0, 4, 2]:kv;  # OUTPUT: «(0, 0, 2, 20)␤»
 
     my %month = Jan => 1, Feb => 2, Mar => 3;
-    dd %month<Feb>:kv;          #-> ("Feb", 2)
-    dd %month<Jan Foo Mar>:kv;  #-> ("Jan", 1, "Mar", 3)
+    dd %month<Feb>:kv;          # OUTPUT: «("Feb", 2)␤»
+    dd %month<Jan Foo Mar>:kv;  # OUTPUT: «("Jan", 1, "Mar", 3)␤»
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
     =begin code :skip-test
-    dd %month<Jan Foo Mar>:!kv;  #-> ("Jan", 1, "Foo", Any, "Mar", 3)
+    dd %month<Jan Foo Mar>:!kv;  # OUTPUT: «("Jan", 1, "Foo", Any, "Mar", 3)␤»
     =end code
 
 This adverb is commonly used to iterate over slices:
@@ -568,17 +568,17 @@ Return only the index/key of the element, rather than its value, and silently
 skip nonexistent elements:
 
     my @tens = 0, 10, 20, 30;
-    dd @tens[1]:k;        #-> 1
-    dd @tens[0, 4, 2]:k;  #-> (0, 2)
+    dd @tens[1]:k;        # OUTPUT: «1␤»
+    dd @tens[0, 4, 2]:k;  # OUTPUT: «(0, 2)␤»
 
     my %month = Jan => 1, Feb => 2, Mar => 3;
-    dd %month<Feb>:k;          #-> "Feb"
-    dd %month<Jan Foo Mar>:k;  #-> ("Jan", "Mar")
+    dd %month<Feb>:k;          # OUTPUT: «"Feb"␤»
+    dd %month<Jan Foo Mar>:k;  # OUTPUT: «("Jan", "Mar")␤»
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
     =begin code :skip-test
-    dd %month<Jan Foo Mar>:!k;  #-> ("Jan", "Foo", "Mar")
+    dd %month<Jan Foo Mar>:!k;  # OUTPUT: «("Jan", "Foo", "Mar")␤»
     =end code
 
 See also the L<keys> routine.
@@ -589,19 +589,19 @@ Return the bare value of the element (rather than potentially returning a
 mutable value container), and silently skip nonexistent elements:
 
     my @tens = 0, 10, 20, 30;
-    dd @tens[1]:v;        #-> 10
-    dd @tens[0, 4, 2]:v;  #-> (0, 20)
+    dd @tens[1]:v;        # OUTPUT: «10␤»
+    dd @tens[0, 4, 2]:v;  # OUTPUT: «(0, 20)␤»
     @tens[3] = 31;        # OK
     @tens[3]:v = 31;      # ERROR, cannot assign to immutable integer value
 
     my %month = Jan => 1, Feb => 2, Mar => 3;
-    dd %month<Feb>:v;          #-> 2
-    dd %month<Jan Foo Mar>:v;  #-> (1, 3)
+    dd %month<Feb>:v;          # OUTPUT: «2␤»
+    dd %month<Jan Foo Mar>:v;  # OUTPUT: «(1, 3)␤»
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
     =begin code :skip-test
-    dd %month<Jan Foo Mar>:!v;  #-> (1, Any, 3)
+    dd %month<Jan Foo Mar>:!v;  # OUTPUT: «(1, Any, 3)␤»
     =end code
 
 See also the L<values> routine.
@@ -646,13 +646,13 @@ Imagine a HTTP::Header type which, despite being a custom class with special
 behavior, can be indexed like a hash:
 
     my $request = HTTP::Request.new(GET => "perl6.org");
-    say $request.header.WHAT;  #-> (HTTP::Header)
+    say $request.header.WHAT;  # OUTPUT: «(HTTP::Header)␤»
 
     $request.header<Accept> = "text/plain";
     $request.header{'Accept-' X~ <Charset Encoding Language>} = <utf-8 gzip en>;
     $request.header.push('Accept-Language' => "fr");  # like .push on a Hash
 
-    say $request.header<Accept-Language>.perl;  #-> ["en", "fr"]
+    say $request.header<Accept-Language>.perl;  # OUTPUT: «["en", "fr"]␤»
 
     my $rawheader = $request.header.Str;  # stringify according to HTTP spec
 

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -115,8 +115,10 @@ invocant as a list of one element. (But there's no such fallback for
 associative subscripts, so they throw a run-time error when applied to an
 object that does not implement support for them.)
 
+    =begin code :skip-test
     say 42[0];    # OUTPUT: «42␤»
     say 42<foo>;  # ERROR: postcircumfix { } not defined for type Int
+    =end code
 
 =head1 Nonexistent elements
 
@@ -588,6 +590,7 @@ See also the L<keys> routine.
 Return the bare value of the element (rather than potentially returning a
 mutable value container), and silently skip nonexistent elements:
 
+    =begin code :skip-test
     my @tens = 0, 10, 20, 30;
     dd @tens[1]:v;        # OUTPUT: «10␤»
     dd @tens[0, 4, 2]:v;  # OUTPUT: «(0, 20)␤»
@@ -597,6 +600,7 @@ mutable value container), and silently skip nonexistent elements:
     my %month = Jan => 1, Feb => 2, Mar => 3;
     dd %month<Feb>:v;          # OUTPUT: «2␤»
     dd %month<Jan Foo Mar>:v;  # OUTPUT: «(1, 3)␤»
+    =end code
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
@@ -645,6 +649,7 @@ subscripting interface.
 Imagine a HTTP::Header type which, despite being a custom class with special
 behavior, can be indexed like a hash:
 
+    =begin code :skip-test
     my $request = HTTP::Request.new(GET => "perl6.org");
     say $request.header.WHAT;  # OUTPUT: «(HTTP::Header)␤»
 
@@ -655,6 +660,7 @@ behavior, can be indexed like a hash:
     say $request.header<Accept-Language>.perl;  # OUTPUT: «["en", "fr"]␤»
 
     my $rawheader = $request.header.Str;  # stringify according to HTTP spec
+    =end code
 
 The simplest way to implement this class, would be to give it an attribute of
 type L<Hash>, and delegate all subscripting and iterating related functionality

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -190,7 +190,7 @@ identifiers with double colons, the right most name is inserted into existing
 or automatically created packages.
 
     my Int $Foo::Bar::buzz = 42;
-    dd $Foo::Bar::buzz; # OUTPUT«Int $v = 42␤»
+    dd $Foo::Bar::buzz; # OUTPUT: «Int $v = 42␤»
 
 Identifiers can contain colon pairs. The entire colon pair becomes part of the
 name of the identifier.

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -198,9 +198,9 @@ name of the identifier.
     my $foo:bar = 1;
     my $foo:bar<2> = 2;
     dd MY::.keys;
-    # OUTPUT«("\$=pod", "!UNIT_MARKER", "EXPORT", "\$_", "\$!", "::?PACKAGE",
-    # "GLOBALish", "\$¢", "\$=finish", "\$/", "\$foo:bar<1>", "\$foo:bar<2>",
-    # "\$?PACKAGE").Seq␤»
+    # OUTPUT: «("\$=pod", "!UNIT_MARKER", "EXPORT", "\$_", "\$!", "::?PACKAGE",
+    #          "GLOBALish", "\$¢", "\$=finish", "\$/", "\$foo:bar<1>", "\$foo:bar<2>",
+    #          "\$?PACKAGE").Seq␤»
 
 Colon pairs in identifiers support interpolation. Please note that resolution
 of names often happens at compile time, so interpolation values must be known
@@ -209,7 +209,7 @@ at compile time.
     constant $c = 42;
     my $a:foo<42> = "answer";
     say $a:foo«$c»;
-    # OUTPUT«answer␤»
+    # OUTPUT: «answer␤»
 
 Unicode superscript numerals are exponents and not part of an identifier;
 e.g. C<$x²> does the square of variable C<$x>.  Subscript numerals are TBD.
@@ -273,7 +273,7 @@ names or constants, but also the term C<self> which refers to an object that
 a method was called on (see L<objects|/language/objects>), and sigilless
 variables:
 
-    say Int;                # (Int)
+    say Int;                # OUTPUT: «(Int)␤»
     #   ^^^ type name (built in)
 
     constant answer = 42;
@@ -286,7 +286,7 @@ variables:
           # ^^^^ built-in term 'self'
         }
     }
-    say Foo.type-name;     # Foo
+    say Foo.type-name;     # OUTPUT: «Foo␤»
     #   ^^^ type name
 
 
@@ -437,7 +437,7 @@ A pair of square brackets can surround an expression to form an itemized
 L<Array|/type/Array> literal; typically there is a comma-delimited list
 inside:
 
-    say ['a', 'b', 42].join(' ');   # a b 42
+    say ['a', 'b', 42].join(' ');   # OUTPUT: «a b 42␤»
     #   ^^^^^^^^^^^^^^ Array constructor
 
 The array constructor flattens non-itemized arrays and lists, but not itemized
@@ -445,10 +445,10 @@ arrays themselves:
 
     my @a = 1, 2;
     # flattens:
-    say [@a, 3, 4].elems;       # 4
+    say [@a, 3, 4].elems;       # OUTPUT: «4␤»
 
     # does not flatten:
-    say [[@a], [3, 4]].elems;   # 2
+    say [[@a], [3, 4]].elems;   # OUTPUT: «2␤»
 
 =head3 Hash literals
 
@@ -458,9 +458,9 @@ inside. If a non-pair is used, it is assumed to be a key and the next element
 is the value. Most often this is used with simple arrow pairs.
 
     say { a => 3, b => 23, :foo, :dog<cat>, "french", "fries" };
-    # a => 3, b => 23, dog => cat, foo => True, french => fries
+    # OUTPUT: «a => 3, b => 23, dog => cat, foo => True, french => fries␤»
 
-    say {a => 73, foo => "fish"}.keys.join(" ");   # a foo
+    say {a => 73, foo => "fish"}.keys.join(" ");   # OUTPUT: «a foo␤»
     #   ^^^^^^^^^^^^^^^^^^^^^^^^ Hash constructor
 
 When assigning to a C<%> sigil variable, the curly braces are optional.
@@ -474,8 +474,8 @@ non-string keys, use a colon prefix:
 
 Note that with objects as keys, you cannot access non-string keys as strings:
 
-    :{ -1 => 41, 0 => 42, 1 => 43 }<0>;  # Any
-    :{ -1 => 41, 0 => 42, 1 => 43 }{0};  # 42
+    :{ -1 => 41, 0 => 42, 1 => 43 }<0>;  # OUTPUT: «Any␤»
+    :{ -1 => 41, 0 => 42, 1 => 43 }{0};  # OUTPUT: «42␤»
 
 =head3 Regex literals
 
@@ -495,10 +495,10 @@ Signatures can be used standalone for pattern matching, in addition to the
 typical usage in sub and block declarations. A standalone signature is declared
 starting with a colon:
 
-    say "match!" if 5, "fish" ~~ :(Int, Str); #=> match!
+    say "match!" if 5, "fish" ~~ :(Int, Str); # OUTPUT: «match!␤»
 
     my $sig = :(Int $a, Str);
-    say "match!" if (5, "fish") ~~ $sig; #=> match!
+    say "match!" if (5, "fish") ~~ $sig; # OUTPUT: «match!␤»
 
     given "foo", 42 {
       when :(Str, Str) { "This won't match" }
@@ -624,13 +624,13 @@ operator.
 Wrap an infix operator in C<[ ]> to create a new reduction operator that works
 on a single list of inputs, resulting in a single value.
 
-    [+] <1 2 3 4 5>;        # 15
+    [+] <1 2 3 4 5>;        # OUTPUT: «15␤»
     (((1 + 2) + 3) + 4) + 5 # equivalent expanded version
 
 Wrap an infix operator in C<« »> (or the ASCII equivalent C<<< >>>) to create a
 new hyper operator that works pairwise on two lists.
 
-    <1 2 3> «+» <4 5 6> # <5 7 9>
+    <1 2 3> «+» <4 5 6> # OUTPUT: «<5 7 9>␤»
 
 The direction of the arrows indicates what to do when the lists are not the same size.
 
@@ -643,6 +643,6 @@ The direction of the arrows indicates what to do when the lists are not the same
 
 You can also wrap a unary operator with a hyper operator.
 
-    -« <1 2 3> # <-1 -2 -3>
+    -« <1 2 3> # OUTPUT: «<-1 -2 -3>␤»
 
 =end pod

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -196,7 +196,7 @@ is evaluated at compile time, what may be too early to make sense.
     constant PHI          = 1.61803398875; # The golden ratio is everywhere!
     constant POW2 = do { my int @table; @table = 1, 2, 4 ... 2**32; @table };
     say POW2[16];
-    # OUTPUT«65536␤»
+    # OUTPUT: «65536␤»
 
 Constants are C<our>-scoped by default, but adding C<my> would make them lexical.
 

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -76,7 +76,7 @@ initializing all attributes yourself. For example
         }
     }
 
-    say A.new(x => 42).x;       # Any
+    say A.new(x => 42).x;       # OUTPUT: «Any␤»
 
 leaves C<$!x> uninitialized, because the custom C<BUILD> doesn't initialize
 it.
@@ -108,7 +108,7 @@ C<BUILDALL> mechanism instead:
         }
     }
 
-    say A.new(x => 42).x;       # 42
+    say A.new(x => 42).x;       # OUTPUT: «42␤»
 
 (Note that C<BUILDALL> is a method, not a submethod. That's because by
 default, there is only one such method per class hierarchy, whereas C<BUILD>
@@ -164,20 +164,20 @@ In Perl 5 one could reference the last element of an array by asking for the
 "-1th" element of the array, e.g.:
 
     my @array = qw{victor alice bob charlie eve};
-    say @array[-1];    #->  eve
+    say @array[-1];    # OUTPUT: «eve␤»
 
 In Perl 6 it is not possible to use negative subscripts, however the same is
 achieved by actually using a function, namely C<*-1>.  Thus accessing the
 last element of an array becomes:
 
     my @array = qw{victor alice bob charlie eve};
-    say @array[*-1];   #->  eve
+    say @array[*-1];   # OUTPUT: «eve␤»
 
 Yet another way is to utilize the array's tail method:
 
     my @array = qw{victor alice bob charlie eve};
-    say @array.tail;      #-> eve
-    say @array.tail(2);   #-> (charlie eve)
+    say @array.tail;      # OUTPUT: «eve␤»
+    say @array.tail(2);   # OUTPUT: «(charlie eve)␤»
 
 =head2 Typed Array parameters
 
@@ -194,14 +194,14 @@ Arrays, use instead:
 It is also common to expect this to work, when it does not:
 
     sub bar(Int @a) { 42.say };
-    bar([1, 2, 3]);             #-> expected Positional[Int] but got Array
+    bar([1, 2, 3]);             # expected Positional[Int] but got Array
 
 The problem here is that [1, 2, 3] is not an C<Array[Int]>, it is a plain
 old Array that just happens to have Ints in it.  To get it to work,
 the argument must also be an C<Array[Int]>.
 
     my Int @b = 1, 2, 3;
-    bar(@b);                    #-> 42
+    bar(@b);                    # OUTPUT: «42␤»
     bar(Array[Int].new(1, 2, 3));
 
 This may seem inconvenient, but on the upside it moves the type-check
@@ -231,8 +231,8 @@ without using C<Q:c> as your quoting construct.
 
 There are methods that Str inherits from Any that work on iterables like lists. Iterators on Strings contain one element that is the whole string. To use C<sort>, C<reverse> and friends, you need to split the string into a list first.
 
-    say "cba".sort;              #   cba (what is wrong)
-    say "cba".comb.sort.join;    #   abc
+    say "cba".sort;              # OUTPUT: «cba␤» (what is wrong)
+    say "cba".comb.sort.join;    # OUTPUT: «abc␤»
 
 =head1 Operators
 
@@ -277,18 +277,18 @@ surprising results.
     my &method = { note $_; $_ };
     $_ = 'object';
     say .&method;
-    # OUTPUT«object␤object␤»
+    # OUTPUT: «object␤object␤»
     say 'topic' ~~ .&method;
-    # OUTPUT«topic␤True␤»
+    # OUTPUT: «topic␤True␤»
 
 In many cases flipping the method call to the LHS will work.
 
     my &method = { note $_; $_ };
     $_ = 'object';
     say .&method;
-    # OUTPUT«object␤object␤»
+    # OUTPUT: «object␤object␤»
     say .&method ~~ 'topic';
-    # OUTPUT«object␤True␤»
+    # OUTPUT: «object␤True␤»
 
 =head1 Common Precedence Mistakes
 
@@ -321,12 +321,12 @@ statements in other languages like C<return>, C<last> and many others.
         # this is actually
         # (return True) and False;
     }
-    say f; # OUTPUT«True␤»
+    say f; # OUTPUT: «True␤»
 
 =head2 Exponentiation Operator and Prefix Minus
 
-    say -1²;   # -1
-    say -1**2; # -1
+    say -1²;   # OUTPUT: «-1␤»
+    say -1**2; # OUTPUT: «-1␤»
 
 When performing a
 L<regular mathematical calculation|http://www.wolframalpha.com/input/?i=-1%C2%B2>,
@@ -335,8 +335,8 @@ Perl 6 matches these rules of mathematics and the precedence of C<**> operator 
 tighter than that of the prefix C<->. If you wish to raise a negative number
 to a power, use parentheses:
 
-    say (-1)²;   # 1
-    say (-1)**2; # 1
+    say (-1)²;   # OUTPUT: «1␤»
+    say (-1)**2; # OUTPUT: «1␤»
 
 The operator infix:<but> is narrower then the list constructor. When providing
 a list of roles to mix in, always use parentheses.
@@ -345,7 +345,7 @@ a list of roles to mix in, always use parentheses.
     role R2 { method n {} }
     my $a = 1 but R1,R2; # R2 is in sink context
     say $a.^name;
-    # OUTPUT«Int+{R1}␤»
+    # OUTPUT: «Int+{R1}␤»
 
 =head1 Subroutine and method calls
 
@@ -449,14 +449,14 @@ exception to be thrown. That means this construct will throw, despite the C<try>
 
     try run("perl6", "-e", "exit 42");
     say "still alive";
-    # OUTPUT: The spawned process exited unsuccessfully (exit code: 42)
+    # OUTPUT: «The spawned process exited unsuccessfully (exit code: 42)␤»
 
 This is because C<try> receives a C<Proc> and returns it, at which point it sinks and
 throws. Explicitly sinking it inside the C<try> avoids the issue:
 
     try sink run("perl6", "-e", "exit 42");
     say "still alive";
-    # OUTPUT: still alive
+    # OUTPUT: «still alive␤»
 
 =head1 Using Shortcuts
 
@@ -474,15 +474,15 @@ The trouble arises when a person wants to use more complex names for the variabl
 
     #In order
     sub f1 { say "$^first $^second"; }
-    f1 "Hello", "there";    #"Hello There"
+    f1 "Hello", "there";    # OUTPUT: «Hello There␤»
 
     #Out of order
     sub f2 { say "$^second $^first"; }
-    f2 "Hello", "there";    #"there Hello"
+    f2 "Hello", "there";    # OUTPUT: «there Hello␤»
 
 Due to the variables allowed to be called anything, this can cause some problems if you are not accustomed to how Perl 6 handles these variables.
 
-    for 1..4 { say "$^one $^two $^three $^four"; }    # 2 4 3 1
+    for 1..4 { say "$^one $^two $^three $^four"; }    # OUTPUT: «2 4 3 1␤»
 
 =head1 Scope
 
@@ -494,7 +494,7 @@ The C<once> block is a block of code that will only run once when it's parent bl
     for 1..10 {
         once { $var++; }
     }
-    say "Variable = $var";    # "Variable = 1"
+    say "Variable = $var";    # OUTPUT: «Variable = 1␤»
 
 This functionality also applies to other code blocks like C<sub> and C<while>, not just C<for> loops. Problems arise though, when trying to nest C<once> blocks inside of other code blocks:
 
@@ -502,7 +502,7 @@ This functionality also applies to other code blocks like C<sub> and C<while>, n
     for 1..10 {
         do { once { $var++; } }
     }
-    say "Variable = $var";    # "Variable = 10"
+    say "Variable = $var";    # OUTPUT: «Variable = 10␤»
 
 In the above example, the C<once> block was nested inside of a code block which was inside of a C<for> loop code block. This causes the C<once> block to run multiple times, because the C<once> block uses state variables to determine whether it has run previously. This means that if the parent code block goes out of scope, then the state variable the C<once> block uses to keep track of if it has run previously, goes out of scope as well. This is why C<once> blocks and C<state> variables can cause some unwanted behaviour when buried within more than one code block.
 
@@ -513,7 +513,7 @@ If you want to have something that will emulate the functionality of a once bloc
         state $run-code = True;
         do { if ($run-code) { $run-code = False; $var++; } }
     }
-    say "Variable = $var";    # "Variable = 1"
+    say "Variable = $var";    # OUTPUT: «Variable = 1␤»
 
 In this example, we essentially manually build a C<once> block by making a C<state> variable called C<$run-code> at the highest level that will be run more than once, then checking to see if C<$run-code> is C<True> using a regular C<if>. If the variable C<$run-code> is C<True>, then make the variable C<False> and continue with the code that should only be completed once.
 
@@ -526,7 +526,7 @@ For example:
         method sayit() { once say 'hi' }
     }
     my $a = A.new;
-    $a.sayit;      # says 'hi'
+    $a.sayit;      # OUTPUT: «hi␤»
     my $b = A.new;
     $b.sayit;      # nothing
 

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -225,7 +225,7 @@ without using C<Q:c> as your quoting construct.
 
     my $a = 1;
     say Q:c«{$a}()$b()»;
-    OUTPUT«1()$b()␤»
+    OUTPUT: «1()$b()␤»
 
 =head2 Strings are not iterable
 

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -24,11 +24,11 @@ L<parameters|/type/Signature#Type_Constraints> and return types.
     my $a = 1;
     $a = Nil;
     say $a.WHAT;
-    # OUTPUT«(Any)␤»
+    # OUTPUT: «(Any)␤»
 
     class C {};
     say C.^parents(:all);
-    # OUTPUT«((Any) (Mu))␤»
+    # OUTPUT: «((Any) (Mu))␤»
 
 For containers the default type is C<Any> but the default type constraint is
 C<Mu>. Please note that binding replaces the container, not just the value. The
@@ -42,7 +42,7 @@ method C<.defined> can be overloaded and may provide false information.
 
     my $a = Int;
     say so $a // $a === $a.WHAT;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head3 Undefinedness
 
@@ -65,7 +65,7 @@ Values can become undefined at runtime via L<mixin|/language/operators#infix_but
 
     my Int $i = 1 but role :: { method defined { False } };
     say $i // "undefined";
-    # OUTPUT«undefined␤»
+    # OUTPUT: «undefined␤»
 
 To test for definedness call C<.defined>, use
 L<//|/language/operators#infix_//>,
@@ -94,7 +94,7 @@ the L<MOP|/language/mop>.
     my $i = 10;
     $i.=C;
     $i.this-is-c();
-    # OUTPUT«oioioioioioioioioioi‽␤»
+    # OUTPUT: «oioioioioioioioioioi‽␤»
 
 Perl 6 provides methods defined in L<Cool|/type/Cool> to convert to a target
 type before applying further operations. Most build-in types descend from
@@ -104,9 +104,9 @@ methods.
 
     my $whatever = "123.6";
     say $whatever.round;
-    # OUTPUT«124␤»
+    # OUTPUT: «124␤»
     say <a b c d>.starts-with("ab");
-    # OUTPUT«False␤»
+    # OUTPUT: «False␤»
 
 =head1 Type Declarators
 
@@ -116,7 +116,7 @@ automatically if no such scope exists already.
 
     class Foo::Bar::C {};
     put Foo::Bar::.keys;
-    # OUTPUT«C␤»
+    # OUTPUT: «C␤»
 
 X«|... (forward declaration)»
 X«Forward declarations» can be provided with a block containing only C<...>. The
@@ -154,7 +154,7 @@ that is mixed in.
     my $a1 = $A.new;
     $a1.m;
     say [$A ~~ R, $a1 ~~ R];
-    # OUTPUT«oi‽␤[True True]␤»
+    # OUTPUT: «oi‽␤[True True]␤»
 
 =head3 Introspection
 
@@ -165,7 +165,7 @@ for L<Metamodel::ClassHOW|/type/Metamodel::ClassHOW>.
 
     class C {};
     say C.HOW ~~ Metamodel::ClassHOW;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head3 Attributes
 
@@ -181,7 +181,7 @@ such they can not be altered from outside the class they are defined in.
     };
 
     say (.name, .package, .has_accessor) for C.new.^attributes;
-    # OUTPUT«($!priv (C) False)␤»
+    # OUTPUT: «($!priv (C) False)␤»
 
 X«|method (declarator)»
 =head3 Methods
@@ -208,7 +208,7 @@ A normal method in a subclass does not compete with multis of a parent class.
 
     my int $i;
     B.new.m($i);
-    # OUTPUT«B::Int␤»
+    # OUTPUT: «B::Int␤»
 
 X«|only method»
 =head4 Only Method
@@ -220,7 +220,7 @@ class C {
     only method m {};
     multi method m {};
 };
-# OUTPUT«X::Comp::AdHoc: Cannot have a multi candidate for 'm' when an only method is also in the package 'C'␤»
+# OUTPUT: «X::Comp::AdHoc: Cannot have a multi candidate for 'm' when an only method is also in the package 'C'␤»
 
 =head4 Submethod BUILD
 
@@ -243,9 +243,8 @@ notation instead.
     };
 
     C.new.say; C.new('answer').say;
-    # OUTPUT:
-    # C.new(attr => 42)
-    # C.new(attr => "answer")
+    # OUTPUT: «C.new(attr => 42)␤
+    #          C.new(attr => "answer")␤»
 
 =head4 Fallback method
 X<|FALLBACK (method)>
@@ -275,8 +274,8 @@ methods from foreign objects.
         method WHAT { "ain't gonna happen" }
     };
 
-    say A.new.WHAT; # OUTPUT«(A)␤»
-    say A.new."WHAT"() # OUTPUT«ain't gonna happen␤»
+    say A.new.WHAT;    # OUTPUT: «(A)␤»
+    say A.new."WHAT"() # OUTPUT: «ain't gonna happen␤»
 
 =head4 Methods in package scope
 
@@ -287,7 +286,7 @@ Any C<our> scoped method will be visible in the package scope of a class.
         method loose {}
     };
     dd C::.keys
-    # OUTPUT«("\&packaged",).Seq␤»
+    # OUTPUT: «("\&packaged",).Seq␤»
 
 =head4 Setting Attributes with Namesake Variables and Methods
 
@@ -301,7 +300,7 @@ shares the name with the attribute:
         method m() { A.new(:$.i) }
     };
     my $a = B.new.m;
-    say $a.i; # OUTPUT«answer␤»
+    say $a.i; # OUTPUT: «answer␤»
 
 Since C<$.i> method call is named C<i> and the attribute is named C<i>, Perl 6
 lets us shortcut. The same applies to C<:$var>, C<:$!private-attribute>,
@@ -312,7 +311,7 @@ C<:&attr-with-code-in-it>, and so on.
 Mark a C<Routine> for hyperoperators to avoid descending into their list operands.
 
     dd [[1,2,3],[4,5]]>>.elems;
-    # OUTPUT«(3, 2)␤»
+    # OUTPUT: «(3, 2)␤»
 
 =head3 trait X<C<handles>|handles trait>
 
@@ -331,7 +330,7 @@ for the object that the call is delegated to can be provided.
         has A $.delegate handles 'm';
         method new($delegate){ self.bless(delegate => $delegate) }
     };
-    say C.new(B.new).m(); # OUTPUT«B::m has been called.␤»
+    say C.new(B.new).m(); # OUTPUT: «B::m has been called.␤»
 
 Instead of a method name, a C<Pair> (for renaming), a list of names or C<Pair>s, a C<Regex>
 or a C<Whatever> can be provided. In the latter case existing methods, both in the class itself and
@@ -379,7 +378,7 @@ methods to provide an interface for introspection and coercion to basic types.
         multi method from-a(){ 'A::from-a' }
     }
     dd A.new.^parents(:all);
-    # OUTPUT«(Any, Mu)␤»
+    # OUTPUT: «(Any, Mu)␤»
 
     class B {
         method from-b(){ 'B::from-b ' }
@@ -388,7 +387,7 @@ methods to provide an interface for introspection and coercion to basic types.
 
     class C is A is B {}
     dd C.new.from-a();
-    # OUTPUT«"A::from-a"␤»
+    # OUTPUT: «"A::from-a"␤»
 
 =head3 trait X«C<is rw>|is rw (class)»
 
@@ -403,7 +402,7 @@ public attributes of that class.
         has $.a;
     };
     my $c = C.new.a = 42;
-    dd $c; # OUTPUT«Int $c = 42␤»
+    dd $c; # OUTPUT: «Int $c = 42␤»
 
 =head3 trait C<is required>
 
@@ -420,14 +419,14 @@ L<X::Attribute::Required|/type/X::Attribute::Required>.
         submethod BUILD (:$attr) { $!attr = $attr }
     }
     say Correct.new(attr => 42);
-    # OUTPUT«Correct.new(attr => 42)␤»
+    # OUTPUT: «Correct.new(attr => 42)␤»
 
     class C {
         has $.attr is required;
     }
     C.new;
     CATCH { default { say .^name => .Str } }
-    # OUTPUT«X::Attribute::Required => The attribute '$!attr' is required, but you did not provide a value for it.␤»
+    # OUTPUT: «X::Attribute::Required => The attribute '$!attr' is required, but you did not provide a value for it.␤»
 
 =head3 trait C<hides>
 
@@ -444,7 +443,7 @@ L<re-dispatching|/language/functions#Re-dispatching>.
 
     B.new.m;
     B.new.n;
-    # OUTPUT«i am hidden␤»
+    # OUTPUT: «i am hidden␤»
 
 The trait <is hidden> allows a class to hide itself from
 L<re-dispatching|/language/functions#Re-dispatching>.
@@ -459,7 +458,7 @@ L<re-dispatching|/language/functions#Re-dispatching>.
 
     B.new.m;
     B.new.n;
-    # OUTPUT«i am hidden␤»
+    # OUTPUT: «i am hidden␤»
 
 =head3 trait C<trusts>
 
@@ -478,7 +477,7 @@ C<trusts>. A forward declaration of the trusted class may be required.
         method change { $!a!A::foo = 42; self }
     };
     say B.new.change;
-    # OUTPUT«B.new(a => A.new(foo => 42))␤»
+    # OUTPUT: «B.new(a => A.new(foo => 42))␤»
 
 =head3 Versioning and Authorship
 
@@ -489,7 +488,7 @@ C<.^ver> and C<^.auth>.
 
     class C:ver<4.2.3>:auth<me@here.local> {}
     say [C.^ver, C.^auth];
-    # OUTPUT«[v4.2.3 me@here.local]␤»
+    # OUTPUT: «[v4.2.3 me@here.local]␤»
 
 =head2 C<role>
 
@@ -513,7 +512,7 @@ object thus allowing the definition of anonymous roles and in-place mixins.
     @list.push: B.new;
 
     say @list».to-string;
-    # OUTPUT«[A<57192848> B<57192880>]␤»
+    # OUTPUT: «[A<57192848> B<57192880>]␤»
 
 Use C<...> as the only element of a method body to declare a method to be
 abstract. Any class getting such a method mixed in has to overload it. If the
@@ -522,7 +521,7 @@ C<X::Comp::AdHoc> will be thrown.
 
     EVAL 'role R { method overload-this(){...} }; class A does R {}; ';
     CATCH { default { say .^name, ' ', .Str } }
-    # OUTPUT«X::Comp::AdHoc Method 'overload-this' must be implemented by A because it is required by a role␤»
+    # OUTPUT: «X::Comp::AdHoc Method 'overload-this' must be implemented by A because it is required by a role␤»
 
 =head3 Role auto-punning
 
@@ -532,11 +531,11 @@ successful against the role.
 
     role R { method m { say 'oi‽' } };
     R.new.^mro.say;
-    # OUTPUT«((R) (Any) (Mu))␤»
+    # OUTPUT: «((R) (Any) (Mu))␤»
     say R.new.^mro[0].HOW.^name;
-    # OUTPUT«Perl6::Metamodel::ClassHOW␤»
+    # OUTPUT: «Perl6::Metamodel::ClassHOW␤»
     say R.new ~~ R;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head3 trait C<does>
 
@@ -553,7 +552,7 @@ comma can be provided. In this case conflicts will be reported at compile time.
     class C does R1 {};
 
     say [C ~~ R1, C ~~ R2];
-    # OUTPUT«[True True]␤»
+    # OUTPUT: «[True True]␤»
 
 For runtime mixins see L<but|/language/operators#infix_but> and L<does|/language/operators#infix_does>.
 
@@ -567,7 +566,7 @@ X<|Type Capture (role)>L<Type captures|/type/Signature#Type_Captures> are suppor
 
     my $c = C.new;
     dd $c;
-    # OUTPUT«C $c = C.new(a => "default")␤»
+    # OUTPUT: «C $c = C.new(a => "default")␤»
 
 Parameters can have type constraints, C<where> clauses are not supported for types but can
 be implemented via C<subset>s.
@@ -583,7 +582,7 @@ Default parameters can be provided.
     role R[$p = fail("Please provide a parameter to role R")] {};
     my $i = 1 does R;
     CATCH { default { say .^name, ': ', .Str} }
-    # OUTPUT«X::AdHoc: Could not instantiate role 'R':␤Please provide a parameter to role R␤»
+    # OUTPUT: «X::AdHoc: Could not instantiate role 'R':␤Please provide a parameter to role R␤»
 
 =head3 Roles as Types
 
@@ -625,9 +624,9 @@ role, is added to the inheritance chain.
     multi sub N(SI-kilogram $kg --> SI-Newton)                            { ($kg * g) does SI-Newton }
 
     say [75kg, N(75kg)];
-    # OUTPUT«[75kg 735.49875kN]»
+    # OUTPUT: «[75kg 735.49875kN]␤»
     say [(75kg).^name, N(75kg).^name];
-    # OUTPUT«[Int+{SI-kilogram} Rat+{SI-Newton}]»
+    # OUTPUT: «[Int+{SI-kilogram} Rat+{SI-Newton}]␤»
 =end code
 
 =head3 Versioning and Authorship
@@ -639,7 +638,7 @@ C<.^ver> and C<^.auth>.
 
     role R:ver<4.2.3>:auth<me@here.local> {}
     say [R.^ver, R.^auth];
-    # OUTPUT«[v4.2.3 me@here.local]␤»
+    # OUTPUT: «[v4.2.3 me@here.local]␤»
 
 =head2 C<enum>
 
@@ -655,8 +654,8 @@ not supported.
 Stringification of the symbol will provide the key of the enum-pair.
 
     enum Names ( name1 => 1, name2 => 2 );
-    say name1, ' ', name2; # OUTPUT«name1 name2»
-    say name1.value, ' ', name2.value; # OUTPUT«1 2␤»
+    say name1, ' ', name2; # OUTPUT: «name1 name2␤»
+    say name1.value, ' ', name2.value; # OUTPUT: «1 2␤»
 
 Comparing symbols will use type information and the value of the enum-pair. As
 value types C<Numerical> and C<Str> are supported.
@@ -666,44 +665,44 @@ value types C<Numerical> and C<Str> are supported.
        $a eqv $b
     }
 
-    say same(name1, name1); # OUTPUT«True␤»
-    say same(name1, name2); # OUTPUT«False␤»
+    say same(name1, name1); # OUTPUT: «True␤»
+    say same(name1, name2); # OUTPUT: «False␤»
     my $a = name1;
-    say $a ~~ Names; # OUTPUT«True␤»
-    say $a.WHAT; # OUTPUT«Names␤»
+    say $a ~~ Names; # OUTPUT: «True␤»
+    say $a.WHAT;     # OUTPUT: «Names␤»
 
 All keys have to be of the same type.
 
     enum Mass ( mg => 1/1000, g => 1/1, kg => 1000/1 );
-    dd Mass.enums; # OUTPUT«{:g(1.0), :kg(1000.0), :mg(0.001)}␤»
+    dd Mass.enums; # OUTPUT: «{:g(1.0), :kg(1000.0), :mg(0.001)}␤»
 
 If no value is given C<Int> will be assumed as the values type and incremented
 by one per key starting at zero. As enum key types C<Int>, C<Num>, C<Rat> and
 C<Str> are supported.
 
     enum Numbers <one two three four>;
-    dd Numbers.enums; # OUTPUT«{:four(3), :one(0), :three(2), :two(1)}␤»
+    dd Numbers.enums; # OUTPUT: «{:four(3), :one(0), :three(2), :two(1)}␤»
 
 A different starting value can be provided.
 
     enum Numbers «:one(1) two three four»;
-    dd Numbers.enums; # OUTPUT«{:four(4), :one(1), :three(3), :two(2)}␤»
+    dd Numbers.enums; # OUTPUT: «{:four(4), :one(1), :three(3), :two(2)}␤»
 
 
 Enums can be anonymous. There will be no type created, resulting in a lack of
 introspectiveness. The returned object is of type C<Map>.
 
     my $e = enum <one two three>;
-    say two; # OUTPUT«two()(Map)␤»
-    say one.WHAT; # OUTPUT«()␤»
-    say $e.WHAT; # OUTPUT«(Map)␤»
+    say two;      # OUTPUT: «two()(Map)␤»
+    say one.WHAT; # OUTPUT: «()␤»
+    say $e.WHAT;  # OUTPUT: «(Map)␤»
 
 There are various methods to get access to keys and values. All of them turn the
 values into C<Str>, which may not be desirable. By treating the enum as a
 package, we can get a list of type objects for the keys.
 
     enum E(<one two>); dd E::.values;
-    # OUTPUT«(E::two, E::one).Seq␤»
+    # OUTPUT: «(E::two, E::one).Seq␤»
 
 =head3 Introspection
 
@@ -714,7 +713,7 @@ for L</type/Metamodel::EnumHOW>.
 
     enum E(<a b c>);
     say E.HOW ~~ Metamodel::EnumHOW;
-    # OUTPUT«True␤»
+    # OUTPUT: «True␤»
 
 =head3 Methods
 
@@ -727,21 +726,21 @@ Defined as:
 Returns the list of enum-pairs. Works both on the enum type and any key.
 
     enum Mass ( mg => 1/1000, g => 1/1, kg => 1000/1 );
-    say Mass.enums, g.enums; # OUTPUT«{g => 1, kg => 1000, mg => 0.001}{g => 1, kg => 1000, mg => 0.001}␤»
+    say Mass.enums, g.enums; # OUTPUT: «{g => 1, kg => 1000, mg => 0.001}{g => 1, kg => 1000, mg => 0.001}␤»
 
 =head4 method key
 
 Returns the key of an enum-pair.
 
 =for code :skip-test
-say g.key; # OUTPUT«g␤»
+say g.key; # OUTPUT: «g␤»
 
 =head4 method value
 
 Returns the value of an enum-pair.
 
 =for code :skip-test
-say g.value; # OUTPUT«1␤»
+say g.value; # OUTPUT: «1␤»
 
 =head4 method pair
 
@@ -753,7 +752,7 @@ method pair(::?CLASS:D:)
 Returns a C<Pair> of the enum-pair.
 
 =for code :skip-test
-say g.pair; # OUTPUT«g => 1␤»
+say g.pair; # OUTPUT: «g => 1␤»
 
 =head4 method kv
 
@@ -765,7 +764,7 @@ multi method kv(::?CLASS:D:)
 Returns a list with key and value of the enum-pair.
 
 =for code :skip-test
-say g.kv; # OUTPUT«(g 1)␤»
+say g.kv; # OUTPUT: «(g 1)␤»
 
 
 =head2 C<module>
@@ -781,7 +780,7 @@ C<.^ver> and C<^.auth>.
 
     module M:ver<4.2.3>:auth<me@here.local> {}
     say [M.^ver, M.^auth];
-    # OUTPUT«[v4.2.3 me@here.local]␤»
+    # OUTPUT: «[v4.2.3 me@here.local]␤»
 
 =head2 C<package>
 
@@ -800,7 +799,7 @@ C<.^ver> and C<^.auth>.
 
     grammar G:ver<4.2.3>:auth<me@here.local> {}
     say [G.^ver, G.^auth];
-    # OUTPUT«[v4.2.3 me@here.local]␤»
+    # OUTPUT: «[v4.2.3 me@here.local]␤»
 
 =head2 C<subset>
 
@@ -812,7 +811,7 @@ will be checked against the given code object.
     my Positive $i = 1;
     $i = -42;
     CATCH { default { put .^name,': ', .Str } }
-    # OUTPUT«X::TypeCheck::Assignment: Type check failed in assignment to $i; expected Positive but got Int (-42)␤ …»
+    # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $i; expected Positive but got Int (-42)␤ …»
 
 Subsets can be anonymous, allowing inline placements where a subset is required
 but a name is neither needed nor desirable.
@@ -823,7 +822,7 @@ but a name is neither needed nor desirable.
         say @a
     }
     g([A, C]);
-    # OUTPUT«[A C]␤»
+    # OUTPUT: «[A C]␤»
 
 Subsets can be used to check types dynamically, what can be useful in conjunction with L<require|/language/modules#require>.
 X<|dynamic subset>

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -9,13 +9,13 @@ Perl 6 has a high level of support of Unicode.
 You can access Unicode codepoints by name:
 Rakudo supports all Unicode 9.0 names.
 
-    say "\c[PENGUIN]"; # 🐧
-    say "\c[BELL]"; # 🔔 (U+1F514 BELL)
+    say "\c[PENGUIN]"; # OUTPUT: «🐧␤»
+    say "\c[BELL]";    # OUTPUT: «🔔␤» (U+1F514 BELL)
 
 Additionally, all Unicode codepoint names/named seq/emoji sequences are now case-insensitive:
 [Starting in 2017.02]
 
-    say "\c[latin capital letter E]"; # E (U+0045)
+    say "\c[latin capital letter E]"; # OUTPUT: «E␤» (U+0045)
 
 =head1 Name Aliases
 
@@ -25,29 +25,29 @@ For full list of them see L<here|http://www.unicode.org/Public/UCD/latest/ucd/Na
 
 Control codes without any official name:
 
-    say "\c[ALERT]"; # Not visible (U+0007 control code (also accessible as \a))
+    say "\c[ALERT]";     # Not visible (U+0007 control code (also accessible as \a))
     say "\c[LINE FEED]"; # Not visible (U+000A same as "\n")
 
 Corrections:
 
-    say "\c[LATIN CAPITAL LETTER GHA]"; # Ƣ
-    say "Ƣ".uniname; # LATIN CAPITAL LETTER OI
+    say "\c[LATIN CAPITAL LETTER GHA]"; # OUTPUT: «Ƣ␤»
+    say "Ƣ".uniname; # OUTPUT: «LATIN CAPITAL LETTER OI␤»
     # This one is a spelling mistake that was corrected in a Name Alias:
     say "\c[PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET]".uniname;
-    # Output: PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
+    # OUTPUT: «PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET␤»
 
 Abbreviations:
 
-    say "\c[ZWJ]".uniname; # ZERO WIDTH JOINER
-    say "\c[NBSP]".uniname; # NO-BREAK SPACE
+    say "\c[ZWJ]".uniname;  # OUTPUT: «ZERO WIDTH JOINER␤»
+    say "\c[NBSP]".uniname; # OUTPUT: «NO-BREAK SPACE␤»
 
 =head1 Named Sequences
 
 You can also use any of the L<Named Sequences|http://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
 these are not single codepoints, but sequences of them. [Starting in 2017.02]
 
-    say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]"; # É̩
-    say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]".ords; # (201 809)
+    say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]";      # OUTPUT: «É̩␤»
+    say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]".ords; # OUTPUT: «(201 809)␤»
 
 =head2 Emoji Sequences
 
@@ -58,7 +58,7 @@ and L<Emoji Sequences|http://www.unicode.org/Public/emoji/4.0/emoji-sequences.tx
 Note that any names with commas should have their commas removed, since Perl 6 uses
 commas to separate different codepoints/sequences inside the same C<\c> sequence.
 
-    say "\c[woman gesturing OK]"; # 🙆‍♀️
-    say "\c[family: man woman girl boy]"; # 👨‍👩‍👧‍👦
+    say "\c[woman gesturing OK]";         # OUTPUT: «🙆‍♀️␤»
+    say "\c[family: man woman girl boy]"; # OUTPUT: «👨‍👩‍👧‍👦␤»
 
 =end pod

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -184,10 +184,10 @@ alternative in POD6.
 
 Thus constructs such as these are now possible:
 
-    say (1, 2) »+« (3, 4);     # (4 6) - element-wise add
-    [1, 2, 3] »+=» 42;            # add 42 to each element of @array
-    say «moo»;                 # moo
-    my $baa = 123; say «$baa»; # (123)
+    say (1, 2) »+« (3, 4);     # OUTPUT: «(4 6)␤» - element-wise add
+    [1, 2, 3] »+=» 42;         # add 42 to each element of @array
+    say «moo»;                 # OUTPUT: «moo␤»
+    my $baa = 123; say «$baa»; # OUTPUT: «(123)␤»
     =begin pod
     L«C<say> routine|https://docs.perl6.org/routine/say»
     =end pod

--- a/doc/Language/unicode_texas.pod6
+++ b/doc/Language/unicode_texas.pod6
@@ -26,7 +26,7 @@ Any codepoint that has the C<Nd> (Number, decimal digit) property, can
 be used as a digit in any number.  For example:
 
   my $var = １９; # U+FF11 U+FF19
-  say $var + 2;  # 21
+  say $var + 2;  # OUTPUT: «21␤»
 
 =head1 Numeric values
 
@@ -35,7 +35,7 @@ property can be used standalone as a numeric value, such as ½ and ⅓. (These
 aren't decimal digit characters, so can't be combined.) For example:
 
   my $var = ⅒ + 2 + Ⅻ; # here ⅒ is No and Rat and Ⅻ is Nl and Int
-  say $var;              # 14.1
+  say $var;            # OUTPUT: «14.1␤»
 
 =head1 Whitespace characters
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -49,11 +49,11 @@ The default type can be set with C<is>.
 
     my %h is FailHash = oranges => "round", bananas => "bendy";
     say %h<oranges>;
-    # OUTPUT «round␤»
+    # OUTPUT: «round␤»
     %h.finalize;
     say %h<cherry>;
     CATCH { default { put .^name, ': ', .Str } }
-    # OUTPUT «X::OutOfRange: Hash key out of range. Is: cherry, should be in (oranges bananas)»
+    # OUTPUT: «X::OutOfRange: Hash key out of range. Is: cherry, should be in (oranges bananas)»
 
 For information on variables without sigils, see
 L<sigilless variables|#Sigilless variables>.
@@ -77,15 +77,15 @@ The type of assignment (item or list) is decided by the first context
 seen in the current expression or declarator:
 
     my $foo = 5;            # item assignment
-    say $foo.perl;          # 5
+    say $foo.perl;          # OUTPUT: «5␤»
 
     my @bar = 7, 9;         # list assignment
-    say @bar.WHAT;          # (Array)
-    say @bar.perl;          # [7, 9]
+    say @bar.WHAT;          # OUTPUT: «(Array)␤»
+    say @bar.perl;          # OUTPUT: «[7, 9]␤»
 
     (my $baz) = 11, 13;     # list assignment
-    say $baz.WHAT;          # (List)
-    say $baz.perl;          # (11, 13)
+    say $baz.WHAT;          # OUTPUT: «(List)␤»
+    say $baz.perl;          # OUTPUT: «(11, 13)␤»
 
 Thus, the behavior of an assignment contained within a list assignment depends
 on the expression or declarator that contains it.
@@ -96,8 +96,8 @@ assignment:
 
     my @array;
     @array = my $num = 42, "str";   # item assignment: uses declarator
-    say @array.perl;                # [42, "str"] (an Array)
-    say $num.perl;                  # 42 (a Num)
+    say @array.perl;                # OUTPUT: «[42, "str"]␤» (an Array)
+    say $num.perl;                  # OUTPUT: «42␤» (a Num)
 
 Similarly, if the internal assignment is an expression that is being
 used as an initializer for a declarator, the context of the internal
@@ -105,13 +105,13 @@ expression determines the assignment type:
 
     my $num;
     my @array = $num = 42, "str";    # item assignment: uses expression
-    say @array.perl;                 # [42, "str"] (an Array)
-    say $num.perl;                   # 42 (a Num)
+    say @array.perl;                 # OUTPUT: «[42, "str"]␤» (an Array)
+    say $num.perl;                   # OUTPUT: «42␤» (a Num)
 
     my ( @foo, $bar );
     @foo = ($bar) = 42, "str";       # list assignment: uses parentheses
-    say @foo.perl;                   # [42, "str"] (an Array)
-    say $bar.perl;                   # $(42, "str")  (a List)
+    say @foo.perl;                   # OUTPUT: «[42, "str"]␤» (an Array)
+    say $bar.perl;                   # OUTPUT: «$(42, "str")␤» (a List)#
 
 However, if the internal assignment is neither a declarator nor an
 expression, but is part of a larger expression, the context of the
@@ -119,8 +119,8 @@ larger expression determines the assignment type:
 
     my ( @array, $num );
     @array = $num = 42, "str";    # list assignment
-    say @array.perl;              # [42, "str"] (an Array)
-    say $num.perl;                # [42, "str"] (an Array)
+    say @array.perl;              # OUTPUT: «[42, "str"]␤»
+    say $num.perl;                # OUTPUT: «[42, "str"]␤»
 
 This is because the whole expression is C<@array = $num = 42, "str">, while
 C<$num = 42> is not is own separate expression.
@@ -231,11 +231,11 @@ boolean context before using it for anything else:
         $*FOO // 'foo';
     }
 
-    say foo; # -> 'foo'
+    say foo; # OUTPUT: «foo␤»
 
     my $*FOO = 'bar';
 
-    say foo; # -> 'bar'
+    say foo; # OUTPUT: «bar␤»
     =end code
 
 
@@ -302,7 +302,7 @@ is also possible:
         method b() { $.a; }
     }
 
-    SaySomething.b; # prints "a"
+    SaySomething.b; # OUTPUT: «a␤»
 
 For more details on objects, classes and their attributes and methods see
 L<object orientation|/language/objects>.
@@ -319,9 +319,8 @@ that block. So the block in the code
         say "$^b follows $^a";
     }
 
-    # OUTPUT:
-    # 1 follows 0
-    # 3 follows 2
+    # OUTPUT: «1 follows 0␤
+    #          3 follows 2»
 
 has two formal parameters, namely C<$a> and C<$b>. Note that even though C<$^b>
 appears before C<$^a> in the code, C<$^a> is still the first formal parameter
@@ -358,8 +357,7 @@ twigil also apply here (with the exception that they are not positional and
 therefore not ordered using Unicode order, of course). So this:
 
     say { $:add ?? $^a + $^b !! $^a - $^b }( 4, 5 ) :!add
-    # OUTPUT:
-    # -1
+    # OUTPUT: «-1␤»
 
 See L<^> for more details about placeholder variables.
 
@@ -421,7 +419,7 @@ Most of the time it's enough to create a new variable using the C<my>
 keyword:
 
     my $amazing-variable = "World";
-    say "Hello $amazing-variable!"; # Hello World!
+    say "Hello $amazing-variable!"; # OUTPUT: «Hello World!␤»
 
 However, there are many declarators that change the details of scoping
 beyond what L<#Twigils> can do.
@@ -454,9 +452,9 @@ exists within the current block. For example:
 =begin code :skip-test
 {
     my $foo = "bar";
-    say $foo; # -> "bar"
+    say $foo; # OUTPUT: «"bar"␤»
 }
-say $foo; # !!! "Variable '$foo' is not declared"
+say $foo; # Exception! "Variable '$foo' is not declared"
 =end code
 
 This dies because C<$foo> is only defined as long as we are in the same
@@ -472,16 +470,16 @@ redefined in a new scope:
         say $location;
     }
 
-    outer-location; # -> "outside"
+    outer-location; # OUTPUT: «outside␤»
 
     sub in-building {
         my $location = "inside";
         say $location;
     }
 
-    in-building; # -> "inside"
+    in-building;    # OUTPUT: «inside␤»
 
-    outer-location; # -> "outside"
+    outer-location; # OUTPUT: «outside␤»
 
 If a variable has been redefined, any code that referenced the outer
 variable will continue to reference the outer variable. So here,
@@ -493,7 +491,7 @@ sub new-location {
     outer-location;
 }
 
-new-location; # -> "outside"
+new-location; # OUTPUT: «outside␤»
 =end code
 
 To make C<new-location()> print C<nowhere>, make C<$location> a dynamic
@@ -528,7 +526,7 @@ variables.
 
     my (Str $a, Str $b, Int $c) = <a b>;
     say [$a, $b, $c].perl;
-    # OUTPUT«["a", "b", Int]␤»
+    # OUTPUT: «["a", "b", Int]␤»
 
 To destructure a list into a single value, create a list literal with one element
 by using C<($var,)>. When used with a variable declarator, providing
@@ -537,13 +535,13 @@ parentheses around a single variable is sufficient.
     sub f { 1,2,3 };
     my ($a) = f;
     say $a.perl;
-    # OUTPUT«1␤»
+    # OUTPUT: «1␤»
 
 To skip elements in the list use the anonymous state variable C<$>.
 
     my ($,$a,$,%h) = ('a', 'b', [1,2,3], {:1th});
     say [$a, %h].perl;
-    # OUTPUT«["b", {:th(1)}]␤»
+    # OUTPUT: «["b", {:th(1)}]␤»
 
 =head2 The C<has> Declarator
 
@@ -634,8 +632,8 @@ State variables are shared between all threads. The result can be unexpected.
         start { loop { last if code() >= 5 } },
         start { loop { last if code() >= 5 } };
 
-    # OUTPUT«1␤2␤3␤4␤4␤3␤5␤»
-    # OUTPUT«2␤1␤3␤4␤5␤»
+    # OUTPUT: «1␤2␤3␤4␤4␤3␤5␤»
+    # OUTPUT: «2␤1␤3␤4␤5␤»
     # many other more or less odd variations can be produced
 
 =head3 The C<$> Variable
@@ -644,7 +642,7 @@ In addition to explicitly declared named state variables, C<$> can be used
 as an anonymous state variable without an explicit C<state> declaration.
 
     say "1-a 2-b 3-c".subst(:g, /\d/, {<one two three>[$++]});
-    # OUTPUT«one-a two-b three-c␤»
+    # OUTPUT: «one-a two-b three-c␤»
 
 Furthermore, state variables are not required in subroutines. You
 could, for example, use C<$> in a one-liner to number the lines in a file.
@@ -658,7 +656,7 @@ variable.
 
 =begin code :skip-test
 perl6 -e '{ say ++$; say $++  } for ^5'
-# OUTPUT«1␤0␤2␤1␤3␤2␤4␤3␤5␤4␤»
+# OUTPUT: «1␤0␤2␤1␤3␤2␤4␤3␤5␤4␤»
 =end code
 
 If you need to use the value of $ more than once in a scope, it should be
@@ -682,7 +680,7 @@ copied to a new variable.
     }
 
     foo() for ^3;
-    # OUTPUT«one␤two␤three␤»
+    # OUTPUT: «one␤two␤three␤»
 
 Note that the implicit state declarator is only applied to the variable
 itself, not the expression that may contain an initializer. If the
@@ -705,10 +703,9 @@ anonymous state variable C<@>.
 
     foo($_) for ^3;
 
-    # OUTPUT:
-    # [0]
-    # [0 1]
-    # [0 1 2]
+    # OUTPUT: «[0]
+    #          [0 1]
+    #          [0 1 2]␤»
 
 The C<@> here is parenthesized in order to disambiguate the expression
 from a class member variable named C<@.push>.  Indexed access doesn't
@@ -723,10 +720,9 @@ to do anything useful with it.
 
     foo($_) for ^3;
 
-    # OUTPUT:
-    # [0]
-    # [0 1]
-    # [0 1 2]
+    # OUTPUT: «[0]
+    #          [0 1]
+    #          [0 1 2]␤»
 
 As with C<$>, each mention of C<@> in a scope introduces a new anonymous
 array.
@@ -741,10 +737,9 @@ In addition, there's an L<Associative> anonymous state variable C<%>.
 
     foo($_) for ^3;
 
-    # OUTPUT:
-    # 0 => 0
-    # 0 => 0, 1 => 1
-    # 0 => 0, 1 => 1, 2 => 2
+    # OUTPUT: «0 => 0
+    #          0 => 0, 1 => 1
+    #          0 => 0, 1 => 1, 2 => 2␤»
 
 The same caveat about disambiguation applies. As you may expect, indexed
 access is also possible (with copying to make it useful).
@@ -757,10 +752,9 @@ access is also possible (with copying to make it useful).
 
     foo($_) for ^3;
 
-    # OUTPUT:
-    # 0 => 0
-    # 0 => 0, 1 => 1
-    # 0 => 0, 1 => 1, 2 => 2
+    # OUTPUT: «0 => 0
+    #          0 => 0, 1 => 1
+    #          0 => 0, 1 => 1, 2 => 2␤»
 
 As with the other anonymous state variables, each mention of C<%> within a
 given scope will effectively introduce a separate variable.
@@ -779,7 +773,7 @@ are better solutions.
     augment class Int {
         method is-answer { self == 42 }
     }
-    say 42.is-answer;       # True
+    say 42.is-answer;       # OUTPUT: «True␤»
 
 (In this case, the better solution would be to use a
 L<function|/language/functions>).
@@ -807,19 +801,18 @@ scope. However, C<temp> does not create a new variable.
     };
     print g(g(f(g()), g(), f()));
 
-    # OUTPUT:
-    # <g>
-    #  <g>
-    #   <f>
-    #    <g>
-    #    </g>
-    #   </f>
-    #   <g>
-    #   </g>
-    #   <f>
-    #   </f>
-    #  </g>
-    # </g>
+    # OUTPUT: «<g>
+    #           <g>
+    #            <f>
+    #             <g>
+    #             </g>
+    #            </f>
+    #            <g>
+    #            </g>
+    #            <f>
+    #            </f>
+    #           </g>
+    #          </g>␤»
 
 =head2 The C<let> Prefix
 
@@ -856,14 +849,14 @@ L<of|/type/Variable#trait_of> to set a type constraint.
     my Int $x = 42;
     $x = 'a string';
     CATCH { default { put .^name, ': ', .Str } }
-    # OUTPUT: X::TypeCheck::Assignment: Type check failed in assignment to $x; expected Int but got Str ("a string")
+    # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $x; expected Int but got Str ("a string")␤»
 
 If a scalar variable has a type constraint but no initial value, it's
 initialized with the type object of the default value of the container it's bound to.
 
     my Int $x;
-    say $x.^name;       # Int
-    say $x.defined;     # False
+    say $x.^name;       # OUTPUT: «Int␤»
+    say $x.defined;     # OUTPUT: «False␤»
 
 Scalar variables without an explicit type constraint are typed as
 L<Mu|/type/Mu> but default to the L<Any|/type/Any> type object.
@@ -876,11 +869,11 @@ The default value of a variable can be set with the C<is default> trait, and
 re-applied by assigning C<Nil> to it:
 
     my Real $product is default(1);
-    say $product;                       # 1
+    say $product;                       # OUTPUT: «1␤»
     $product *= 5;
-    say $product;                       # 5
+    say $product;                       # OUTPUT: «5␤»
     $product = Nil;
-    say $product;                       # 1
+    say $product;                       # OUTPUT: «1␤»
 
 =head2 Default Defined Variables Pragma
 
@@ -891,7 +884,7 @@ variables :_>.
 =begin code :skip-test
 use variables :D;
 my Int $i;
-# OUTPUT«===SORRY!=== Error while compiling <tmp>␤Variable definition of type Int:D (implicit :D by pragma) requires an initializer ...
+# OUTPUT: «===SORRY!=== Error while compiling <tmp>␤Variable definition of type Int:D (implicit :D by pragma) requires an initializer ...
 my Int $i = 1; # that works
 { use variables :_; my Int $i; } # switch it off in this block
 =end code
@@ -950,11 +943,10 @@ work on C<$_>:
         .say if m/<!alpha>/;
     }
 
-    # OUTPUT:
-    # Looking for strings with non-alphabetic characters...
-    # ab:c
-    # d$e
-    # ij*
+    # OUTPUT: «Looking for strings with non-alphabetic characters...
+    #          ab:c
+    #          d$e
+    #          ij*␤»
 
 =head3 The C<$/> Variable
 
@@ -962,7 +954,7 @@ C<$/> is the match variable. It stores the result of the last L<Regex|/language/
 match and so usually contains objects of type L<Match>.
 
     'abc 12' ~~ /\w+/;  # sets $/ to a Match object
-    say $/.Str;         # abc
+    say $/.Str;         # OUTPUT: «abc␤»
 
 The C<Grammar.parse> method also sets the caller's C<$/> to the resulting
 L<Match> object.  For the following code:
@@ -972,18 +964,17 @@ use XML::Grammar; # zef install XML
 XML::Grammar.parse("<p>some text</p>");
 say $/;
 
-# OUTPUT:
-# ｢<p>some text</p>｣
-#  root => ｢<p>some text</p>｣
-#   name => ｢p｣
-#   child => ｢some text｣
-#    text => ｢some text｣
-#    textnode => ｢some text｣
-#  element => ｢<p>some text</p>｣
-#   name => ｢p｣
-#   child => ｢some text｣
-#    text => ｢some text｣
-#    textnode => ｢some text｣
+# OUTPUT: «｢<p>some text</p>｣
+#           root => ｢<p>some text</p>｣
+#            name => ｢p｣
+#            child => ｢some text｣
+#             text => ｢some text｣
+#             textnode => ｢some text｣
+#           element => ｢<p>some text</p>｣
+#            name => ｢p｣
+#            child => ｢some text｣
+#             text => ｢some text｣
+#             textnode => ｢some text｣␤»
 =end code
 
 =head4 X«Positional Attributes|variable,$0;variable,$1;variable,@()»
@@ -992,18 +983,18 @@ C<$/> can have positional attributes if the L<Regex|/language/regexes> had
 capture-groups in it, which are just formed with parentheses.
 
     'abbbbbcdddddeffg' ~~ / a (b+) c (d+ef+) g /;
-    say $/[0]; # ｢bbbbb｣
-    say $/[1]; # ｢dddddeff｣
+    say $/[0]; # OUTPUT: «｢bbbbb｣␤»
+    say $/[1]; # OUTPUT: «｢dddddeff｣␤»
 
 These can also be accessed by the shortcuts C<$0>, C<$1>, C<$2>, etc.
 
-    say $0; # ｢bbbbb｣
-    say $1; # ｢dddddeff｣
+    say $0; # OUTPUT: «｢bbbbb｣␤»
+    say $1; # OUTPUT: «｢dddddeff｣␤»
 
 To get all of the positional attributes, any of C<$/.list>, C<@$/>, or
 C<@()> can be used.
 
-    say @().join; # bbbbbdddddeff
+    say @().join; # OUTPUT: «bbbbbdddddeff␤»
 
 =head4 X«Named Attributes|variable,$<named>;variable,%()»
 
@@ -1011,18 +1002,18 @@ C<$/> can have named attributes if the L<Regex|/language/regexes> had named
 capture-groups in it, or if the Regex called out to another Regex.
 
     'I.... see?' ~~ / \w+ $<punctuation>=[ <-[\w\s]>+ ] \s* $<final-word> = [ \w+ . ] /;
-    say $/<punctuation>; # ｢....｣
-    say $/<final-word>;  # ｢see?｣
+    say $/<punctuation>; # OUTPUT: «｢....｣␤»
+    say $/<final-word>;  # OUTPUT: «｢see?｣␤»
 
 These can also be accessed by the shortcut C«$<named>».
 
-    say $<punctuation>; # ｢....｣
-    say $<final-word>;  # ｢see?｣
+    say $<punctuation>; # OUTPUT: «｢....｣␤»
+    say $<final-word>;  # OUTPUT: «｢see?｣␤»
 
 To get all of the named attributes, any of C<$/.hash>, C<%$/>, or C<%()> can
 be used.
 
-    say %().join;       # "punctuation     ....final-word  see?"
+    say %().join;       # OUTPUT: «"punctuation     ....final-word  see?"␤»
 
 =head3 The C<$!> Variable
 

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -154,7 +154,7 @@ the return values of C<&block>, unless the element does the C<Iterable> role.
 For those elements C<deepmap> will descend recursively into the sublist.
 
     dd [[1,2,3],[[4,5],6,7]].deepmap(*+1);
-    # OUTPUT«[[2, 3, 4], [[5, 6], 7, 8]]␤»
+    # OUTPUT: «[[2, 3, 4], [[5, 6], 7, 8]]␤»
 
 =head2 method duckmap
 
@@ -168,7 +168,7 @@ will try to descend into the element if that element implements C<Iterable>.
 
     my @a = [1,[2,3],4];
     dd @a.duckmap({ $_ ~~ Int ?? $_++ !! Any });
-    # OUTPUT«(1, (2, 3), 4)␤»
+    # OUTPUT: «(1, (2, 3), 4)␤»
 
 =head2 method flat
 

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -44,7 +44,7 @@ set with the trait C<is default>.
     say $c;
     $c.a = Nil;
     say $c;
-    # OUTPUT«C.new(a => 666)␤C.new(a => 42)␤»
+    # OUTPUT: «C.new(a => 666)␤C.new(a => 42)␤»
 
 =head2 X<Trait is required|trait,is required (Attribute)>
 
@@ -56,7 +56,7 @@ when the object is instantiated. Failing to do so will result in a runtime error
     }
     my $c = C.new;
     CATCH{ default { say .^name, ': ', .Str } }
-    # OUTPUT«X::Attribute::Required: The attribute '$!a' is required, but you did not provide a value for it.␤»
+    # OUTPUT: «X::Attribute::Required: The attribute '$!a' is required, but you did not provide a value for it.␤»
 
 =head2 X<trait is DEPRECATED|trait,is DEPRECATED (Attribute)>
 

--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -77,11 +77,13 @@ value of the right function will be L<slipped|/type/Slip> into the left function
     # or to:
     say f g 2;
 
+    =begin code
     sub f($a, $b, $c) { [~] $c, $b, $a }
     sub g($str){ $str.comb }
     my &composed = &f ∘ &g;
     say composed 'abc'; # OUTPUT: «cba␤»
     # equivalent to:
     say f |g 'abc';
+    =end code
 
 =end pod

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -96,19 +96,23 @@ listener should be C<close>d.
 
 For example, when using C<tap>:
 
+    =begin code :skip-test
     my $listener = IO::Socket::Async.listen('127.0.0.1', 8080);
     my $tap = $listener.tap({ ... });
 
     # When you want to close the listener
     $tap.close;
+    =end code
 
 Or when using C<whenever>:
 
+    =begin code :skip-test
     my $listener = IO::Socket::Async.listen('127.0.0.1', 5000);
     my $big-finish = Promise.new;
     my $tap = do whenever $listener -> $conn { ... }
     await $big-finish;
     $tap.close;
+    =end code
 
 =head2 method udp
 

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -147,7 +147,7 @@ there were no values to skip:
 
     my $i = <a b>.iterator;
     say $i.skip-one; say $i.pull-one; say $i.skip-one
-    # OUTPUT«1␤b␤0␤»
+    # OUTPUT: «1␤b␤0␤»
 
 =head2 method skip-at-least
 
@@ -160,7 +160,7 @@ there were not enough values to skip:
 
     my $i = <a b c>.iterator;
     say $i.skip-at-least(2); say $i.pull-one; say $i.skip-at-least(20);
-    # OUTPUT«1␤c␤0␤»
+    # OUTPUT: «1␤c␤0␤»
 
 =head2 method skip-at-least-pull-one
 
@@ -174,6 +174,6 @@ or C<IterationEnd> if there were not enough values:
     my $i = <a b c>.iterator;
     say $i.skip-at-least-pull-one(2);
     say $i.skip-at-least-pull-one(20) =:= IterationEnd;
-    # OUTPUT«c␤True␤»
+    # OUTPUT: «c␤True␤»
 
 =end pod

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -508,9 +508,9 @@ against a L<Signature|/type/Signature>.
 
 Defined as:
 
-    sub    pick($count, *@list --> Seq:D)
-    method pick(List:D: $count --> Seq:D)
-    method pick(List:D: --> Mu)
+    multi sub    pick($count, *@list --> Seq:D)
+    multi method pick(List:D: $count --> Seq:D)
+    multi method pick(List:D: --> Mu)
 
 If C<$count> is supplied: Returns C<$count> elements chosen at random
 and without repetition from the invocant. If C<*> is passed as C<$count>,
@@ -530,9 +530,9 @@ Examples:
 
 Defined as:
 
-    sub    roll($count, *@list --> Seq:D)
-    method roll(List:D: $count --> Seq:D)
-    method roll(List:D: --> Mu)
+    multi sub    roll($count, *@list --> Seq:D)
+    multi method roll(List:D: $count --> Seq:D)
+    multi method roll(List:D: --> Mu)
 
 If C<$count> is supplied: Returns a sequence of C<$count> elements, each randomly
 selected from the list. Each random choice is made independently, like a separate
@@ -555,8 +555,8 @@ Examples:
 
 Defined as:
 
-    method eager(List:D: --> List:D)
-    sub eager(*@elems --> List:D)
+    multi method eager(List:D: --> List:D)
+    multi sub eager(*@elems --> List:D)
 
 Evaluates all elements in the list eagerly, and returns them as a list.
 
@@ -566,8 +566,8 @@ Evaluates all elements in the list eagerly, and returns them as a list.
 
 Defined as:
 
-    sub    reverse(*@list  --> List:D)
-    method reverse(List:D: --> List:D)
+    multi sub    reverse(*@list  --> List:D)
+    multi method reverse(List:D: --> List:D)
 
 Returns a list with the same elements in reverse order.
 
@@ -583,8 +583,8 @@ Examples:
 
 Defined as:
 
-    sub    rotate(@list,  Int:D $n = 1 --> List:D)
-    method rotate(List:D: Int:D $n = 1 --> List:D)
+    multi sub    rotate(@list,  Int:D $n = 1 --> List:D)
+    multi method rotate(List:D: Int:D $n = 1 --> List:D)
 
 Returns the list rotated by C<$n> elements.
 
@@ -597,10 +597,10 @@ Examples:
 
 Defined as:
 
-    sub    sort(*@elems      --> Seq:D)
-    sub    sort(&by, *@elems --> Seq:D)
-    method sort(List:D:      --> Seq:D)
-    method sort(List:D: &by  --> Seq:D)
+    multi sub    sort(*@elems      --> Seq:D)
+    multi sub    sort(&by, *@elems --> Seq:D)
+    multi method sort(List:D:      --> Seq:D)
+    multi method sort(List:D: &by  --> Seq:D)
 
 Sorts the list, smallest element first. By default C<< infix:<cmp> >>
 is used for comparing list elements.
@@ -623,8 +623,8 @@ Examples:
 
 Defined as:
 
-    sub    unique(*@values, :&as, :&with --> Seq:D)
-    method unique(List:D:  :&as, :&with --> Seq:D)
+    multi sub    unique(*@values, :&as, :&with --> Seq:D)
+    multi method unique(List:D:  :&as, :&with --> Seq:D)
 
 Returns a sequence of B<unique> values from the invocant/argument list, such
 that only the first occurrence of each duplicated value remains in the
@@ -662,8 +662,8 @@ Example:
 
 Defined as:
 
-    sub    repeated(*@values, :&as, :&with --> Seq:D)
-    method repeated(List:D:  :&as, :&with --> Seq:D)
+    multi sub    repeated(*@values, :&as, :&with --> Seq:D)
+    multi method repeated(List:D:  :&as, :&with --> Seq:D)
 
 Returns a sequence of B<repeated> values from the invocant/argument list.
 It takes the same parameters as L<C<unique>>, but instead of passing through
@@ -683,8 +683,8 @@ Examples:
 
 Defined as:
 
-    sub    squish(*@values, :&as --> Seq:D)
-    method squish(List:D:  :&as --> Seq:D)
+    multi sub    squish(*@values, :&as --> Seq:D)
+    multi method squish(List:D:  :&as --> Seq:D)
 
 Returns a sequence of values from the invocant/argument list where runs
 of more than one value are replaced with only the first instance.
@@ -706,8 +706,8 @@ temporarily transformed before comparison.
 
 Defined as:
 
-    sub    reduce(&with, *@values)
-    method reduce(List:D: &with)
+    multi sub    reduce(&with, *@values)
+    multi method reduce(List:D: &with)
 
 Generates a single "combined" value from a list of arbitrarily many of values,
 by iteratively applying a function which knows how to combine I<two> values.
@@ -774,8 +774,8 @@ it is a left fold.
 
 Defined as:
 
-    sub    produce(&with, *@values)
-    method produce(List:D: &with)
+    multi sub    produce(&with, *@values)
+    multi method produce(List:D: &with)
 
 Generates a list of all intermediate "combined" values along with the final
 result by iteratively applying a function which knows how to combine I<two>
@@ -831,9 +831,9 @@ C<redo> statements inside C<&with>:
 
 Defined as:
 
-    sub    combinations($n, $k                     --> Seq:D)
-    method combinations(List:D: Int:D $of          --> Seq:D)
-    method combinations(List:D: Range:D $of = 0..* --> Seq:D)
+    multi sub    combinations($n, $k                     --> Seq:D)
+    multi method combinations(List:D: Int:D $of          --> Seq:D)
+    multi method combinations(List:D: Range:D $of = 0..* --> Seq:D)
 
 The C<Int> variant returns all C<$of>-combinations of the invocant list.
 For example
@@ -879,8 +879,8 @@ systems have a limit of C<2³¹-1> and 32-bit systems have a limit of C<2²⁸-1
 
 Defined as:
 
-    sub    permutations($n      --> Seq:D)
-    method permutations(List:D: --> Seq:D)
+    multi sub    permutations($n      --> Seq:D)
+    multi method permutations(List:D: --> Seq:D)
 
 Returns all possible permutations of a list as a sequence of lists. So
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -72,7 +72,7 @@ check for the absence of elements.
     for @a, @a.list, @a.Seq -> \listoid {
         say listoid ~~ ()
     }
-    # OUTPUT«True␤True␤True␤»
+    # OUTPUT: «True␤True␤True␤»
 
 Coercion to Bool also indicates if the List got any elements.
 

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -321,7 +321,7 @@ checked unless the return value is C<Nil>. A control exception is raised and
 can be caught with L<CONTROL|/language/phasers#CONTROL>.
 
     sub f { (1|2|3).return };
-    dd f(); # OUTPUT«any(1, 2, 3)␤»
+    dd f(); # OUTPUT: «any(1, 2, 3)␤»
 
 =head2 method return-rw
 

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -79,7 +79,7 @@ Creates a new Promise that will be kept in C<$seconds> seconds, or later.
         my $promise = $proc.start,
         Promise.in(5).then: { note 'timeout'; $proc.kill }
     ).then: {$promise.result};
-    # OUTPUT«timeout␤»
+    # OUTPUT: «timeout␤»
 
 =head2 method at
 

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -26,16 +26,18 @@ called.
 
     multi sub f() is default { say "Hello there" }
     multi sub f() { say "Hello friend" }
-    f();   #"Hello there" is printed.
+    f();   # OUTPUT: «"Hello there"␤»
 
 The C<is default> trait can become very useful for debugging and other uses but
 keep in mind that it will only resolve an ambiguous dispatch between two C<Routine>s
 of the same precedence. If one of the C<Routine>s are narrower than another, then
 that one will be called. For example:
 
+    =begin code :skip-test
     multi sub f() is default { say "Hello there" }
     multi sub f(:$greet) { say "Hello " ~ $greet }
-    f();   #"Use of uninitialized value $greet..."
+    f();   # "Use of uninitialized value $greet..."
+    =end code
 
 In this example, the C<multi> without C<is default> was called because it was
 actually narrower than the C<Sub> with it.
@@ -275,7 +277,7 @@ OH NOEZ
 
 but if C<inner> is marked with C<hidden-from-backtrace>
 
-=begin code
+=begin code :skip-test
 sub inner is hidden-from-backtrace { die "OH NOEZ" };
 sub outer { inner() };
 outer();

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -16,9 +16,11 @@ A typical use case is L<method C<lines> in C<IO::Handle>|/type/IO::Handle#method
 which could use a lot of memory if it stored all the lines read from the
 file. So
 
+    =begin code :skip-test
     for open('README.md').lines -> $line {
         say $line;
     }
+    =end code
 
 won't keep all lines from the file in memory.
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -603,6 +603,7 @@ the C<0> flag is ignored:
 (Note that this feature currently works for unsigned integer conversions, but not
 for signed integer.)
 
+  =begin code :skip-test
   NYI sprintf '<%.6d>', 1;      # <000001>
   NYI sprintf '<%+.6d>', 1;     # <+000001>
   NYI sprintf '<%-10.6d>', 1;   # <000001    >
@@ -615,6 +616,7 @@ for signed integer.)
   sprintf '<%10.6x>', 1;       # OUTPUT: «<    000001>␤»
   sprintf '<%010.6x>', 1;      # OUTPUT: «<    000001>␤»
   sprintf '<%#10.6x>', 1;      # OUTPUT: «<  0x000001>␤»
+  =end code
 
 For string conversions, specifying a precision truncates the string to
 fit the specified width:
@@ -625,10 +627,12 @@ fit the specified width:
 You can also get the precision from the next argument using C<.*>, or
 from a specified argument (e.g., with C<.*2$>):
 
+  =begin code :skip-test
   sprintf '<%.6x>', 1;       # OUTPUT: «<000001>␤»
   sprintf '<%.*x>', 6, 1;    # OUTPUT: «<000001>␤»
   NYI sprintf '<%.*2$x>', 1, 6;  # "<000001>"
   NYI sprintf '<%6.*2$x>', 1, 4; # "<  0001>"
+  =end code
 
 If a precision obtained through C<*> is negative, it counts as having
 no precision at all:

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -45,7 +45,7 @@ called by hand.
 Marks a variable as dynamic, that is, accessible from inner dynamic scopes
 without being in an inner lexical scope.
 
-=begin code :allow<B L>
+=begin code :allow<B L> :skip-test
     sub introspect() {
         say B<$CALLER::x>;
     }

--- a/util/extract-examples.p6
+++ b/util/extract-examples.p6
@@ -52,7 +52,7 @@ my &verbose = sub (|c) {};
 sub MAIN(Str :$source-path!, Str :$prefix!, Str :$exclude = ".git", Bool :v(:verbose($v)), Bool :$force, *@files) {
     my \exclude = none(flat <. ..>, $exclude.split(','));
     # We exclude these files from examples list
-    my @exclude-list = '5to6', 'rb', 'module', 'nativecall', 'testing', 'traps', 'packages';
+    my @exclude-list = '5to6', 'rb', 'module', 'nativecall', 'testing', 'traps', 'packages', 'tables', 'phasers';
 
     @files ||= gather for $source-path {
         take .IO when .IO.f

--- a/xt/examples-compilation.t
+++ b/xt/examples-compilation.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+use lib 'lib';
+use File::Find;
+
+# Extract examples
+chdir $?FILE.IO.dirname.IO.dirname;
+my $p1 = run 'make', 'extract-examples';
+chdir 'examples';
+
+my @files = find(dir => '.',
+                 name => /'Type'|'Language' .*? .p6$/,
+                 exclude => /'exceptions.p6'|'ArgFiles.p6'/,
+                 type => 'file');
+my $proc;
+plan +@files;
+
+for @files -> $file {
+    $proc = run 'perl6', $file, out => '/dev/null', err => '/dev/null';
+    if $proc.exitcode == 0 {
+        pass "$file is compileable";
+    } else {
+        flunk "$file examples check isn't successful";
+    }
+}

--- a/xt/return-type.t
+++ b/xt/return-type.t
@@ -5,7 +5,7 @@ use lib 'lib';
 my @files;
 
 # Every .pod6 file in the Type directory.
-@files = qx<git ls-files>.lines.grep(* ~~ /'.pod6'/).grep(* ~~ /Type/);
+@files = qx<git ls-files>.lines.grep(* ~~ /'.pod6'/).grep(* ~~ /Type | Language/);
 
 plan +@files;
 


### PR DESCRIPTION
No more `#->`. No more `#=>`. No more `# OUTPUT<<`(all of these could be mixed even in a single file). Just our plain unified style described here: https://github.com/perl6/doc/issues/776#issuecomment-240106630
This is a final stage of formatting work, there will be (hopefully) no more such PRs.