### PR TITLE
Fix grammer around IO::Handle.getc.

### DIFF
--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -126,7 +126,7 @@ Defined as:
 Reads a single line of input from the handle, removing the trailing newline
 characters (as set by L«C<.nl-in>|/routine/nl-in»)
 if the handle's C<.chomp> attribute is set to C<True>. Returns
-C<Nil>, if no more input as available. The subroutine form defaults to
+C<Nil>, if no more input is available. The subroutine form defaults to
 L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES» if no handle
 is given.
 
@@ -155,7 +155,7 @@ Reads a single character from the input stream. Attempting to call this method
 when the handle is L<in binary mode|/type/IO::Handle#method_encoding> will
 result in C<X::IO::BinaryMode> exception being thrown. The subroutine form
 defaults to L«C<$*ARGFILES>|/language/variables#index-entry-%24%2AARGFILES» if
-no handle is given. Returns C<Nil>, if no more input as available, otherwise
+no handle is given. Returns C<Nil>, if no more input is available, otherwise
 operation will block, waiting for at least one character to be available; these
 caveats apply:
 


### PR DESCRIPTION
Fix grammer around IO::Handle.getc.