### PR TITLE
It seems we have sub form of `Str`

### DIFF
--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -104,7 +104,8 @@ public attributes:
 
 =head2 method Str
 
-    multi method Str(--> Str)
+    multi sub    Str(Mu --> Str)
+    multi method Str(   --> Str)
 
 Returns a string representation of the invocant, intended to be machine
 readable. Method C<Str> warns on type objects, and produces the empty string.


### PR DESCRIPTION
It seems we have sub form of `Str`
`say Str(Mu.new()).perl; # OUTPUT: "Mu<140381106429184>"`
`say Str(42).perl; # OUTPUT: "42"`

But `say Str(Mu); # OUTPUT: (Str(Mu))`, which perform different from `Mu.Str`