### PR TITLE
Remove reference to Perl 5 in not 5-to-6 document.

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1132,6 +1132,13 @@ a better choice for grammar reuse.
 TODO more rules. Use L<< C<translate_regex.pl> from Blue
 Tiger|https://github.com/Util/Blue_Tiger/ >> in the meantime.
 
+=head3 Comments
+
+As with Perl 5, comments work as usual in regexes.
+
+    / word #`(match lexical "word") /
+
+
 =head1 Pragmas
 
 =head3 C<strict>

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -31,7 +31,7 @@ instead.
 Whitespace in regexes is generally ignored (except with the C<:s> or,
 completely, C<:sigspace> adverb).
 
-As with Perl 5, comments work as usual in regexes.
+Comments work within a regular expression:
 
     / word #`(match lexical "word") /
 


### PR DESCRIPTION
As of discussion <https://github.com/perl6/doc/issues/1705> related to
my previous pull request <https://github.com/perl6/doc/pull/1704> I decided
to remove the explicit reference to Perl 5 and to make it
a separate section in the 5-to-6 part related to regexps.