### PR TITLE
5to6: Add caution about `exec` workarounds

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -394,7 +394,21 @@ Nothing in Perl 6 exactly replicates the Perl 5 C<exec>. C<shell> and
 C<run> are similar to Perl 5's C<system>, but C<exec>'s behavior of not
 returning after executing a system command would have to be emulated by
 something like C<shell($command);exit();> or possibly C<exit
-shell($command);>
+shell($command);>.
+
+Neither of these workarounds have the behavior (on Unix-like systems)
+of I<replacing> your Perl program's process with the new program;
+notably, they will not work for the practice in some long-running
+daemons of periodically "re-execing themselves" to reset their state
+or force operating-system cleanup. Nor will they serve C<exec>'s
+function of returning stale resources to the operating system.
+
+If you want C<exec> for these behaviors, you can use an C<exec*>
+function via the C<NativeCall> interface. Consult your operating
+system manual pages for C<exec> (or other similarly-named calls such
+as C<execl>, C<execv>, C<execvp>, or C<execvpe>). (Beware: these
+calls are not generally portable between Unix-like opearitng system
+families.)
 
 =head2 exists
 


### PR DESCRIPTION
"shell and exit" are poor substitutes for exec in some common
situations. Add language to 5to6-perlfunc to explain these situations
and suggest NativeCall if they pertain.

Also note that most Unixes have no single "exec" function exactly (Perl
5 automagically dispatches the right one for the situation).