### PR TITLE
Document the infix method call operators

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -23,6 +23,7 @@ tightest to loosest:
     N  Autoincrement     ++ --
     R  Exponentiation    **
     L  Symbolic unary    ! + - ~ ? | || +^ ~^ ?^ ^
+    L  Dotty infix       .= .
     L  Multiplicative    * / % %% +& +< +> ~& ~< ~> ?& div mod gcd lcm
     L  Additive          + - +| +^ ~| ~^ ?| ?^
     L  Replication       x xx
@@ -35,7 +36,7 @@ tightest to loosest:
     X  Tight and         &&
     X  Tight or          || ^^ // min max
     R  Conditional       ?? !! ff fff
-    R  Item assignment   = => += -= **= xx= .=
+    R  Item assignment   = => += -= **= xx=
     L  Loose unary       so not
     X  Comma operator    , :
     X  List infix        Z minmax X X~ X* Xeqv ...
@@ -881,6 +882,41 @@ excluding) the argument.
 
     say ^5;         # OUTPUT: «0..^5␤»
     for ^5 { }      # 5 iterations
+
+=head1 Dotty Infix Precedence
+
+These operators are like their Method Postfix counterparts, but require
+surrounding whitespace (before and/or after) to distinguish them.
+
+=head2 infix C«.=»
+
+Calls the right-side method on the value in the left-side container,
+replacing the resulting value in the left-side container.
+
+In most cases this behaves identically to the the postfix mutator, but the
+precedence is lower so:
+
+    my $a = -5
+    say ++$a.=abs
+    # OUTPUT: «6␤»
+    say ++$a .= abs
+    # OUTPUT: «Cannot modify an immutable Int␤
+    #           in block <unit> at <tmp> line 1␤␤»
+
+=head2 infix C«.»
+
+Calls the following method (whose name must be alphabetic) on the left-side
+invocant.
+
+Note that the infix form of the operator has a slightly lower precedence
+than postfix C<.meth>.
+
+    say -5.abs      # like: -(5.abs)
+    # OUTPUT: «-5␤»
+    say -5 . abs    # like: (-5) . abs
+    # OUTPUT: «5␤»
+    say -5 .abs     # following whitespace is optional
+    # OUTPUT: «5␤»
 
 =head1 Multiplicative Precedence
 


### PR DESCRIPTION
This documents the behavior implemented in:
    https://github.com/rakudo/rakudo/commit/cb25b2f475f31335d77d018474482aceec2c74de
and
    https://github.com/rakudo/rakudo/commit/be141b8d9bddc9798db6f11f70cdb117b7309526