### PR TITLE
Correct Perl 6 interpretation of trap examples.

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -382,11 +382,11 @@ Interpolation in string literals can be too clever for your own good.
 
 =for code :skip-test
     "$foo<html></html>" # Perl 6 understands that as:
-    $foo<html> ~ '</html>'
+    "$foo{'html'}{'/html'}"
 
 =for code :skip-test
     "$foo(" ~ @args ~ ")" # Perl 6 understands that as:
-    $foo( ~ @args ~ ")"   # and will produce very confusing error messages
+    "$foo(' ~ @args ~ ')"  
 
 You can avoid those problems using non-interpolating single quotes and switching
 to more liberal interpolation with C<\qq[]> escape sequence:


### PR DESCRIPTION
While browsing the traps section I came across the examples traps in "quotes and interpolation", and the "Perl 6 understands that as ..."  answers looked all wrong to me.  Here are my suggested corrections.

FWIW, the "You can avoid those problems ... "  section looks equally confusing to me -- I know Perl 6 (or think that I do) and yet I have to really work to figure out what the alternative is accomplishing.  Jumping straight into qq[] and :c feels very line-noisey to me.

To me some much simpler alternatives might be:

```
   "$foo\<html></html>"
   "{$foo}<html></html>"

   "{$foo}(" ~ @args ~ ")"
   "$foo\(@args[])"
```

Pm