### PR TITLE
Describe how to look up class members

### DIFF
--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -179,6 +179,14 @@ from a type name by use of the C<::> postfix:
 =for code :skip-test
 MyType::<$foo>
 
+=head2 Class member lookup
+
+Class attributes and methods are stored in the class meta object and can be looked up
+through by the L<lookup|/method/lookup> method.
+
+=for code :skip-test
+Str.^lookup('chars')
+
 =head1 Globals
 
 Interpreter globals live in the C<GLOBAL> package. The user's program


### PR DESCRIPTION
Lookup within packages and the global namespace is described. Classes should be covered as well.