### PR TITLE
doc/Type: correct List definition

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE Sequence of values
 
 =for code :skip-test
-my class List is Iterable does Positional { }
+my class List does Iterable does Positional { }
 
 C<List> stores items sequentially and potentially lazily.
 


### PR DESCRIPTION
Sync with latest rakudo definition for `List`