### PR TITLE
Add vim modeline at end of every file without one

### DIFF
--- a/doc/404.pod6
+++ b/doc/404.pod6
@@ -12,3 +12,5 @@
 </p>
 
 =end Html
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -59,3 +59,5 @@ Documentation for the different but related <a href="https://www.perl.org/">Perl
 can be found on the <a href="http://perldoc.perl.org/">Perl 5 documentation website</a>.
 </p>
 =end Html
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1755,4 +1755,4 @@ be better than losing the information about a real need.
 
 =end comments
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1878,3 +1878,5 @@ This synonym for C<tr///> is gone. For functionality, see the entry for
 C<tr///>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -345,3 +345,5 @@ boolean or is C<?|>.
 Left shift and right shift are C<< +< >> and C<< +> >>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -184,3 +184,5 @@ perl6, you may need to specify the location of C<Pod::To::Text>.)
 Details on Perl 6 style pod is at L<https://design.perl6.org/S26.html>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -543,3 +543,5 @@ It should go without saying that, as these have been removed from Perl 5
 already, there should be no need to tell you how to use them in Perl 6.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -148,3 +148,5 @@ renders like this
 Notice that text after a pipe ('|') has no formatting. Also note that B<V< C<> >>
 preserves spaces and treats text as verbatim.
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -682,3 +682,5 @@ bunch of bytes needs to know the attributes of that object, which it can
 find out via introspection.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -16,3 +16,5 @@ There is a large presence on the C<#perl6> channel on C<freenode.net>,
 who are happy to provide support and answer questions.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -791,3 +791,5 @@ possibly better fix would be to refactor the code so that sharing a container
 is not necessary.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -354,3 +354,5 @@ work with types in Perl 6.
     CATCH { default { say .^name, ': ', .Str } };
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/contributors.pod6
+++ b/doc/Language/contributors.pod6
@@ -975,3 +975,5 @@ L<Pull Request|/language/glossary#Pull_Request> with the required change(s).
   Zoffix Znet
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -928,4 +928,4 @@ multi indent-say ( Str $string ) {
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/enumeration.pod6
+++ b/doc/Language/enumeration.pod6
@@ -57,4 +57,4 @@ for $dirs -> $dir {
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -270,4 +270,4 @@ converted to a normal exception.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -80,3 +80,5 @@ B<Note the collation features, especially the $*COLLATION API could change
 at any time>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -846,3 +846,5 @@ Examples:
     =end code
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -956,4 +956,4 @@ C<$*USAGE> variable.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -1056,3 +1056,5 @@ X<|whitespace>
 X<|6model>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -614,3 +614,5 @@ breakpoints and color-coded MATCH and FAIL output for each of your grammar
 tokens.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -409,3 +409,5 @@ the whitespace before closing C<}> does not gobble up the newlines looked for
 in C<token TOP>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -550,3 +550,5 @@ answered here, please add it to the document. Even if we do not have a good
 answer yet, that will be better than losing the information about a real need.
 
 =end comments
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -327,4 +327,4 @@ L«C<indir> routine|/routine/indir» for that purpose.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -225,4 +225,4 @@ rmdir "newdir" or die "$!";
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -102,4 +102,4 @@ Use the C<write> method to pass data into the program.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -596,3 +596,5 @@ values is needed, or for very large Arrays where a native-typed array cannot be 
 Such a creature should never be passed back to unsuspecting users.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/modules-core.pod6
+++ b/doc/Language/modules-core.pod6
@@ -18,3 +18,5 @@ list of them, along with links to their source code.
 =item L«C<newline>|https://github.com/rakudo/rakudo/blob/master/lib/newline.pm6»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -46,3 +46,5 @@ or skeletons.
 =item L<Foo|https://modules.perl6.org/dist/Foo> A module with two distributions of different versions
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -702,4 +702,4 @@ L<https://github.com/perl6/toolchain-bikeshed>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -201,3 +201,5 @@ and can't expect the same "do what I mean" convenience that ordinary Perl 6
 code offers.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -620,3 +620,5 @@ Here is an example of a Windows API call:
 =end code
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -988,3 +988,5 @@ the meta class of C<class> and also the L<general documentation on the meta
 object protocol|/language/mop>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2481,4 +2481,4 @@ a subthread).
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -195,3 +195,5 @@ object can be accessed via C<$?PACKAGE.^ver> or from outside the package
 C<Fully::Qualified::Name.^ver>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -236,3 +236,5 @@ L<our user experience repo|https://github.com/perl6/user-experience/issues> befo
 Thanks. :)
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -426,3 +426,5 @@ prefixed with the C<DOC> keyword. The compiler is in documentation when run with
   DOC INIT { say 'init'  }  # prints 'init' at initialization time when in documentation mode.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -508,3 +508,5 @@ multi MAIN(Bool :$man)
 Now C<myprogram --man> will output your Pod rendered as a man page.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -137,3 +137,5 @@ before using them. You can relax this restriction with C<no>.
 =item X<B<worries>|worries> [TBD]
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -735,3 +735,5 @@ X<|input (Python)>
 See the L<prompt> function.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -472,3 +472,5 @@ For information about quoting as applied in regexes see the L<regular
 expression documentation|/language/regexes>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -1163,3 +1163,5 @@ answered here, please add it to the document. Even if we do not have a good
 answer yet, that will be better than losing the information about a real need.
 
 =end comments
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1876,4 +1876,4 @@ two newlines. To allow such input strings, replace C<\n+> with C<\n\s*>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -499,3 +499,5 @@ Equivalent to L«(+)», at codepoint U+228E (MULTISET UNION).
 Equivalent to set(), aka X<the empty set>, at codepoint U+2205 (EMPTY SET).
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -965,3 +965,5 @@ get an appropriate error message when they try to bind to an associative
 slot of an object of this type.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -752,3 +752,5 @@ You can also wrap a unary operator with a hyper operator.
     say -« <1 2 3> # OUTPUT: «(-1 -2 -3)␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -283,3 +283,5 @@ r0c0  |  r0c1
 =end code
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -204,3 +204,5 @@ Constants are C<our>-scoped by default, but adding C<my> would make them lexical
     my constant SpeedOfLight = 186200; # mi/s (watch out, not SI units)
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -814,4 +814,4 @@ to provide visual markers on how the testing of a test-file is progressing
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -1317,4 +1317,4 @@ L<single argument rule|/language/functions#Slurpy_Conventions>, and
 there are other cases when this kind of a generalization may not work.
 
 =end pod
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -875,3 +875,5 @@ require ::('YourModule');
 subset C where ::('YourModule::C');
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -138,3 +138,5 @@ commas to separate different codepoints/sequences inside the same C<\c> sequence
 
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/unicode_ascii.pod6
+++ b/doc/Language/unicode_ascii.pod6
@@ -153,3 +153,5 @@ X<|»=»>X<|«=«>X<|«=»>X<|»=«>
   »=«    | U+00BB = U+00AB  | >>[=]<< | v6.c  | uses ASCII '='
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -316,3 +316,5 @@ Or to specify the elements in a list from C<1> up to C<k>:
     =end code
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1177,3 +1177,5 @@ with the default changed before using C<.hyper> or C<.race>:
 This behavior is not tested in the spec tests and is subject to change.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Programs/00-running.pod6
