### PR TITLE
Add examples for << and >> (regex)

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -715,7 +715,7 @@ These are both zero width assertions.
 X<<<|regex, <<; regex, >>; regex, «; regex, »>>>
 
 C«<<» matches a left word boundary. It matches positions where there
-is a non-word character at the left (or the start of the string) and a word
+is a non-word character (i.e., C<\W> character) at the left (or the start of the string) and a word
 character to the right.
 
 C«>>» matches a right word boundary. It matches positions where there
@@ -725,12 +725,15 @@ the end of the string).
 These are both zero width assertions.
 
     my $str = 'The quick brown fox';
+    say so ' ' ~~ /\W/;               # OUTPUT: «True␤»
     say so $str ~~ /br/;              # OUTPUT: «True␤»
     say so $str ~~ /<< br/;           # OUTPUT: «True␤»
     say so $str ~~ /br >>/;           # OUTPUT: «False␤»
     say so $str ~~ /own/;             # OUTPUT: «True␤»
     say so $str ~~ /<< own/;          # OUTPUT: «False␤»
     say so $str ~~ /own >>/;          # OUTPUT: «True␤»
+    say so $str ~~ /<< The/;          # OUTPUT: «True␤»
+    say so $str ~~ /fox >>/;          # OUTPUT: «True␤»
 
 You can also use the variants C<«> and C<»> :
 


### PR DESCRIPTION
Fix #1755
(I thought make it clear what non-word character is is better than demonstrating by a non-word character other than whitespace)