### PR TITLE
Modify Label Doc and Examples

### DIFF
--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -41,6 +41,27 @@ Begin the next iteration of the loop associated with the label.
 
     # OUTPUT: «5 6 7 8 9 10 »
 
+=head2 method redo
+
+Defined as:
+
+    method redo(Label:)
+
+Repeat the same iteration of the loop associated with the label.
+
+    my $has-repeated = False;
+
+    MY-LABEL:
+    for 1..10 {
+        print "$_ ";
+        if $_ == 5 {
+            LEAVE $has-repeated = True;
+            redo MY-LABEL unless $has-repeated;
+        }
+    }
+
+    # OUTPUT: «1 2 3 4 5 5 6 7 8 9 10 »
+
 =head2 method last
 
 Defined as:

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -35,9 +35,11 @@ Begin the next iteration of the loop associated with the label.
 
     MY-LABEL:
     for 1..10 {
-        next MY-LABEL if $_ > 5; # does 5 iteration and then 5 empty iteration
-        say $_;
+        next MY-LABEL if $_ < 5;
+        print "$_ ";
     }
+
+    # OUTPUT: «5 6 7 8 9 10 »
 
 =head2 method last
 
@@ -49,8 +51,10 @@ Terminate the execution of the loop associated with the label.
 
     MY-LABEL:
     for 1..10 {
-        last MY-LABEL if $_ > 5; # does only 5 iteration
-        say $_;
+        last MY-LABEL if $_ > 5;
+        print "$_ ";
     }
+
+    # OUTPUT: «1 2 3 4 5 »
 
 =end pod


### PR DESCRIPTION
The largest of the changes here is the documenting of the redo method on
Label. Also made some modifications for the existing label examples.

Changed the example for the next method so that it's output differs from
that of the last example. With the change, the numbers 5 through 10 are
printed, which makes it more clear that the loop has iterated a total of
ten times but only reached the print statement during 6 of those.

Also, added the output to the example, as I believe that is clearer and
allows better visualization of what occurred. It also is more consistent with
the example-then-output style used throughout the docs.

These example changes are largely subjective, but I think they are for the allow
for better clarity / consistency.