### PR TITLE
first call to show_captures has wrong number of arguments in section Backtracking

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1914,7 +1914,7 @@ my $string = 'PostgreSQL is an SQL database!';
 say $string ~~ /(.+)(SQL) (.+) $1/; # OUTPUT: ｢PostgreSQL is an SQL｣
 =end code
 
-What happens in the above example is that the string has to be match against the
+What happens in the above example is that the string has to be matched against the
 second occurrence of the word I<SQL>, eating all characters before and leaving out
 the rest.
 
@@ -1934,7 +1934,7 @@ sub show_captures( Match $m ){
     say $result_split;
 }
 
-$string ~~ /(.+)(SQL) (.+) $1 (.+) { show_captures( $/, $string );  }/;
+$string ~~ /(.+)(SQL) (.+) $1 (.+) { show_captures( $/ );  }/;
 =end code
 
 The C<show_captures> method will dump all the elements of C<$/> producing


### PR DESCRIPTION
In the first example where `show_captures` is defined, the call to it has also `$string` as its second argument(line 1937). this is not used in the sub signature.

Furthermore a small typo on line 1917 (matched instead of match).

Regards,
Marcel