### PR TITLE
if/elsif/else construct being one statement simplifies explanation

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -97,9 +97,8 @@ if True { say "Hello" }; say "world";
 #                     ^^^ this ; is required
 =end code
 
-As a special case, a series of blocks that are part of the same C<if>/C<elsif>/C<else> (or similar) construct
-are treated as a single statement, with an implied statement separator following the last block of the series,
-if the last closing curly brace is followed by a newline character.
+An C<if>/C<elsif>/C<else> (or similar) construct is a single statement and can have the aforementioned implied
+statement separator following its last closing curly C<}>.
 
 These three are equivalent:
 =begin code


### PR DESCRIPTION
Jonathan Worthington pointed out that the if/elsif/else block is really a single statement, which makes this easier to explain.