### PR TITLE
Capitalize the Exception method

### DIFF
--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -34,11 +34,11 @@ Returns C<True> for handled failures, C<False> otherwise.
 
     sub f() { fail }; my $v = f; say $v.handled; # OUTPUT: «False␤»
 
-=head2 method exception
+=head2 method Exception
 
 Defined as:
 
-    method exception(Failure:D: --> Exception)
+    method Exception(Failure:D: --> Exception)
 
 Returns the L<Exception> object that the failure wraps.
 


### PR DESCRIPTION
The example shows it capitalize and running it uncapitalized does nothing apparently (but certainly not what the example does).