### PR TITLE
Document the proper way to concat arrays.

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -567,7 +567,6 @@ for full details on all operators.
 
 Unchanged:
 
-=item C<,> List Separator
 =item C<+> Numeric Addition
 =item C<-> Numeric Subtraction
 =item C<*> Numeric Multiplication
@@ -580,6 +579,18 @@ Unchanged:
 =item C<not and or xor> Booleans, low-precedence
 =item C«== != < > <= >=»   Numeric comparisons
 =item C<eq ne lt gt le ge>  String comparisons
+
+=head2 C<,> (Comma) List Separator
+
+Unchanged, but note that in order to flatten an array variable to a list (in
+order to append or prefix more items) one should use the C<|> operator. E.g:
+
+=for code
+    my @numbers = (100, 200, 300);
+    my @more_numbers = (500, 600, 700);
+    my @all_numbers = [|@numbers, 400, |@more_numbers];
+
+That way one can concatenate arrays.
 
 =head2 C«<=> cmp» Three-way comparisons
 


### PR DESCRIPTION
In 5to6 - it was not properly documented. Also spell "," as the comma.

This got me tripped when working on perl6-examples.