### PR TITLE
Link to non-raw GitHub page, with edit link

### DIFF
--- a/lib/Pod/Htmlify.pm6
+++ b/lib/Pod/Htmlify.pm6
@@ -93,14 +93,18 @@ sub footer-html($pod-path) is export {
     my $footer = slurp 'template/footer.html';
     $footer.subst-mutate(/DATETIME/, ~DateTime.now.utc.truncated-to('seconds'));
     my $pod-url;
+    my $edit-url;
     my $gh-link = q[<a href='https://github.com/perl6/doc'>perl6/doc on GitHub</a>];
     if $pod-path eq "unknown" {
         $pod-url = "the sources at $gh-link";
+        $edit-url = "";
     }
     else {
-        $pod-url = "<a href='https://github.com/perl6/doc/raw/master/doc/$pod-path'>$pod-path\</a\> from $gh-link";
+        $pod-url = "<a href='https://github.com/perl6/doc/blob/master/doc/$pod-path'>$pod-path\</a\> from $gh-link";
+        $edit-url = "<a href='https://github.com/perl6/doc/edit/master/doc/$pod-path'>Edit this page\</a\>.";
     }
     $footer.subst-mutate(/SOURCEURL/, $pod-url);
+    $footer.subst-mutate(/EDITURL/, $edit-url);
     state $source-commit = qx/git rev-parse --short HEAD/.chomp;
     $footer.subst-mutate(:g, /SOURCECOMMIT/, $source-commit);
 

--- a/template/footer.html
+++ b/template/footer.html
@@ -4,6 +4,7 @@
       Generated on DATETIME from SOURCEURL, commit <a href="https://github.com/perl6/doc/commit/SOURCECOMMIT"><span id="footer-commit">SOURCECOMMIT</span></a>.
       This is a work in progress to document Perl 6, and known to be
       incomplete.
+      EDITURL
       <a href="https://github.com/perl6/doc/blob/master/CONTRIBUTING.md#reporting-bugs">Please report any issues.</a>
       Your contribution is appreciated.
   </p>


### PR DESCRIPTION
Let the pod6 docs link to their non-raw GitHub pages, so visitors can
see and maybe help out on improving some more.  And for convenience,
also provide an edit link.

There's probably some more improvement to do on the footer as well; will
further work on separate commits/PRs.
