### PR TITLE
Correct small typo: "suck like".

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1217,7 +1217,7 @@ Still we list several conventions that are widely held.
 
 =item1 Built-in dynamic variables and compile-time variables are always uppercase, such like C<$*OUT>, C<$?FILE>.
 
-=item1 Methods from the MOP and other internals use "_" to separate multiple words, suck like C<add_method>.
+=item1 Methods from the MOP and other internals use "_" to separate multiple words, such like C<add_method>.
 
 =end pod
 


### PR DESCRIPTION
Left as "such like" for consistency with the rest of the text.