### PR TITLE
Fix link to Promise.

### DIFF
--- a/doc/Type/Proc/Async.pod6
+++ b/doc/Type/Proc/Async.pod6
@@ -206,8 +206,8 @@ the program through the C<.print>, C<.say> and C<.write> methods.
 
     method start(Proc::Async:D: :$scheduler = $*SCHEDULER, :$cwd = $*CWD --> Promise:D)
 
-Initiates spawning of the external program. Returns a promise that will be
-kept with a L<Proc|/type/Proc> object once the external
+Initiates spawning of the external program. Returns a  L<Promise|/type/Promise>
+that will be kept with a L<Proc|/type/Proc> object once the external
 program exits, and that will be broken if the program cannot be started.
 
 If C<start> is called on a Proc::Async object on which it has already been


### PR DESCRIPTION
Very simple link from Proc::Async to Promise while documenting the start method.