+++ b/doc/Programs/00-running.pod6
@@ -236,3 +236,5 @@ C<65536> or the value of C<RAKUDO_DEFAULT_READ_ELEMS> environmental variable, if
 set.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Programs/01-debugging.pod6
+++ b/doc/Programs/01-debugging.pod6
@@ -92,3 +92,5 @@ string:
     #   in block <unit> at /tmp/script.p6 line 4
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Programs/02-reading-docs.pod6
+++ b/doc/Programs/02-reading-docs.pod6
@@ -68,3 +68,5 @@ with C<META6.json> changes) to extract B<all> Perl 6 pod in files
 included with the installed distribution.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/AST.pod6
+++ b/doc/Type/AST.pod6
@@ -15,3 +15,5 @@ There is no API defined for ASTs yet.  Hopefully that will emerge as
 part of the work on macros.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -830,4 +830,4 @@ TODO
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -312,3 +312,5 @@ order to get correct information.
     say $s.VAR.dynamic;                      # OUTPUT: «True␤»   (correct approach)
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Associative.pod6
+++ b/doc/Type/Associative.pod6
@@ -16,3 +16,5 @@ The C<%> sigil restricts variables to objects that do C<Associative>.
 Associative does not provide any methods.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Attribute.pod6
+++ b/doc/Type/Attribute.pod6
@@ -231,3 +231,5 @@ writable value.
    # OUTPUT: «X::Assignment::RO: Cannot modify an immutable Any␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -52,3 +52,5 @@ frames, compiler-specific frames and those from the setting.
     say $backtrace.full;
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Bag.pod6
+++ b/doc/Type/Bag.pod6
@@ -107,3 +107,5 @@ Creates a new C<Bag> from C<@args>.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/BagHash.pod6
+++ b/doc/Type/BagHash.pod6
@@ -104,3 +104,5 @@ set and bag operators with detailed explanations.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -461,3 +461,5 @@ C<$other> has the same elements, with the same weights, as the invocant.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -199,3 +199,5 @@ Returns a Blob with all elements in reversed order.
     say buf32.new([16, 32]).reverse;    # OUTPUT: «Buf[uint32]:0x<20 10>␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Block.pod6
