### PR TITLE
Perl 6 -> Python in a nutshell, fixes

### DIFF
--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -46,9 +46,9 @@ contained in curly braces are interpolated.
 Perl 6
 
     my $planet = 'earth';
-    say "Hello, $planet";   # Hello, earth
-    say 'Hello, $planet';   # Hello, $planet
+    say "Hello, $planet";                 # Hello, earth
     say "Hello, planet number { 1 + 2 }"; # Hello, planet number 3
+    say 'I have $2';                      # I have $2
 
 =head2 Statement Separators
 
@@ -64,14 +64,14 @@ The semicolon may be omitted if it is the last statement
 of a block.  The semicolon may also be omitted if there
 is a closing curly brace followed by a newline.
 
-Python:
+Python
 
     print 1 + 2 + \
         3 + 4
     print ( 1 +
         2 )
 
-Perl 6:
+Perl 6
 
     say 1 + 2 +
         3 + 4;
@@ -79,24 +79,26 @@ Perl 6:
 
 =head2 Blocks
 
-In Python indentation is used to indicate a block.  Perl 6
+In Python, indentation is used to indicate a block.  Perl 6
 uses curly braces.
 
-Python:
+Python
+
     if 1 == 2:
         print "Wait, what?"
     else:
         print "1 is not 2."
 
-Perl 6:
+Perl 6
+
     if 1 == 2 {
         say "Wait, what?"
     } else {
         say "1 is not 2."
     }
 
-Parentheses are optional in both languages in expressions in conditionals,
-as shown above.
+Parentheses are optional in both languages in expressions in
+conditionals, as shown above.
 
 =head2 Variables
 
@@ -119,8 +121,9 @@ hold arrays, and variables starting with a C<%> hold a hash (dict).
 Immutable variables can be sigil-less, if they are declared with a C<\>.
 
 Python
+
     s = 10
-    l = [1,2,3]
+    l = [1, 2, 3]
     d = { a : 12, b : 99 }
 
     print s
@@ -129,6 +132,7 @@ Python
     # 10, 2, 12
 
 Perl 6
+
     my $s = 10;
     my @l = 1, 2, 3;
     my %d = a => 12, b => 99;
@@ -144,18 +148,20 @@ Perl 6
 =head2 Scope
 
 In Python, functions and classes create a new scope, but no other
-block constructor (e.g. loops, conditionals) creates a scope.  In Python 2,
-list comprehensions do not create a new scope, but in Python 3, they do.
+block constructor (e.g. loops, conditionals) creates a scope.  In
+Python 2, list comprehensions do not create a new scope, but in Python 3, they do.
 
 In Perl 6, every block creates a lexical scope.
 
 Python
+
     if True:
         x = 10
     print x
     # x is now 10
 
 Perl 6
+
     if True {
         my $x = 10
     }
@@ -170,6 +176,7 @@ Perl 6
     # ok, x is 10
 
 Python
+
    x = 10
    for x in 1, 2, 3:
        pass
@@ -177,6 +184,7 @@ Python
    # x is 3
 
 Perl 6
