### PR TITLE
Add a short introduction to subroutines and precedence dropping.

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -670,9 +670,9 @@ Within a method the special variable C<self> contains the object instance
 
     =begin code :skip-test
     # Method invocation. Object (instance) is $person, method is set-name-age
-    $person.set-name-age('jane', 98);  # Most common way
-    $person.set-name-age: 'jane', 98;      # Precedence drop
-    set-name-age($person: 'jane', 98);     # Invocant marker
+    $person.set-name-age('jane', 98);   # Most common way
+    $person.set-name-age: 'jane', 98;   # Precedence drop
+    set-name-age($person: 'jane', 98);  # Invocant marker
     =end code
 
 For more information see L<functions|/language/functions>.

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -644,7 +644,16 @@ Inside of a class, you can also declare multi-dispatch methods.
 
 =head1 Subroutine calls
 
-See L<functions|/language/functions>.
+Subroutines are created with the keyword C<sub> followed
+by an optional name, an optional signature and a code block.
+Subroutine are lexically scoped, so if a name is specified
+at the declaration, the same name can be used
+in the lexical scope to invoke the subroutine.
+A subroutine is an instance of type L<Sub|type/Sub> and
+can be assigned to any container.
+
+
+
 
 =comment TODO
 
@@ -654,8 +663,14 @@ See L<functions|/language/functions>.
     &f();  # Invoke &f, which contains a function
     &f.(); # Same as above, needed to make the following work
     my @functions = ({say 1}, {say 2}, {say 3});
-    @functions>>.();
+    @functions>>.(); # hyper method call operator
     =end code
+
+When declared within a class, a subroutine is named "method": methods
+are subroutines invoked against an object (i.e., a class instance).
+Within a method the special variable C<self> contains the object instance
+(see L<Methods|classtut#Methods>).
+
 
     =begin code :skip-test
     # Method invocation. Object (instance) is $person, method is set-name-age
@@ -664,6 +679,31 @@ See L<functions|/language/functions>.
     set-name-age($person: 'jane', 98);     # Invocant marker
     =end code
 
+<<<<<<< HEAD
+=======
+For more information see L<functions|/language/functions>.
+
+=head 2 Precedence Drop
+
+In the case of method invocation (i.e., when invocking a subroutine against
+a class instance) it is possible to apply the C<precedence drop>, identified
+by a colon C<:> just after the method name and before the argument list.
+The argument list takes precedence over the method call, that on the other
+hand "drops" its precedence. In order to better understand consider
+the following simple example (extra spaces have been added just to align
+method calls):
+
+    =begin code :skip-test
+    my $band = 'Foo Fighters';
+    say $band.substr( 0, 3 ) .substr( 0, 1 ); # F
+    say $band.substr: 0, 3   .substr( 0, 1 ); # Foo
+    =end code
+
+In the second method call the rightmost C<substr> is applied to "3" and not
+to the result of the leftmost C<substr>, which on the other hand yelds precedence
+to the rightmost one.
+
+>>>>>>> 7666ab84... Add a short introduction to subroutines.
 =head1 Operators
 
 See L<Operators|/language/operators> for lots of details.

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -646,8 +646,8 @@ Inside of a class, you can also declare multi-dispatch methods.
 
 Subroutines are created with the keyword C<sub> followed
 by an optional name, an optional signature and a code block.
-Subroutine are lexically scoped, so if a name is specified
-at the declaration, the same name can be used
+Subroutines are lexically scoped, so if a name is specified
+at the declaration time, the same name can be used
 in the lexical scope to invoke the subroutine.
 A subroutine is an instance of type L<Sub|type/Sub> and
 can be assigned to any container.

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -679,7 +679,7 @@ For more information see L<functions|/language/functions>.
 
 =head 2 Precedence Drop
 
-In the case of method invocation (i.e., when invocking a subroutine against
+In the case of method invocation (i.e., when invoking a subroutine against
 a class instance) it is possible to apply the C<precedence drop>, identified
 by a colon C<:> just after the method name and before the argument list.
 The argument list takes precedence over the method call, that on the other

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -694,7 +694,7 @@ method calls):
     =end code
 
 In the second method call the rightmost C<substr> is applied to "3" and not
-to the result of the leftmost C<substr>, which on the other hand yelds precedence
+to the result of the leftmost C<substr>, which on the other hand yields precedence
 to the rightmost one.
 
 =head1 Operators

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -652,9 +652,6 @@ in the lexical scope to invoke the subroutine.
 A subroutine is an instance of type L<Sub|type/Sub> and
 can be assigned to any container.
 
-
-
-
 =comment TODO
 
     =begin code :skip-test
@@ -671,7 +668,6 @@ are subroutines invoked against an object (i.e., a class instance).
 Within a method the special variable C<self> contains the object instance
 (see L<Methods|classtut#Methods>).
 
-
     =begin code :skip-test
     # Method invocation. Object (instance) is $person, method is set-name-age
     $person.set-name-age('jane', 98);  # Most common way
@@ -679,8 +675,6 @@ Within a method the special variable C<self> contains the object instance
     set-name-age($person: 'jane', 98);     # Invocant marker
     =end code
 
-<<<<<<< HEAD
-=======
 For more information see L<functions|/language/functions>.
 
 =head 2 Precedence Drop
@@ -703,7 +697,6 @@ In the second method call the rightmost C<substr> is applied to "3" and not
 to the result of the leftmost C<substr>, which on the other hand yelds precedence
 to the rightmost one.
 
->>>>>>> 7666ab84... Add a short introduction to subroutines.
 =head1 Operators
 
 See L<Operators|/language/operators> for lots of details.


### PR DESCRIPTION
Should help removing the TODO tag on this section.
The subroutine are now briefly explained in the section, and the example
contains a reference to the hyper method call ">>".

A new head2 section about precedence dropping has been created
with a short example about the difference on using a "standard" method call
and a precedence drop one.