### PR TITLE
Added a note about run/shell exceptions due to non-zero exits

### DIFF
--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -38,6 +38,12 @@ all output pipes, the program will usually not terminate.
     }
     $git.out.close();
 
+If the program fails (exits with a non-zero exit code), it will throw
+an exception when the return object is sunk.  You can capture the
+L<Proc|/type/Proc> object to avoid this if needed.
+
+    my $don't-die = run '/bin/false';
+
 You can tell the C<Proc> object to capture output as a file handle by passing
 the C<:out> and C<:err> flags. You may also pass input via the C<:in> flag.
 

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -423,7 +423,7 @@ Using the terminal run the following command:
 perl6 --doc=Markdown input.pod6 > output.md
 =end code
 
-=head Text
+=head2 Text
 
 In order to generate Text from Pod, you can use the default
 C<Pod::To::Text> module.

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -423,4 +423,27 @@ Using the terminal run the following command:
 perl6 --doc=Markdown input.pod6 > output.md
 =end code
 
+=head Text
+
+In order to generate Text from Pod, you can use the default
+C<Pod::To::Text> module.
+
+Using the terminal, run the following command:
+=begin code
+perl6 --doc input.pod6 > output.txt
+=end code
+
+You can even embed Pod directly in your program and add the
+traditional Unix command line "--man" option to your program with a
+multi MAIN subroutine like this:
+
+=begin code
+multi MAIN(Bool :$man)
+{
+    run $*EXECUTABLE, '--doc', $*PROGRAM;
+}
+=end code
+
+Now C<myprogram --man> will output your Pod rendered as a man page.
+
 =end pod


### PR DESCRIPTION
Per discussion on IRC and SO:

http://stackoverflow.com/questions/43199427/why-doesnt-perl-6s-try-handle-a-non-zero-exit-in-shell
