### PR TITLE
Add Metamodel::EnumHOW page

### DIFF
--- a/doc/Type/Metamodel/EnumHOW.pod6
+++ b/doc/Type/Metamodel/EnumHOW.pod6
@@ -1,0 +1,74 @@
+=begin pod
+
+=TITLE class Metamodel::EnumHOW
+
+=SUBTITLE Metaobject representing a Perl 6 enum.
+
+    class Metamodel::EnumHOW
+        does Metamodel::Naming
+        does Metamodel::Documenting
+        does Metamodel::Stashing
+        does Metamodel::AttributeContainer
+        does Metamodel::MethodContainer
+        does Metamodel::MultiMethodContainer
+        does Metamodel::RoleContainer
+        does Metamodel::BaseType
+        does Metamodel::MROBasedMethodDispatch
+        does Metamodel::MROBasedTypeChecking
+        does Metamodel::BUILDPLAN
+        does Metamodel::BoolificationProtocol
+        does Metamodel::REPRComposeProtocol
+        does Metamodel::InvocationProtocol
+        does Metamodel::Mixins
+            { }
+
+C<Metamodel::EnumHOW> is the meta class behind the C<enum> keyword.
+
+    enum numbers <1 2>;
+    say numbers.HOW ~~ Metamodel::EnumHOW       # OUTPUT: «True␤»
+
+=head1 Methods
+
+=head2 method add_enum_value
+
+    method add_enum_value($Metamodel::ClassHOW:D: obj, $value)
+
+Add a value to this enum.
+
+=head2 method enum_values
+
+    method enum_values(Metamodel::ClassHOW:D: $obj)
+
+Returns the values for the enum.
+
+    enum numbers <10 20>;
+    say numbers.^enum_values;                   # OUTPUT: {10 => 0, 20 => 1}
+
+=head2 method elems
+
+    method elems(Metamodel::ClassHOW:D: $obj)
+
+Returns the number of values.
+
+    enum numbers <10 20>;
+    say numbers.^elems;                         # OUTPUT: 2
+
+=head2 method enum_from_value
+
+    method enum_from_value(Metamodel::ClassHOW:D: $obj, $value)
+
+Given an value, return the corresponding enum.
+
+    enum numbers <10 20>;
+    say numbers.^enum_from_value(0)             # OUTPUT: 10
+
+=head2 method enum_value_list
+
+    method enum_value_list(Metamodel::ClassHOW:D: $obj)
+
+Returns a list of the enum values.
+
+    enum numbers <10 20>;
+    say numbers.^enum_value_list;               # OUTPUT: (10 20)
+
+=end pod


### PR DESCRIPTION
This adds a page for MetaModel::EnumHOW.  Looking for feedback -- I took these from the source, though I don't think they are part of the spec, so not sure if it's appropriate to list them here?  (Or maybe there should be a note about them being rakudo-specific?)

Resolves #1642