### PR TITLE
Add a Q and A about Rakudo Star release cycle

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -693,6 +693,15 @@ bootstrapping files created by earlier runs of the build process.
 
     (not (not Nil))
 
+X<|Perl 6 Distribution (FAQ)>
+=head1 Perl 6 Distribution
+
+X<|Rakudo Star release cycle (FAQ)>
+=head2 When will the next version of Rakudo Star be released?
+
+A Rakudo Star release is produced at least quarterly (sometimes monthly).
+See L<rakudo.org About|http://rakudo.org/about/> for more information.
+
 =head1 Meta Questions and Advocacy
 
 =head2 Why is Perl 6 called Perl?


### PR DESCRIPTION
Fix #1830 
I didn't describe the release cycle of the compiler-only version because this one is not a mainstream distribution for many users.
See also: https://github.com/perl6/perl6.org/issues/93