### PR TITLE
Document that Failure.handled is an lvalue

### DIFF
--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -34,6 +34,14 @@ Returns C<True> for handled failures, C<False> otherwise.
 
     sub f() { fail }; my $v = f; say $v.handled; # OUTPUT: «False␤»
 
+The C<handled> method is an lvalue, which means you can also use it to set the
+handled state:
+
+    sub f() { fail }
+    my $v = f;
+    $v.handled = True;
+    say $v.handled; # OUTPUT: «True␤»
+
 =head2 method exception
 
 Defined as:


### PR DESCRIPTION
Something I learned today as part of code review. Thought it might be useful in the documentation.