### PR TITLE
Proc::Async example with ｢react｣

### DIFF
--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -28,7 +28,7 @@ standard output and error handles, and optionally write to its standard input.
             say ‘stderr: ’, $_
         }
         whenever $proc.start {
-            say ‘Proc finished’;
+            say ‘Proc finished. Exit code: ’, .exitcode;
             done # gracefully jump from the react block
         }
         whenever $proc.print: “I\n♥\nCamelia\n” {
@@ -66,7 +66,7 @@ line: and
 line: Camelia
 line: ♥
 line: I
-Proc finished
+Proc finished. Exit code: 0
 Program finished
 =end code
 

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -57,6 +57,19 @@ standard output and error handles, and optionally write to its standard input.
     say ‘Program finished’;
 
 
+Example above produces the following output:
+=begin code :skip-test
+line: me
+line: ♡
+line: Camelia
+line: and
+line: Camelia
+line: ♥
+line: I
+Proc finished
+Program finished
+=end code
+
 Alternatively, you can use C<Proc::Async> without using a
 L<react|/language/concurrency#index-entry-react> block:
 

--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -14,6 +14,52 @@ moment.
 C<Proc::Async> allows you to run external commands asynchronously, capturing
 standard output and error handles, and optionally write to its standard input.
 
+    my $file = ‘foo’.IO;
+    spurt $file, “and\nCamelia\n♡\nme\n”;
+
+    my $proc = Proc::Async.new: :w, ‘tac’, ‘--’, $file, ‘-’;
+    # my $proc = Proc::Async.new: :w, ‘sleep’, 15; # uncomment to try timeouts
+
+    react {
+        whenever $proc.stdout.lines { # split input on \r\n, \n, and \r
+            say ‘line: ’, $_
+        }
+        whenever $proc.stderr { # chunks
+            say ‘stderr: ’, $_
+        }
+        whenever $proc.start {
+            say ‘Proc finished’;
+            done # gracefully jump from the react block
+        }
+        whenever $proc.print: “I\n♥\nCamelia\n” {
+            $proc.close-stdin
+        }
+        whenever signal(SIGTERM).merge: signal(SIGINT) {
+            once {
+                say ‘Signal received, asking the process to stop’;
+                $proc.kill; # send SIGHUP
+                whenever signal($_).zip: Promise.in(2).Supply {
+                    say ‘Kill it!’;
+                    $proc.kill: SIGKILL
+                }
+            }
+        }
+        whenever Promise.in(10) {
+            say ‘Timeout. Asking the process to stop’;
+            $proc.kill; # send SIGHUP
+            whenever Promise.in(2) {
+                say ‘Timeout. Forcing the process to stop’;
+                $proc.kill: SIGKILL
+            }
+        }
+    }
+
+    say ‘Program finished’;
+
+
+Alternatively, you can use C<Proc::Async> without using a
+L<react|/language/concurrency#index-entry-react> block:
+
     # command with arguments
     my $proc = Proc::Async.new('echo', 'foo', 'bar');
 


### PR DESCRIPTION
Tackle issue #1468.

IMO in this case it is reasonable to expect that people will be
copying the example and reducing it to their needs, so I tried to
include everything that may be needed.

The logic for kill signals is questionable, I don't know if there's
anything better we can show.

**This is not mergeable because of [RT #132016](https://rt.perl.org/Ticket/Display.html?id=132016)**. Either wait for the
ticket to be resolved or get rid of ｢Supply.merge｣ and ｢Supply.zip｣.