+++ b/doc/Type/Block.pod6
@@ -52,3 +52,5 @@ Bare blocks in sink context are automatically executed:
     say 3;
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -98,3 +98,5 @@ Coerces its argument to C<Bool>.
 Coerces its argument to C<Bool>, has looser precedence than C<< prefix:<?> >>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Buf.pod6
+++ b/doc/Type/Buf.pod6
@@ -39,3 +39,5 @@ Returns a writable reference to a part of a buffer. Similar to the C<subbuf-rw> 
     dd $b;        # OUTPUT: Buf $b = Buf.new(1,2,42)
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/CallFrame.pod6
+++ b/doc/Type/CallFrame.pod6
@@ -108,4 +108,4 @@ Returns L<Mu> if there is no call information for the given level. (Negative lev
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Callable.pod6
+++ b/doc/Type/Callable.pod6
@@ -135,3 +135,5 @@ Both C<.count> and C<.arity> of the RHS will be maintained.
     =end code
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Cancellation.pod6
+++ b/doc/Type/Cancellation.pod6
@@ -30,4 +30,4 @@ Cancels the scheduled execution of a task before normal completion.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Capture.pod6
+++ b/doc/Type/Capture.pod6
@@ -199,3 +199,5 @@ Returns the number of positional elements in the Capture.
     say \(1,2,3, apples => 2).Numeric;                # OUTPUT: «3␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Channel.pod6
+++ b/doc/Type/Channel.pod6
@@ -203,3 +203,5 @@ L<promises|/type/Promise>.
     say await $c;
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -114,3 +114,5 @@ Returns the line number in which the code object was declared.
     say &infix:<+>.line;
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Complex.pod6
+++ b/doc/Type/Complex.pod6
@@ -183,3 +183,5 @@ normal addition operator.
     say (1-3i).perl;                # OUTPUT: «<1-3i>␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/ComplexStr.pod6
+++ b/doc/Type/ComplexStr.pod6
@@ -96,4 +96,4 @@ coerce to the C<Complex> or C<Str> values first:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1359,4 +1359,4 @@ match, subst, sprintf, printf, samecase
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/CurrentThreadScheduler.pod6
+++ b/doc/Type/CurrentThreadScheduler.pod6
@@ -12,3 +12,5 @@ that L<method cue|/type/Scheduler#method cue> blocks until the code has
 finished executing.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Cursor.pod6
+++ b/doc/Type/Cursor.pod6
@@ -41,3 +41,5 @@ This is the value that the regex engine works with internally.
 Returns the current position as a string index into `Cursor.target`.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Date.pod6
+++ b/doc/Type/Date.pod6
@@ -338,3 +338,5 @@ L«C<Date>|/type/Date» object.
     say 1 + Date.new('2015-12-25');   # OUTPUT: «2015-12-26␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/DateTime.pod6
+++ b/doc/Type/DateTime.pod6
@@ -398,3 +398,5 @@ L«C<Duration>|/type/Duration», preserving the timezone.
     say Duration.new(42) + DateTime.new(:2015year, :3600timezone); # OUTPUT: «2015-01-01T00:00:42+01:00␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -221,3 +221,5 @@ colons (C<:>) in filenames, which would be present in C<IO::Path> created from a
 L<DateTime|/type/DateTime> object.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Distro.pod6
+++ b/doc/Type/Distro.pod6
@@ -55,3 +55,5 @@ established.
 See Also: L<Systemic>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Duration.pod6
+++ b/doc/Type/Duration.pod6
@@ -19,3 +19,5 @@ modulus of two C<Duration>s). The type of object returned for other numeric
 operations is currently unspecified.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Encoding.pod6
