### PR TITLE
5to6-perlfunc: Fix typo

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -407,7 +407,7 @@ If you want C<exec> for these behaviors, you can use an C<exec*>
 function via the C<NativeCall> interface. Consult your operating
 system manual pages for C<exec> (or other similarly-named calls such
 as C<execl>, C<execv>, C<execvp>, or C<execvpe>). (Beware: these
-calls are not generally portable between Unix-like opearitng system
+calls are not generally portable between Unix-like operating system
 families.)
 
 =head2 exists


### PR DESCRIPTION
I apparently managed to hit the transpose key a few times accidentally
right after spell-checking...