### PR TITLE
Fix "head2" POD title section.

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -677,7 +677,7 @@ Within a method the special variable C<self> contains the object instance
 
 For more information see L<functions|/language/functions>.
 
-=head 2 Precedence Drop
+=head2 Precedence Drop
 
 In the case of method invocation (i.e., when invoking a subroutine against
 a class instance) it is possible to apply the C<precedence drop>, identified


### PR DESCRIPTION
That was my fault on PR merged by commit 135102b39481aa.
There was an extra space between "head" and "2" leading to
the wrong rendering of the section title.