+++ b/doc/Type/Encoding.pod6
@@ -48,4 +48,4 @@ Windows).
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -163,4 +163,4 @@ throw an exception.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Failure.pod6
+++ b/doc/Type/Failure.pod6
@@ -129,3 +129,5 @@ the failure as handled.
     sub f() { fail }; my $v = f; say $v.defined; # OUTPUT: «False␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/FatRat.pod6
+++ b/doc/Type/FatRat.pod6
@@ -20,3 +20,5 @@ denominator, or by calling the C<.FatRat> method on an L<Int> or L<Rat>
 object.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Grammar.pod6
+++ b/doc/Type/Grammar.pod6
@@ -132,3 +132,5 @@ are passed on to L<method parse|/routine/parse>.
     # OUTPUT : «TimToady,lizmat,jnthn,moritz,zoffixznet,MasterDuke17␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Hash.pod6
+++ b/doc/Type/Hash.pod6
@@ -696,3 +696,5 @@ empty angle brackets in which case all the keys and values will be listed:
     say %h2<>:v; # OUTPUT: «(1 2)␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -373,4 +373,4 @@ See also the related classes L<IO::Handle> and L<IO::Path>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Instant.pod6
+++ b/doc/Type/Instant.pod6
@@ -99,3 +99,5 @@ Coerces the invocant to L<DateTime>.
     say now.DateTime;  # OUTPUT: «2017-05-09T14:02:58.147165Z␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -209,3 +209,5 @@ number, or L<NaN|/type/Num#NaN> if it does not represent a number.
 Does an integer division, rounded down.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/IntStr.pod6
+++ b/doc/Type/IntStr.pod6
@@ -87,4 +87,4 @@ coerce to a C<Int> or C<Str> value first:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Iterable.pod6
+++ b/doc/Type/Iterable.pod6
@@ -101,3 +101,5 @@ Unlike C<hyper>, C<race> does not preserve the order of elements.
     say ([1..100].race.map({ $_ +1 }).list);
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -237,3 +237,5 @@ In other words, it's expected the user of the class will be able to
 still L<pull-one> after calling this method.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Junction.pod6
+++ b/doc/Type/Junction.pod6
@@ -152,3 +152,5 @@ individually and then re-create the C<Junction> from the result:
 =item L<https://perl6advent.wordpress.com/2009/12/13/day-13-junctions/>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Kernel.pod6
+++ b/doc/Type/Kernel.pod6
@@ -82,3 +82,5 @@ established.
 See Also: L<Systemic>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Label.pod6
