### PR TITLE
Fix reference to Perl 5.

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -31,7 +31,7 @@ instead.
 Whitespace in regexes is generally ignored (except with the C<:s> or,
 completely, C<:sigspace> adverb).
 
-As with Perl 6, comments work as usual in regexes.
+As with Perl 5, comments work as usual in regexes.
 
     / word #`(match lexical "word") /
 


### PR DESCRIPTION
It seems the comment working on regexp was referencing the similar feature of
Perl 5, not Perl 6.

Reading as it is now cannot make me  sure if this was referencing \x regexp in Perl 5 and comments or it was bad spelled out to explain that Perl 6 comments work _also_ in regexp.