### PR TITLE
Clear ambiguity regarding Int/Real rand()

### DIFF
--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -21,9 +21,9 @@ Converts the number to a C<Rat> with the precision C<$epsilon>.
     sub term:<rand> (--> Num:D)
     method rand(Real:D: --> Real:D)
 
-Returns a pseudo-random number between zero and the number.
+Returns a pseudo-random number between zero (inclusive) and the number (non-inclusive.)
 
-The term form returns a pseudo-random C<Num> between 0e0 and 1e0.
+The term form returns a pseudo-random C<Num> between 0e0 (inclusive) and 1e0 (non-inclusive.)
 
 =head2 method sign
 


### PR DESCRIPTION
Specify whether the endpoints are included or not when selecting the
pseudo-random number.

References:

- https://github.com/perl6/roast/blob/master/S32-num/rand.t#L13-L30
- https://github.com/MoarVM/MoarVM/blob/master/3rdparty/tinymt/tinymt64.c#L97-L116

Fixes #787.