+++ b/doc/Type/Label.pod6
@@ -79,3 +79,5 @@ Terminate the execution of the loop associated with the label.
     # OUTPUT: «1 2 3 4 5 »
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1266,4 +1266,4 @@ longer.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Lock.pod6
+++ b/doc/Type/Lock.pod6
@@ -113,3 +113,5 @@ L<https://en.wikipedia.org/wiki/Monitor_%28synchronization%29> for background.
     $l.condition;
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Macro.pod6
+++ b/doc/Type/Macro.pod6
@@ -11,3 +11,5 @@ parsing. By returning an L<AST>, a macro can inject code into
 the calling location.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -225,3 +225,5 @@ The returned C<Capture> will not contain any positional arguments.
     }
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -142,3 +142,5 @@ The sub form operates on the current C<$/>, which can be a convenient shortcut:
     }
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Method.pod6
+++ b/doc/Type/Method.pod6
@@ -95,3 +95,5 @@ C<samewith> was called):
 
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Mix.pod6
+++ b/doc/Type/Mix.pod6
@@ -101,3 +101,5 @@ original C<Mix>, if any of the weights are negative or truncate to zero.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/MixHash.pod6
+++ b/doc/Type/MixHash.pod6
@@ -105,3 +105,5 @@ original C<MixHash>, if any of the weights are negative or truncate to zero.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Mixy.pod6
+++ b/doc/Type/Mixy.pod6
@@ -33,3 +33,5 @@ ones.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -488,4 +488,4 @@ like so:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NFC.pod6
+++ b/doc/Type/NFC.pod6
@@ -12,4 +12,4 @@ L<Unicode TR15|http://www.unicode.org/reports/tr15/>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NFD.pod6
+++ b/doc/Type/NFD.pod6
@@ -10,4 +10,4 @@ A Codepoint string in the "D" L<Unicode Normalization Form|http://www.unicode.or
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NFKC.pod6
+++ b/doc/Type/NFKC.pod6
@@ -11,4 +11,4 @@ followed by Canonical Composition. For more information on what this means, see
 L<Unicode TR15|http://www.unicode.org/reports/tr15/>.
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NFKD.pod6
+++ b/doc/Type/NFKD.pod6
@@ -11,4 +11,4 @@ For more information on what this means, see L<Unicode TR15|http://www.unicode.o
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Nil.pod6
+++ b/doc/Type/Nil.pod6
@@ -163,4 +163,4 @@ Warns the user that they tried to numify a C<Nil>.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Num.pod6
+++ b/doc/Type/Num.pod6
@@ -102,3 +102,5 @@ Converts the number to a L<Rat> with the precision C<$epsilon>.
 Converts the number to a L<FatRat> with the precision C<$epsilon>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NumStr.pod6
+++ b/doc/Type/NumStr.pod6
@@ -87,4 +87,4 @@ coerce to a C<Num> or C<Str> value first:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -148,3 +148,5 @@ Returns the number incremented by one (successor).
 Returns the number decremented by one (predecessor).
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/ObjAt.pod6
+++ b/doc/Type/ObjAt.pod6
@@ -13,3 +13,5 @@ If two objects compare equally via C<===>, their C<.WHICH> methods return
 the same ObjAt object.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Order.pod6
+++ b/doc/Type/Order.pod6
@@ -21,3 +21,5 @@ Coerces its arguments to Stringy.
 Specialized form for Int.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -272,3 +272,5 @@ as I<key ~ \t ~ value>.
     say $b.Str;                                       # OUTPUT: «eggs  3␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Parameter.pod6
+++ b/doc/Type/Parameter.pod6
@@ -282,3 +282,5 @@ L<sub-signature|/type/Signature#Destructuring_Parameters>,
 returns a C<Signature> object for it.  Otherwise returns C<Any>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Perl.pod6
+++ b/doc/Type/Perl.pod6
@@ -60,3 +60,5 @@ supported by this version of Perl.
 L<Systemic>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Positional.pod6
+++ b/doc/Type/Positional.pod6
@@ -20,3 +20,5 @@ Returns the type constraint for elements of the positional container. Defaults
 to L<Mu>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/PositionalBindFailover.pod6
+++ b/doc/Type/PositionalBindFailover.pod6
@@ -68,3 +68,5 @@ This method stub ensure that a class implementing role
 C<PositionalBindFailover> provides an C<iterator> method.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Proc.pod6
