### PR TITLE
Document Regex Interpolation, jnthn++

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1255,17 +1255,45 @@ list of predefined subrules is listed in
 L<S05-regex|https://design.perl6.org/S05.html#Predefined_Subrules> of design
 documents.
 
-=head1 X«Regex Interpolation|Regex Interpolation; <$pattern>»
+=head1 X<Regex Interpolation|regex, Regex Interpolation>
 
 If you want to build a regex using pattern given at the runtime, regex
 interpolation is what you looking for.
 
-    sub runtime-regex(Str $pattern --> Regex) { /<$pattern>/ }
+There are two ways you can interpolate a string into regex as a pattern,
+which are quite similar to interpolate it into a double-quote string.
+That is using C«<$pattern>» or C«<{$pattern.method}>».
 
-    my $regex = runtime-regex(get);  # INPUT : «\d+␤»
-    my $text = get;                  # INPUT : «42␤»
+    my $text = 'camelia';
+    my $pattern = '\w+';
+    my $pattern_ = 'ailemac';
+    say $text ~~ / <$pattern> /;          # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / <{$pattern}> /;        # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / <{$pattern_.flip}> /;  # OUTPUT: «｢camelia｣␤»
+    # say $text ~~ / <$pattern_.flip> /;  !!Compile Error!!
 
-    say $text ~~ $regex;             # OUTPUT: «｢42｣␤»
+Note that this syntax causes I<implicit EVAL>, that is a known trap.
+
+When your pattern is a lexical string, there are two more syntax helping you
+interpolate it.
+
+    my $text = 'camelia';
+    my $string = 'camelia';
+    my $string_ = 'ailemac';
+    say $text ~~ / $string /;                 # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / $($string) /;              # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / $($string_.flip) /;        # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / $string_.flip /;           # OUTPUT: «Nil␤»
+    say 'ailemacxflip' ~~ / $string_.flip /;  # OUTPUT: «｢ailemacxflip｣␤»
+
+Because it interpolates a string lexically, it doesn't EVAL the string
+implicitly.
+
+    my $text = '42';
+    my $text_ = '\d+';
+    my $lexical = '\d+';
+    say $text ~~ / $($lexical) /;             # OUTPUT: «Nil␤»
+    say $text_ ~~ / $($lexical) /;            # OUTPUT: «｢\d+｣␤»
 
 =head1 Adverbs
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1272,7 +1272,8 @@ That is using C«<$pattern>» or C«<{$pattern.method}>».
     say $text ~~ / <{$pattern_.flip}> /;  # OUTPUT: «｢camelia｣␤»
     # say $text ~~ / <$pattern_.flip> /;  !!Compile Error!!
 
-Note that this syntax causes I<implicit EVAL>, that is a known trap.
+Note that this syntax causes L«implicit EVAL|
+/language/traps#<{$x}>_vs_$($x):_Implicit_EVAL», that is a known trap.
 
 When your pattern is a lexical string, there are two more syntax helping you
 interpolate it.

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1255,12 +1255,12 @@ list of predefined subrules is listed in
 L<S05-regex|https://design.perl6.org/S05.html#Predefined_Subrules> of design
 documents.
 
-=head1 X«Patten Interpolation|regex, Patten Interpolation; <$patten>»
+=head1 X«Regex Interpolation|Regex Interpolation; <$pattern>»
 
-If you want to build a regex using pattern given at the runtime, patten
+If you want to build a regex using pattern given at the runtime, regex
 interpolation is what you looking for.
 
-    sub runtime-regex(Str $patten --> Regex) { /<$patten>/ }
+    sub runtime-regex(Str $pattern --> Regex) { /<$pattern>/ }
 
     my $regex = runtime-regex(get);  # INPUT : «\d+␤»
     my $text = get;                  # INPUT : «42␤»

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1255,17 +1255,17 @@ list of predefined subrules is listed in
 L<S05-regex|https://design.perl6.org/S05.html#Predefined_Subrules> of design
 documents.
 
-=head1 X«Regex Interpolation|Regex Interpolation; <$patten>»
+=head1 X«Patten Interpolation|regex, Patten Interpolation; <$patten>»
 
-If you want to build a regex using pattern given at the runtime, regex
+If you want to build a regex using pattern given at the runtime, patten
 interpolation is what you looking for.
 
     sub runtime-regex(Str $patten --> Regex) { /<$patten>/ }
 
-    my $regex = runtime-regex(get);  # INPUT  : «\d+␤»
-    my $text = get;                  # INPUT  : «42␤»
+    my $regex = runtime-regex(get);  # INPUT : «\d+␤»
+    my $text = get;                  # INPUT : «42␤»
 
-    say $text ~~ $regex;             # OUTPUT : «｢42｣␤»
+    say $text ~~ $regex;             # OUTPUT: «｢42｣␤»
 
 =head1 Adverbs
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1255,6 +1255,18 @@ list of predefined subrules is listed in
 L<S05-regex|https://design.perl6.org/S05.html#Predefined_Subrules> of design
 documents.
 
