### PR TITLE
Change $p to $promise in Async documentation

### DIFF
--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -29,9 +29,9 @@ And a client that connects to it, and prints out what the server answers:
 =begin code
 use v6.c;
 
-await IO::Socket::Async.connect('localhost', 3333).then( -> $p {
-    if $p.status {
-        given $p.result {
+await IO::Socket::Async.connect('localhost', 3333).then( -> $promise {
+    if $promise.status {
+        given $promise.result {
             .print('Hello, Perl 6');
             react {
                 whenever .Supply() -> $v {


### PR DESCRIPTION
As per Issue #1213, change the use of $p to $promise to make it
more expressive.