+++ b/doc/Type/Proc.pod6
@@ -158,3 +158,5 @@ Returns the signal number with which the external process was killed, or 0 or
 an undefined value otherwise.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -268,3 +268,5 @@ rethrow their exceptions. If a list of promises is provided a list of promises
 is returned.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Proxy.pod6
+++ b/doc/Type/Proxy.pod6
@@ -37,3 +37,5 @@ fetch produces. C<&STORE> is called with two arguments (the proxy object, and
 the new value) when a new value is stored in the container.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/PseudoStash.pod6
+++ b/doc/Type/PseudoStash.pod6
@@ -23,3 +23,5 @@ This shows how you can use a C<PseudoStash> to look up variables, by name,
 at runtime.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -18,3 +18,5 @@ entries with non-default values, automatically deleting any entry if its
 value goes to that (false) default value.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -242,3 +242,5 @@ L«C<.infinite>|/type/Range#method_infinite», and
 L«C<.is-int>|/type/Range#method_is-int» as named arguments.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Rat.pod6
+++ b/doc/Type/Rat.pod6
@@ -53,3 +53,5 @@ operator.
     say (2/4).perl;                # OUTPUT: «0.5␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/RatStr.pod6
+++ b/doc/Type/RatStr.pod6
@@ -95,4 +95,4 @@ coerce to the C<Rat> or C<Str> values first:
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -88,3 +88,5 @@ The precision for determining the repeating group is limited to 1000
 characters, above that, the second string is C<???>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -90,3 +90,5 @@ The final digit produced is always rounded.
 For reverse operation, see L«C<parse-base>|/routine/parse-base»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Regex.pod6
+++ b/doc/Type/Regex.pod6
@@ -70,3 +70,5 @@ Matches against the caller's L<$_|/syntax/$_> variable, and returns C<True> for 
 C<False> for no match.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Routine.pod6
+++ b/doc/Type/Routine.pod6
@@ -361,3 +361,5 @@ TODO: explain export tags
 =end comment
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Scalar.pod6
+++ b/doc/Type/Scalar.pod6
@@ -253,3 +253,5 @@ the loop, and so lift the read out of the loop, thus causing the program to
 never terminate.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Scheduler.pod6
+++ b/doc/Type/Scheduler.pod6
@@ -50,3 +50,5 @@ C<&catch> is called with the L<Exception|/type/Exception> as its sole argument
 if C<&code> dies.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Semaphore.pod6
+++ b/doc/Type/Semaphore.pod6
@@ -76,3 +76,5 @@ Release the semaphore raising the number of permissions. Any blocked thread will
 get access after that.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -123,3 +123,5 @@ number of values have been discarded.
     say (1..5).map({$_}).skip(-1); # OUTPUT: «(1,2,3,4,5)␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Set.pod6
+++ b/doc/Type/Set.pod6
@@ -91,3 +91,5 @@ Creates a C<Set> from the given C<@args>
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -95,3 +95,5 @@ complete list of set operators with detailed explanations.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -251,3 +251,5 @@ Returns a L<MixHash|/type/MixHash> containing the elements of the invocant.
 L<Sets, Bags, and Mixes|/language/setbagmix>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -791,3 +791,5 @@ Defined as:
 Throws C<X::Cannot::Capture>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Slip.pod6
+++ b/doc/Type/Slip.pod6
@@ -70,3 +70,5 @@ C<Empty> is a C<Slip> of the empty C<List>.
 
 =end pod
 
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Stash.pod6
+++ b/doc/Type/Stash.pod6
@@ -38,3 +38,5 @@ a separate method table, and are accessible through introspection on the
 class itself, via C<.can> and C<.^methods>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1249,4 +1249,4 @@ cannot parse the string as a number.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Stringy.pod6
+++ b/doc/Type/Stringy.pod6
@@ -9,3 +9,5 @@
 Common role for string types (such as Str).
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Sub.pod6
+++ b/doc/Type/Sub.pod6
@@ -84,3 +84,5 @@ to it (or even themselves) and we can apply traits to objects at runtime.
     # OUTPUT: «is foo called␤is foo called␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Submethod.pod6
