### PR TITLE
Implied separator rule: focus on ending blocks (instead of the curly brace itself)

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -71,14 +71,11 @@ routine argument lists.
     alignment\         (1,2,3,4).say;
     long-name-alignment(3,5)\   .say;
 
-=head2 Separating Statements
+=head2 Separating Statements with Semicolons
 
 A Perl 6 program is a list of statements, separated by semicolons C<;>.
 A semicolon after the final statement (or after the final statement inside a
 block) is optional, though it's good form to include it.
-
-In general, a closing curly brace followed by a newline character implies a statement
-separator,  which is why you don't need to write a semicolon after an C<if> statement block.
 
 =begin code
 if True {
@@ -90,15 +87,24 @@ say "world";
 Both semicolons are optional here, but leaving them out increases the chance
 of syntax errors when adding more lines later.
 
-You do need to include a semicolon between the C<if> block and the say statement if you want them all on one line.
+=head2 Implied Separator Rule (for statements ending in blocks)
+
+Complete statements ending in blocks can omit the trailing semicolon, if no
+additional statements on the same line follow the the block's closing curly
+brace C<}>. This is called the "implied separator rule". For example, you
+don't need to write a semicolon after an C<if> statement block as seen above.
+
+If you want additional statements to trail the block, you do need to include
+a semicolon between the block and the statement.
 
 =begin code
 if True { say "Hello" }; say "world";
 #                     ^^^ this ; is required
 =end code
 
-This doesn't happen in series of blocks that are part of the same C<if>/C<elsif>/C<else> (or similar) construct
-because they are part of a single statement. The implied separator rule only applies at the end. These three are equivalent:
+However, for a series of blocks that are part of the same C<if>/C<elsif>/C<else> (or similar)
+construct, the implied separator rule only applies at the end of the last block of that series.
+These three are equivalent:
 
 =begin code
 if True { say "Hello" } else { say "Goodbye" }; say "world";
@@ -112,8 +118,19 @@ say "world";
 
 =begin code
 if True { say "Hello" }   # still in the middle of an if/else statement
-else    { say "Goodbye" } # <- implied statement separator, just after }
+else    { say "Goodbye" } # <- no semicolon required because it ends in a block
+                          #    without trailing statements in the same line
 say "world";
+=end code
+
+But, remember, this implied statement separator rule applies in other ways that
+statements could end with block. For example, in combination with the colon C<:>
+syntax for method calls:
+
+=begin code
+my @names = <Foo Bar Baz>;
+my @upper-case-names = @names.map: { .uc }
+# [FOO BAR BAZ]
 =end code
 
 =head2 Comments


### PR DESCRIPTION
I've modified the explanation to focus more on the ending blocks than on the ending semicolon. This is to make improvements toward resolving (or at least mitigating) concerns with issue #1471. Also included an example of implied separator rule with a colon method call.