### PR TITLE
Remove link to outdated META6 spec

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -562,7 +562,7 @@ lib
     The L<Test::META module | https://github.com/jonathanstowe/Test-META/>
     can help you check the correctness of the META.info file.
 
-    There are more fields described in the L<META specification |
+    There are more fields described in the L<META design documents |
     https://design.perl6.org/S22.html#META6.json>, but not all of these are
     implemented by existing package managers. Hence you should stick to the
     fields described in the above example block to ensure compatability with

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -565,7 +565,7 @@ lib
     There are more fields described in the L<META design documents |
     https://design.perl6.org/S22.html#META6.json>, but not all of these are
     implemented by existing package managers. Hence you should stick to the
-    fields described in the above example block to ensure compatability with
+    fields described in the above example block to ensure compatibility with
     existing package managers.
 
     =end item

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -562,6 +562,12 @@ lib
     The L<Test::META module | https://github.com/jonathanstowe/Test-META/>
     can help you check the correctness of the META.info file.
 
+    There are more fields described in the L<META specification |
+    https://design.perl6.org/S22.html#META6.json>, but not all of these are
+    implemented by existing package managers. Hence you should stick to the
+    fields described in the above example block to ensure compatability with
+    existing package managers.
+
     =end item
 
     =item Put your project under git version control if you haven't done so

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -560,10 +560,7 @@ lib
     C<%?RESOURCES> Hash indexed on the name provided.
 
     The L<Test::META module | https://github.com/jonathanstowe/Test-META/>
-    can help you check the correctness of the META.info file.  See the full
-    L<META specification | https://design.perl6.org/S22.html#META6.json> for
-    more details as well as further options available for use in
-    C<META6.json> files.
+    can help you check the correctness of the META.info file.
 
     =end item
 


### PR DESCRIPTION
After discussion in #perl6, the consensus seems to be that the link referenced in the docs does not resemble the META6 spec. To avoid confusion, the link should be removed.