+++ b/doc/Type/Submethod.pod6
@@ -28,3 +28,5 @@ declarator:
 =comment TODO
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Supplier.pod6
+++ b/doc/Type/Supplier.pod6
@@ -78,3 +78,5 @@ L<X::AdHoc> with the supplied message.
 This is meant for shutting down a supply with an error.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -788,3 +788,5 @@ IO::Notification.watch-path(".").act( { say "$^file changed" } );
 ".".IO.watch.act(                     { say "$^file changed" } );   # same
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Tap.pod6
+++ b/doc/Type/Tap.pod6
@@ -27,3 +27,5 @@ A Tap is a subscription to a L<Supply|/type/Supply>.
 Closes the tap.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Telemetry.pod6
+++ b/doc/Type/Telemetry.pod6
@@ -310,3 +310,5 @@ If there are C<snap>s available in the internal array at the end of the
 program, then C<report> will be automatically generated and printed on C<STDERR>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Telemetry/Period.pod6
+++ b/doc/Type/Telemetry/Period.pod6
@@ -50,3 +50,5 @@ Returns the number of CPUs that were in full use on average in this period
 Returns the % of CPUs that were used on average in this period.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Thread.pod6
+++ b/doc/Type/Thread.pod6
@@ -161,3 +161,5 @@ Performs a full memory barrier, preventing re-ordering of reads/writes.
 Required for implementing some lock-free data structures and algorithms.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/ThreadPoolScheduler.pod6
+++ b/doc/Type/ThreadPoolScheduler.pod6
@@ -23,3 +23,5 @@ Creates a new C<ThreadPoolScheduler> object with the given range of threads to
 maintain.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/UInt.pod6
+++ b/doc/Type/UInt.pod6
@@ -34,3 +34,5 @@ Some examples of its behavior and uses:
   say $d - 3;      # OUTPUT: «-3␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -62,4 +62,4 @@ Returns the number of codepoints in the invocant.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/VM.pod6
+++ b/doc/Type/VM.pod6
@@ -65,3 +65,5 @@ established.
 See Also: L<Systemic>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -70,3 +70,5 @@ Sets the type constraint of a container bound to a variable.
     # OUTPUT: «X::TypeCheck::Assignment Type check failed in assignment to $i; expected Int but got Str ("forty plus two")␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Version.pod6
+++ b/doc/Type/Version.pod6
@@ -97,3 +97,5 @@ Defined as:
 Throws C<X::Cannot::Capture>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/Whatever.pod6
+++ b/doc/Type/Whatever.pod6
@@ -112,3 +112,5 @@ Defined as:
 Throws C<X::Cannot::Capture>.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/WhateverCode.pod6
+++ b/doc/Type/WhateverCode.pod6
@@ -75,3 +75,5 @@ to type:
     sub run-with-rand (&code) { code time };
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/WrapHandle.pod6
+++ b/doc/Type/WrapHandle.pod6
@@ -26,4 +26,4 @@ Unwraps a wrapped routine and returns C<Bool::True> on success.
 
 =end pod
 
-# vim: expandtab shiftwidth=4 ft=perl6
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/atomicint.pod6
+++ b/doc/Type/atomicint.pod6
@@ -299,3 +299,5 @@ subtraction is performed.
 Synonym for ⚛-= using U+2212 minus.
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/nativeInt.pod6
+++ b/doc/Type/nativeInt.pod6
@@ -9,3 +9,5 @@
 TODO
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/snapper.pod6
+++ b/doc/Type/snapper.pod6
@@ -20,3 +20,5 @@ L<Telemetry>
 L<Telemetry::Period>
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/utf8.pod6
+++ b/doc/Type/utf8.pod6
@@ -13,3 +13,5 @@ encoded text.
     say $b[1].fmt("0x%X"); # OUTPUT: «0x69␤»
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
The settings in the modeline do the following:

* Highlight this file as Perl6
* Expand tabs into 4 spaces

This is helpful for vim users for highlighting an atypical file format
and creates formatting consistency with regards to tabs and spacing.