### PR TITLE
Fix slice table.

### DIFF
--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -205,26 +205,21 @@ For associative slices, the angle-brackets form often comes in handy:
     say %color{*};                 # OUTPUT: «(red yellow green)␤»
 
 Be aware that slices are controlled by the I<type> of what is passed to
-(L<one dimension of|#Multiple dimensions>) the subscript, not its length:
+(L<one dimension of|#Multiple dimensions>) the subscript, not its length.
+In particular the I<type> can be any of the following:
 
-=begin table
-    subscript                         result
-    --------------------------------  -----------------------------------------
-    any Iterable not mentioned below  normal slice
+=item a Range or a lazy Iterable, that L<truncates|#Truncating slices> in [ ]
 
-    a Range                           L<truncates|#Truncating slices> in [ ]
+=item '*' (whatever-star), that returns the full slice (as if all keys/indices were specified)
 
-    a lazy Iterable                   L<truncates|#Truncating slices> in [ ]
+=item any other object, that provides a single-element access rather than a slice
 
-    * (Whatever-star)                 full slice (as if all keys/indices were
-                                      specified)
+=item Callable,  whatever is returned by the callable (this can lead to recursion)
 
-    any other object                  single-element access rather than a slice
+=item empty, the full slice known as L<Zen slice|#Zen slices>
 
-    Callable                          Whatever is returned by the callable. This can lead to recursion.
+=item any iterable different from the above ones, normal slice
 
-    empty                             L<Zen slice|#Zen slices>
-=end table
 
 So even a one-element list returns a slice, whereas a bare scalar value doesn't:
 


### PR DESCRIPTION
The L<> directive does not work within a table, while it seems to work
within an iterable list.

I'm not sure this is the best solution, in particular with regard to its verbosity in explaining the slicing.