+
     my \x = 10;
     for 1, 2, 3 -> \x {
         # do nothing
@@ -187,13 +195,17 @@ Perl 6
 Lambdas in Python can be written as blocks or pointy blocks in Perl 6.
 
 Python
+
     l = lambda i: i + 12
+
 Perl 6
+
     $l = -> $i { $i + 12 }
 
 Another Perl 6 idiom for constructing lambdas is the Whatever star, C<*>.
 
 Perl 6
+
     $l = * + 12    # same as above
 
 A C<*> in an expression will become a placeholder for the argument,
@@ -205,6 +217,7 @@ See the section below for more constructs regarding subroutines and blocks.
 Another example (from the Python L<FAQ|https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result>):
 
 Python
+
     squares = []
     for x in range(5):
         squares.append(lambda: x ** 2)
@@ -213,16 +226,17 @@ Python
     # both 16 since there is only one x
 
 Perl 6
-    my \squares = [];
+
+    my @squares;
     for ^5 -> \x {
-        squares.append({ x² });
+        @squares.append({ x² });
     }
-    say squares[2]();
-    say squares[4]();
+    say @squares[2]();
+    say @squares[4]();
     # 4, 16 since each loop iteration has a lexically scoped x,
 
 Note that C<^N> is like C<range(N)>.  Similarly,
-C<N..^M> works like C<range(N,M)> (a list from N
+C<N..^M> works like C<range(N, M)> (a list from N
 to M - 1).  C<N..M> is a list from N to M.  The
 C<^> before or after the C<..> indicates that the
 beginning or ending endpoint of the list (or both)
@@ -238,6 +252,7 @@ or symbol that can be used in Perl 6 has an ASCII equivalent
 =head2 Control Flow
 
 Python has C<for> loops and C<while> loops:
+
     for i in 1, 2:
         print i
     j = 1
@@ -248,6 +263,7 @@ Python has C<for> loops and C<while> loops:
     # 1, 2, 1, 2
 
 Perl 6 also has C<for> loops and C<while> loops:
+
     for 1, 2 -> $i {
         say $i
     }
@@ -265,6 +281,7 @@ C<break> in Python.  C<continue> in Python is C<next>
 in Perl 6.
 
 Python
+
     for i in range(10):
         if i == 3:
             continue
@@ -273,6 +290,7 @@ Python
         print i
 
 Perl 6
+
     for ^10 -> $i {
         next if $i == 3;
         last if $i == 5;
@@ -341,6 +359,7 @@ In Perl 6, positional and named arguments are determined
 by the signature of the routine.
 
 Python
+
     def speak(word, times):
         for i in range(times):
             print word
@@ -399,7 +418,7 @@ Perl 6
     $square = { $^x ** 2 };          # placeholder variable
     $square = { $_ ** 2 };           # topic variable
 
-Placeholder variables are lexicographically ordered to form positional parameters.
+Placeholder variables are put in lexicographic order to form positional parameters.
 i.e. these are the same:
 
     $power = { $^x ** $^y }
@@ -418,25 +437,26 @@ Perl 6
     ( -> \i { i * 2 } for 3, 9 );
     ( { $^i * 2 } for 3, 9 );
     ( { $_ * 2 } for 3, 9 );
+    ( * * 2 for 3, 9 );
 
 Conditionals can be applied, but the C<if> comes first,
 unlike in Python where the if comes second.
 
-    [ x * 2 for x in 1, 2, 3 if x > 1 ]
+    [ x * 2 for x in 1, 2, 3 if x > 1 ]   # Python
 
 vs
 
-    ( $_ * 2 if $_ > 1 for 1, 2, 3 );
+    ( $_ * 2 if $_ > 1 for 1, 2, 3 )      # Perl 6
 
 For nested loops, the cross product operator C<X>
 will help:
 
-    [ i + j for i in 3,9 for j in 2,10 ]
+    [ i + j for i in 3, 9 for j in 2, 10 ]  # Python
 
 becomes either of these:
 
-    ( { $_[0] + $_[1] } for (3,9) X (2,10) );
-    ( -> (\i, \j) { i + j } for (3,9) X (2,10) );
+    ( { $_[0] + $_[1] } for (3, 9) X (2, 10) );       # Perl 6, topic variable
+    ( -> (\i, \j) { i + j } for (3, 9) X (2, 10) );   # Perl 6, pointy block
 
 Using C<map> (which is just like Python's C<map>) is
 an alternative.
@@ -447,11 +467,13 @@ Here's an example from the Python L<docs|https://docs.python.org/3/tutorial/clas
 First, "instance variables", aka attributes in Perl 6:
 
 Python:
+
     class Dog:
         def __init__(self, name):
             self.name = name
 
 Perl 6:
+
     class Dog {
         has $.name;
     }
@@ -460,12 +482,14 @@ Constructors by default take named arguments in Perl 6,
 and use the method C<new>.
 
 Python
+
     d = Dog('Fido')
     e = Dog('Buddy')
     print d.name
     print e.name
 
 Perl 6
+
     my $d = Dog.new(:name<Fido>);
     my $e = Dog.new(:name<Buddy>);
     say $d.name;
@@ -475,6 +499,7 @@ Class attributes in Perl 6 can be declared in a few ways.  One way
 is to just declare a lexical variable and a method for accessing it.
 
 Python:
+
     class Dog:
         kind = 'canine'                # class attribute
         def __init__(self, name):
@@ -487,6 +512,7 @@ Python:
     print e.name
 
 Perl 6:
+
     class Dog {
         my $kind = 'canine';           # class attribute
         method kind { $kind }
@@ -503,6 +529,7 @@ Perl 6:
 To mutate attributes, in Perl 6 you"ll want to use C<is rw>:
 
 Python:
+
     class Dog:
         def __init__(self, name):
             self.name = name
@@ -510,6 +537,7 @@ Python:
     d.name = 'rover'
 
 Perl 6:
+
     class Dog {
         has $.name is rw;
     }
@@ -519,6 +547,7 @@ Perl 6:
 Inheritance is done using C<is>:
 
 Python
+
     class Animal:
         def jump:
             print "I am jumping"
@@ -530,6 +559,7 @@ Python
     d.jump()
 
 Perl 6
+
     class Animal {
         method jump {
             say "I am jumping"
@@ -542,9 +572,10 @@ Perl 6
     my $d = Dog.new;
     $d.jump;
 
-Multiple inheritance is possible with multiple C<is> traits, or with C<also>.
+Multiple inheritance is possible by using C<is> multiple times, or with C<also>.
 
 Python
+
     class Dog(Animal, Friend, Pet):
         pass
 
@@ -563,9 +594,10 @@ or
 =head2 Decorators
 
 Decorators in Perl 6 are a way of wrapping a function
-in another one.  In Perl 6 this is done with C<wrap>.
+in another one.  In Perl 6, this is done with C<wrap>.
 
 Python
+
     def greeter(f):
         def new():
             print 'hello'
@@ -579,6 +611,7 @@ Python
     world();
 
 Perl 6
+
     sub world {
         say 'world'
     }
@@ -590,7 +623,7 @@ Perl 6
 
     world;
 
-An alternative would be to use a trait:
+To encapsulate the wrapping, it can be done in a trait:
 
     # declare the trait 'greeter'
     multi sub trait_mod:<is>(Routine $r, :$greeter) {
@@ -615,7 +648,7 @@ Here's a python context manager that prints the strings
 'hello', 'world', and 'bye':
 
     class hello:
-        def __exit__(self, type, value, traceback):
+        def __exit__(self, type, value, trace):
             print 'bye'
         def __enter__(self):
             print 'hello'

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -418,7 +418,7 @@ Perl 6
     $square = { $^x ** 2 };          # placeholder variable
     $square = { $_ ** 2 };           # topic variable
 
-Placeholder variables are put in lexicographic order to form positional parameters.
+Placeholder variables are lexicographically ordered to form positional parameters.
 i.e. these are the same:
 
     $power = { $^x ** $^y }


### PR DESCRIPTION
This fixes a few issues with py-nutshell:
- a few cases of nbsps for "Perl 6":
- consistent use of colons for indicating the language
- added missing blank lines around code blocks
- some slight changes to wording and examples