+=head1 X«Regex Interpolation|Regex Interpolation; <$patten>»
+
+If you want to build a regex using pattern given at the runtime, regex
+interpolation is what you looking for.
+
+    sub runtime-regex(Str $patten --> Regex) { /<$patten>/ }
+
+    my $regex = runtime-regex(get);  # INPUT  : «\d+␤»
+    my $text = get;                  # INPUT  : «42␤»
+
+    say $text ~~ $regex;             # OUTPUT : «｢42｣␤»
+
 =head1 Adverbs
 
 Adverbs modify how regexes work and provide convenient shortcuts for

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1264,10 +1264,10 @@ There are four ways you can interpolate a string into regex as a pattern.
 That is using C«$pattern», C«$($pattern)», C«<$pattern>» or
 C«<{$pattern.method}>».
 
-    my $text = 'camelia';
-    my $pattern0 = 'camelia';
-    my $pattern1 = 'ailemac';
-    my $pattern2 = '\w+';
+    my Str $text = 'camelia';
+    my Str $pattern0 = 'camelia';
+    my Str $pattern1 = 'ailemac';
+    my Str $pattern2 = '\w+';
 
     say $text ~~ / $pattern0 /;                # OUTPUT: «｢camelia｣␤»
     say $text ~~ / $($pattern0) /;             # OUTPUT: «｢camelia｣␤»

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1257,44 +1257,34 @@ documents.
 
 =head1 X<Regex Interpolation|regex, Regex Interpolation>
 
-If you want to build a regex using pattern given at the runtime, regex
-interpolation is what you looking for.
+If you want to build a regex using a pattern given at runtime, regex
+interpolation is what you are looking for.
 
-There are two ways you can interpolate a string into regex as a pattern,
-which are quite similar to interpolate it into a double-quote string.
-That is using C«<$pattern>» or C«<{$pattern.method}>».
-
-    my $text = 'camelia';
-    my $pattern = '\w+';
-    my $pattern_ = 'ailemac';
-    say $text ~~ / <$pattern> /;          # OUTPUT: «｢camelia｣␤»
-    say $text ~~ / <{$pattern}> /;        # OUTPUT: «｢camelia｣␤»
-    say $text ~~ / <{$pattern_.flip}> /;  # OUTPUT: «｢camelia｣␤»
-    # say $text ~~ / <$pattern_.flip> /;  !!Compile Error!!
-
-Note that this syntax causes L«implicit EVAL|
-/language/traps#<{$x}>_vs_$($x):_Implicit_EVAL», that is a known trap.
-
-When your pattern is a lexical string, there are two more syntax helping you
-interpolate it.
+There are four ways you can interpolate a string into regex as a pattern.
+That is using C«$pattern», C«$($pattern)», C«<$pattern>» or
+C«<{$pattern.method}>».
 
     my $text = 'camelia';
-    my $string = 'camelia';
-    my $string_ = 'ailemac';
-    say $text ~~ / $string /;                 # OUTPUT: «｢camelia｣␤»
-    say $text ~~ / $($string) /;              # OUTPUT: «｢camelia｣␤»
-    say $text ~~ / $($string_.flip) /;        # OUTPUT: «｢camelia｣␤»
-    say $text ~~ / $string_.flip /;           # OUTPUT: «Nil␤»
-    say 'ailemacxflip' ~~ / $string_.flip /;  # OUTPUT: «｢ailemacxflip｣␤»
+    my $pattern0 = 'camelia';
+    my $pattern1 = 'ailemac';
+    my $pattern2 = '\w+';
 
-Because it interpolates a string lexically, it doesn't EVAL the string
-implicitly.
+    say $text ~~ / $pattern0 /;                # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / $($pattern0) /;             # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / $($pattern1.flip) /;        # OUTPUT: «｢camelia｣␤»
+    say 'ailemacxflip' ~~ / $pattern1.flip /;  # OUTPUT: «｢ailemacxflip｣␤»
+    say '\w+' ~~ / $pattern2 /;                # OUTPUT: «｢\w+｣␤»
+    say '\w+' ~~ / $($pattern2) /;             # OUTPUT: «｢\w+｣␤»
 
-    my $text = '42';
-    my $text_ = '\d+';
-    my $lexical = '\d+';
-    say $text ~~ / $($lexical) /;             # OUTPUT: «Nil␤»
-    say $text_ ~~ / $($lexical) /;            # OUTPUT: «｢\d+｣␤»
+    say $text ~~ / <{$pattern1.flip}> /;       # OUTPUT: «｢camelia｣␤»
+    # say $text ~~ / <$pattern1.flip> /;       # !!Compile Error!!
+    say $text ~~ / <$pattern2> /;              # OUTPUT: «｢camelia｣␤»
+    say $text ~~ / <{$pattern2}> /;            # OUTPUT: «｢camelia｣␤»
+
+Note that the first two syntax interpolate the string lexically, while
+C«<$pattern>» and C«<{$pattern.method}>» causes L«implicit EVAL|
+/language/traps#<{$x}>_vs_$($x):_Implicit_EVAL», which is a known trap.
+
 
 =head1 Adverbs
 


### PR DESCRIPTION
I think it's worthy to be documented, because people will looking for a way to using patten given at the runtime.

But I'm not sure if this's the only way to interpolate patten(string) into regex.