### PR TITLE
File test adverb forms with links to method forms

### DIFF
--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -550,12 +550,16 @@ my $perl-files = gather while @stack {
 =head2 File test operators
 
 For most file tests, you can do a smart match C<~~> or you can call a method.
-You don't need to actually open a filehandle in the traditional way (although you can) to do a filetest. You can simply append C<.IO> to the filename. For instance, here is how to check if a file is readable using smart match:
-C<'/path/to/file'.IO ~~ :r>
-You can, of course, use an already opened filehandle. Here, using the file handle C<$fh>, is an example, using the method syntax for the file test:
-    $fh.r
-    
-File tests include 
+You don't need to actually open a filehandle in the traditional way (although
+you can) to do a filetest. You can simply append C<.IO> to the filename. For
+instance, here is how to check if a file is readable using smart match:
+C<'/path/to/file'.IO ~~ :r>
+
+You can, of course, use an already opened filehandle. Here, using the file
+handle C<$fh>, is an example, using the method syntax for the file test:
+    $fh.r
+
+File tests include
     :e L«Exists|/type/IO/Path#method_e»
     :d L«Directory|type/IO/Path#method_d»
     :f L«File|type/IO/Path#method_f»
@@ -568,9 +572,9 @@ File tests include
 
 All of these tests can be used as methods (without the colon).
 Three tests, however exist only as methods:
-    $fh.modified;
-    $fh.accessed;
-    $fh.changed;
+    $fh.modified;
+    $fh.accessed;
+    $fh.changed;
 
 =head2 method e
 

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -547,6 +547,31 @@ my $perl-files = gather while @stack {
 }
 .put for $perl-files[^3];
 
+=head2 File test operators
+
+For most file tests, you can do a smart match C<~~> or you can call a method.
+You don't need to actually open a filehandle in the traditional way (although you can) to do a filetest. You can simply append C<.IO> to the filename. For instance, here is how to check if a file is readable using smart match:
+C<'/path/to/file'.IO ~~ :r>
+You can, of course, use an already opened filehandle. Here, using the file handle C<$fh>, is an example, using the method syntax for the file test:
+    $fh.r
+    
+File tests include 
+    :e L«Exists|/type/IO/Path#method_e»
+    :d L«Directory|type/IO/Path#method_d»
+    :f L«File|type/IO/Path#method_f»
+    :l L«Symbolic link|type/IO/Path#method_l»
+    :r L«Readable|type/IO/Path#method_r»
+    :w L«Writable|type/IO/Path#method_w»
+    :x L«Executable|type/IO/Path#method_x»
+    :s L«Size|type/IO/Path#method_s»
+    :z L«Zero size|type/IO/Path#method_z»
+
+All of these tests can be used as methods (without the colon).
+Three tests, however exist only as methods:
+    $fh.modified;
+    $fh.accessed;
+    $fh.changed;
+
 =head2 method e
 
 Defined as:


### PR DESCRIPTION
Also intended to fix broken link to https://docs.perl6.org/type/IO::Path#File_test_operators from https://docs.perl6.org/language/5to6-perlfunc#Filetests. Much was copied from https://docs.perl6.org/type/IO::Path#File_test_operators.