### PR TITLE
How to work around immutable string issue when using map

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -302,6 +302,22 @@ not. The C<s///> operator works on a variable, into which it puts a newly
 created string object. Likewise, C<$i++> works on the C<$i> variable, not
 just on the value in it.
 
+So, you cannot do the following, because they try to change the original C<Str>:
+
+    my @foo = <hello world>.map: { s/h/H/} ; # dies with
+                                             # Cannot modify an immutable Str (hello)
+
+    my @bar = <hello world>.map: { .subst-mutate('h','H')}; # dies with 
+                                                            # Cannot resolve caller subst-mutate(Str: Str, Str);
+                                                            # the following candidates match the type but require
+                                                            # mutable arguments: ...
+
+But if you use an operator that returns a new value instead of changing the 
+original, you can acheive your goal:
+
+    my @foo = <hello world>.map: { .subst('h','H')}; # ['Hello','world']
+    my @bar = <hello world>.map: { .uc };            # ['HELLO','WORLD']
+    
 See the documentation on L<containers|/language/containers> for more
 information.
 

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -302,7 +302,9 @@ not. The C<s///> operator works on a variable, into which it puts a newly
 created string object. Likewise, C<$i++> works on the C<$i> variable, not
 just on the value in it.
 
-So, you cannot do the following, because they try to change the original C<Str>:
+Knowing this, you would not try to change a literal string (e.g. like 
+C<'hello' ~~ s/h/H/; #doesn't work>), but you might accidentally do
+something equivalent using `map`:
 
     my @foo = <hello world>.map: { s/h/H/} ; # dies with
                                              # Cannot modify an immutable Str (hello)
@@ -312,8 +314,7 @@ So, you cannot do the following, because they try to change the original C<Str>:
                                                             # the following candidates match the type but require
                                                             # mutable arguments: ...
 
-But if you use an operator that returns a new value instead of changing the 
-original, you can acheive your goal:
+Instead, use an operator that returns a new value instead of changing the original:
 
     my @foo = <hello world>.map: { .subst('h','H')}; # ['Hello','world']
     my @bar = <hello world>.map: { .uc };            # ['HELLO','WORLD']


### PR DESCRIPTION
Explained how one may encounter errors with immutable objects using `map` and gave examples of how to work around the issue.