### PR TITLE
Split and rephrase lines in the footer

### DIFF
--- a/lib/Pod/Htmlify.pm6
+++ b/lib/Pod/Htmlify.pm6
@@ -97,11 +97,11 @@ sub footer-html($pod-path) is export {
     my $gh-link = q[<a href='https://github.com/perl6/doc'>perl6/doc on GitHub</a>];
     if $pod-path eq "unknown" {
         $pod-url = "the sources at $gh-link";
-        $edit-url = "";
+        $edit-url = ".";
     }
     else {
         $pod-url = "<a href='https://github.com/perl6/doc/blob/master/doc/$pod-path'>$pod-path\</a\> from $gh-link";
-        $edit-url = "<a href='https://github.com/perl6/doc/edit/master/doc/$pod-path'>Edit this page\</a\>.";
+        $edit-url = " or <a href='https://github.com/perl6/doc/edit/master/doc/$pod-path'>edit this page\</a\>.";
     }
     $footer.subst-mutate(/SOURCEURL/, $pod-url);
     $footer.subst-mutate(/EDITURL/, $edit-url);

--- a/lib/Pod/Htmlify.pm6
+++ b/lib/Pod/Htmlify.pm6
@@ -100,7 +100,7 @@ sub footer-html($pod-path) is export {
         $edit-url = ".";
     }
     else {
-        $pod-url = "<a href='https://github.com/perl6/doc/blob/master/doc/$pod-path'>$pod-path\</a\> from $gh-link";
+        $pod-url = "<a href='https://github.com/perl6/doc/blob/master/doc/$pod-path'>$pod-path\</a\> at $gh-link";
         $edit-url = " or <a href='https://github.com/perl6/doc/edit/master/doc/$pod-path'>edit this page\</a\>.";
     }
     $footer.subst-mutate(/SOURCEURL/, $pod-url);

--- a/template/footer.html
+++ b/template/footer.html
@@ -1,12 +1,15 @@
 </div>
 <footer class="pretty-box yellow">
   <p>
-      Generated on DATETIME from SOURCEURL, commit <a href="https://github.com/perl6/doc/commit/SOURCECOMMIT"><span id="footer-commit">SOURCECOMMIT</span></a>.
+      From SOURCEURL, commit <a href="https://github.com/perl6/doc/commit/SOURCECOMMIT"><span id="footer-commit">SOURCECOMMIT</span></a>.
+      <br/>
       This is a work in progress to document Perl 6, and known to be
       incomplete.
-      EDITURL
-      <a href="https://github.com/perl6/doc/blob/master/CONTRIBUTING.md#reporting-bugs">Please report any issues.</a>
+      <br/>
+      <a href="https://github.com/perl6/doc/blob/master/CONTRIBUTING.md#reporting-bugs">Please report any issues</a>EDITURL
       Your contribution is appreciated.
+      <br/>
+      Generated on DATETIME
   </p>
   <p>
       This documentation is provided under the terms of the


### PR DESCRIPTION
The first paragraph/line was getting too long, so split it a bit and
rephrase to emphasize source location and actions to either report
issues and/or edit/fork.

Fixes #1535.