### PR TITLE
Remove leading indentation from (some) pod code blocks.

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -57,9 +57,9 @@ If you've read any Perl 6 code at all, it's immediately obvious that
 method call syntax now uses a dot instead of an arrow:
 
 =for code :lang<perl5>
-    $person->name  # Perl 5
+$person->name  # Perl 5
 =for code :preamble<no strict;>
-    $person.name   # Perl 6
+$person.name   # Perl 6
 
 The dot notation is both easier to type and more of an industry standard.
 But we also wanted to steal the arrow for something else.  (Concatenation
@@ -68,9 +68,9 @@ is now done with the C<~> operator, if you were wondering.)
 To call a method whose name is not known until runtime:
 
 =for code :lang<perl5>
-    $object->$methodname(@args);  # Perl 5
+$object->$methodname(@args);  # Perl 5
 =for code :preamble<no strict;>
-    $object."$methodname"(@args); # Perl 6
+$object."$methodname"(@args); # Perl 6
 
 If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
 a C<Method> object, rather than the simple string name of the method.
@@ -81,11 +81,11 @@ Perl 5 allows a surprising amount of flexibility in the use of whitespace,
 even with strict mode and warnings turned on:
 
 =for code :lang<perl5>
-    # unidiomatic but valid Perl 5
-    say"Hello ".ucfirst  ($people
-        [$ i]
-        ->
-        name)."!"if$greeted[$i]<1;
+# unidiomatic but valid Perl 5
+say"Hello ".ucfirst  ($people
+    [$ i]
+    ->
+    name)."!"if$greeted[$i]<1;
 
 Perl 6 also endorses programmer freedom and creativity, but balanced
 syntactic flexibility against its design goal of having a consistent,
@@ -106,11 +106,11 @@ habitual coding styles:
 I<No space allowed before the opening parenthesis of an argument list.>
 
 =for code :lang<perl5>
-    substr ($s, 4, 1); # Perl 5 (in Perl 6 this would try to pass a single
+substr ($s, 4, 1); # Perl 5 (in Perl 6 this would try to pass a single
                        #         argument of type List to substr)
 =for code :preamble<no strict;>
-    substr($s, 4, 1);  # Perl 6
-    substr $s, 4, 1;   # Perl 6 - alternative parentheses-less style
+substr($s, 4, 1);  # Perl 6
+substr $s, 4, 1;   # Perl 6 - alternative parentheses-less style
 
 =end item
 
@@ -118,21 +118,21 @@ I<No space allowed before the opening parenthesis of an argument list.>
 I<Space is B<required> immediately after keywords>
 
 =for code :lang<perl5>
-    my($alpha, $beta);          # Perl 5, tries to call my() sub in Perl 6
+my($alpha, $beta);          # Perl 5, tries to call my() sub in Perl 6
 =for code :preamble<no strict;>
-    my ($alpha, $beta);         # Perl 6
+my ($alpha, $beta);         # Perl 6
 
 =for code :lang<perl5>
-    if($a < 0) { ... }          # Perl 5, dies in Perl 6
+if($a < 0) { ... }          # Perl 5, dies in Perl 6
 =for code :preamble<no strict;>
-    if ($a < 0) { ... }         # Perl 6
-    if $a < 0 { ... }           # Perl 6, more idiomatic
+if ($a < 0) { ... }         # Perl 6
+if $a < 0 { ... }           # Perl 6, more idiomatic
 
 =for code :lang<perl5>
-    while($x-- > 5) { ... }     # Perl 5, dies in Perl 6
+while($x-- > 5) { ... }     # Perl 5, dies in Perl 6
 =for code :preamble<no strict;>
-    while ($x-- > 5) { ... }    # Perl 6
-    while $x-- > 5 { ... }      # Perl 6, more idiomatic
+while ($x-- > 5) { ... }    # Perl 6
+while $x-- > 5 { ... }      # Perl 6, more idiomatic
 
 =end item
 
@@ -141,18 +141,18 @@ I<No space allowed after a prefix operator, or before a
 postfix/postcircumfix operator (including array/hash subscripts).>
 
 =for code :lang<perl5>
-    $seen {$_} ++; # Perl 5
+$seen {$_} ++; # Perl 5
 =for code :preamble<no strict;>
-    %seen{$_}++;   # Perl 6
+%seen{$_}++;   # Perl 6
 =end item
 
 =begin item
 I<No space allowed around the method call operator.>
 
 =for code :lang<perl5>
-    $customer -> name; # Perl 5
+$customer -> name; # Perl 5
 =for code :preamble<no strict;>
-    $customer.name;    # Perl 6
+$customer.name;    # Perl 6
 =end item
 
 =begin item
@@ -160,9 +160,9 @@ I<Space required before an infix operator if it would
 conflict with an existing postfix/postcircumfix operator.>
 
 =for code :lang<perl5>
-    $n<1;   # Perl 5 (in Perl 6 this would conflict with postcircumfix < >)
+$n<1;   # Perl 5 (in Perl 6 this would conflict with postcircumfix < >)
 =for code :preamble<no strict;>
-    $n < 1; # Perl 6
+$n < 1; # Perl 6
 
 =end item
 
@@ -171,14 +171,14 @@ to add whitespace in Perl 6 code in places where it is otherwise not
 allowed:
 
 =for code :lang<perl5>
-    # Perl 5
-    my @books = $xml->parse_file($file)          # some comment
-                    ->findnodes("/library/book");
+# Perl 5
+my @books = $xml->parse_file($file)          # some comment
+                ->findnodes("/library/book");
 
 =for code :preamble<no strict;>
-    # Perl 6
-    my @books = $xml.parse-file($file)\          # some comment
-                    .findnodes("/library/book");
+# Perl 6
+my @books = $xml.parse-file($file)\          # some comment
+                .findnodes("/library/book");
 
 See also L<S03#Minimal whitespace
 DWIMmery|https://design.perl6.org/S03.html#Minimal_whitespace_DWIMmery> and
@@ -222,14 +222,14 @@ backslash) to refer to the function object of a named subroutine/operator
 without invoking it, i.e. to use the name as a "noun" instead of a "verb":
 
 =for code :lang<perl5>
-    my $sub = \&foo; # Perl 5
+my $sub = \&foo; # Perl 5
 =for code :preamble<sub foo {};>
-    my $sub = &foo;  # Perl 6
+my $sub = &foo;  # Perl 6
 
 =for code :lang<perl5>
-    callback => sub { say @_ }  # Perl 5 - can't pass built-in sub directly
+callback => sub { say @_ }  # Perl 5 - can't pass built-in sub directly
 =for code
-    callback => &say            # Perl 6 - & gives "noun" form of any sub
+callback => &say            # Perl 6 - & gives "noun" form of any sub
 
 Since Perl 6 does not allow adding/removing symbols in a lexical scope once
 it has finished compiling, there is no equivalent to Perl 5's
@@ -250,14 +250,14 @@ makes a difference whether you, say, pass a literal code block or a
 variable holding a code object as an argument:
 
 =for code :lang<perl5>
-    # Perl 5:
-    first_index { $_ > 5 } @values;
-    &first_index($coderef, @values); # (disabling the prototype that parses a
+# Perl 5:
+first_index { $_ > 5 } @values;
+&first_index($coderef, @values); # (disabling the prototype that parses a
                                      # literal block as the first argument)
 =for code
-    # Perl 6:
-    first { $_ > 5 }, @values, :k;   # the :k makes first return an index
-    first $coderef, @values, :k;
+# Perl 6:
+first { $_ > 5 }, @values, :k;   # the :k makes first return an index
+first $coderef, @values, :k;
 =end item
 
 =begin item
@@ -270,13 +270,13 @@ replacing the caller in the call stack>
 =end comment
 
 =for code :lang<perl5>
-    sub foo { say "before"; &bar;     say "after" } # Perl 5
+sub foo { say "before"; &bar;     say "after" } # Perl 5
 =for code
-    sub foo { say "before"; bar(|@_); say "after" } # Perl 6 - have to be explicit
+sub foo { say "before"; bar(|@_); say "after" } # Perl 6 - have to be explicit
 
 
 =for code :lang<perl5>
-    sub foo { say "before"; goto &bar } # Perl 5
+sub foo { say "before"; goto &bar } # Perl 5
 
 =end item
 
@@ -296,35 +296,35 @@ version that does not support lexical filehandles, when a filehandle needed
 to be passed into a sub.
 
 =for code :lang<perl5>
-    # Perl 5 - ancient method
-    sub read_2 {
-        local (*H) = @_;
-        return scalar(<H>), scalar(<H>);
-    }
-    open FILE, '<', $path or die;
-    my ($line1, $line2) = read_2(*FILE);
+# Perl 5 - ancient method
+sub read_2 {
+    local (*H) = @_;
+    return scalar(<H>), scalar(<H>);
+}
+open FILE, '<', $path or die;
+my ($line1, $line2) = read_2(*FILE);
 
 You should refactor your Perl 5 code to remove the need for the GLOB,
 before translating into Perl 6.
 
 =for code :lang<perl5>
-    # Perl 5 - modern use of lexical filehandles
-    sub read_2 {
-        my ($fh) = @_;
-        return scalar(<$fh>), scalar(<$fh>);
-    }
-    open my $in_file, '<', $path or die;
-    my ($line1, $line2) = read_2($in_file);
+# Perl 5 - modern use of lexical filehandles
+sub read_2 {
+    my ($fh) = @_;
+    return scalar(<$fh>), scalar(<$fh>);
+}
+open my $in_file, '<', $path or die;
+my ($line1, $line2) = read_2($in_file);
 
 And here's just one possible Perl 6 translation:
 
 =for code :preamble<no strict;>
-    # Perl 6
-    sub read-n($fh, $n) {
-        return $fh.get xx $n;
-    }
-    my $in-file = open $path or die;
-    my ($line1, $line2) = read-n($in-file, 2);
+# Perl 6
+sub read-n($fh, $n) {
+    return $fh.get xx $n;
+}
+my $in-file = open $path or die;
+my ($line1, $line2) = read-n($in-file, 2);
 
 =head2 [] Array indexing/slicing
 
@@ -335,25 +335,25 @@ L<sigil|#@_Array>, and adverbs can be used to control the type of slice:
 I<Indexing>
 
 =for code :lang<perl5>
-    say $months[2]; # Perl 5
+say $months[2]; # Perl 5
 =for code :preamble<no strict;>
-    say @months[2]; # Perl 6 - @ instead of $
+say @months[2]; # Perl 6 - @ instead of $
 =end item
 
 =begin item
 I<Value-slicing>
 
 =for code :preamble<no strict;>
-    say join ',', @months[6, 8..11]; # Perl 5 and Perl 6
+say join ',', @months[6, 8..11]; # Perl 5 and Perl 6
 =end item
 
 =begin item
 I<Key/value-slicing>
 
 =for code :lang<perl5>
-    say join ',', %months[6, 8..11];    # Perl 5
+say join ',', %months[6, 8..11];    # Perl 5
 =for code :preamble<no strict;>
-    say join ',', @months[6, 8..11]:kv; # Perl 6 - @ instead of %; use :kv adverb
+say join ',', @months[6, 8..11]:kv; # Perl 6 - @ instead of %; use :kv adverb
 =end item
 
 Also note that the subscripting brackets are now a normal postcircumfix
@@ -374,37 +374,37 @@ construct):
 I<Indexing>
 
 =for code :lang<perl5>
-    say $calories{"apple"}; # Perl 5
+say $calories{"apple"}; # Perl 5
 =for code :preamble<no strict;>
-    say %calories{"apple"}; # Perl 6 - % instead of $
+say %calories{"apple"}; # Perl 6 - % instead of $
 
 =for code :lang<perl5>
-    say $calories{apple};   # Perl 5
+say $calories{apple};   # Perl 5
 =for code :preamble<no strict;>
-    say %calories<apple>;   # Perl 6 - angle brackets; % instead of $
-    say %calories«"$key"»;  # Perl 6 - double angles interpolate as a list of Str
+say %calories<apple>;   # Perl 6 - angle brackets; % instead of $
+say %calories«"$key"»;  # Perl 6 - double angles interpolate as a list of Str
 =end item
 
 =begin item
 I<Value-slicing>
 
 =for code :lang<perl5>
-    say join ',', @calories{'pear', 'plum'}; # Perl 5
+say join ',', @calories{'pear', 'plum'}; # Perl 5
 =for code :preamble<no strict;>
-    say join ',', %calories{'pear', 'plum'}; # Perl 6 - % instead of @
-    say join ',', %calories<pear plum>;      # Perl 6 (prettier version)
-    my $keys = 'pear plum';
-    say join ',', %calories«$keys»;          # Perl 6 the split is done after interpolation
+say join ',', %calories{'pear', 'plum'}; # Perl 6 - % instead of @
+say join ',', %calories<pear plum>;      # Perl 6 (prettier version)
+my $keys = 'pear plum';
+say join ',', %calories«$keys»;          # Perl 6 the split is done after interpolation
 =end item
 
 =begin item
 I<Key/value-slicing>
 
 =for code :lang<perl5>
-    say join ',', %calories{'pear', 'plum'};    # Perl 5
+say join ',', %calories{'pear', 'plum'};    # Perl 5
 =for code :preamble<no strict;>
-    say join ',', %calories{'pear', 'plum'}:kv; # Perl 6 - use :kv adverb
-    say join ',', %calories<pear plum>:kv;      # Perl 6 (prettier version)
+say join ',', %calories{'pear', 'plum'}:kv; # Perl 6 - use :kv adverb
+say join ',', %calories<pear plum>:kv;      # Perl 6 (prettier version)
 =end item
 
 Also note that the subscripting curly braces are now a normal postcircumfix
@@ -429,23 +429,23 @@ preceding the sub name with a C<&> sigil. References to existing named
 variables are generated by C<item> context.
 
 =for code
-    my $aref = [ 1, 2, 9 ];          # Both Perl 5&6
-    my $href = { A => 98, Q => 99 }; # Both Perl 5&6 [*See Note*]
+my $aref = [ 1, 2, 9 ];          # Both Perl 5&6
+my $href = { A => 98, Q => 99 }; # Both Perl 5&6 [*See Note*]
 
 =for code :lang<perl5>
-    my $aref =     \@aaa  ; # Perl 5
+my $aref =     \@aaa  ; # Perl 5
 =for code :preamble<no strict;>
-    my $aref = item(@aaa) ; # Perl 6
+my $aref = item(@aaa) ; # Perl 6
 
 =for code :lang<perl5>
-    my $href =     \%hhh  ; # Perl 5
+my $href =     \%hhh  ; # Perl 5
 =for code :preamble<no strict;>
-    my $href = item(%hhh) ; # Perl 6
+my $href = item(%hhh) ; # Perl 6
 
 =for code :lang<perl5>
-    my $sref =     \&foo  ; # Perl 5
+my $sref =     \&foo  ; # Perl 5
 =for code :preamble<sub foo {};>
-    my $sref =      &foo  ; # Perl 6
+my $sref =      &foo  ; # Perl 6
 
 B<NOTE:> If one or more values reference the topic variable, C<$_>, the
 right-hand side of the assignment will be interpreted as a L<Block|/type/Block>,
@@ -501,18 +501,18 @@ type-sigil and curly braces, with the reference inside the curly braces.
 In Perl 6, the curly braces are changed to parentheses.
 
 =for code :lang<perl5>
-    # Perl 5
-        say      ${$scalar_ref};
-        say      @{$arrayref  };
-        say keys %{$hashref   };
-        say      &{$subref    };
+# Perl 5
+    say      ${$scalar_ref};
+    say      @{$arrayref  };
+    say keys %{$hashref   };
+    say      &{$subref    };
 
 =for code :preamble<no strict;>
-    # Perl 6
-        say      $($scalar_ref);
-        say      @($arrayref  );
-        say keys %($hashref   );
-        say      &($subref    );
+# Perl 6
+    say      $($scalar_ref);
+    say      @($arrayref  );
+    say keys %($hashref   );
+    say      &($subref    );
 
 Note that in both Perl 5 and Perl 6, the surrounding curly braces or parentheses can
 often be omitted, though the omission can reduce readability.
@@ -522,16 +522,16 @@ composite's reference or to call a sub through its reference. In Perl 6,
 we now use the dot operator C<.> for those tasks.
 
 =for code :lang<perl5>
-    # Perl 5
-        say $arrayref->[7];
-        say $hashref->{'fire bad'};
-        say $subref->($foo, $bar);
+# Perl 5
+    say $arrayref->[7];
+    say $hashref->{'fire bad'};
+    say $subref->($foo, $bar);
 
 =for code :preamble<no strict;>
-    # Perl 6
-        say $arrayref.[7];
-        say $hashref.{'fire bad'};
-        say $subref.($foo, $bar);
+# Perl 6
+    say $arrayref.[7];
+    say $hashref.{'fire bad'};
+    say $subref.($foo, $bar);
 
 In recent versions of Perl 5 (5.20 and later), a new feature allows the use of the arrow
 operator for dereferencing:  see
@@ -539,24 +539,24 @@ L<Postfix Dereferencing|http://search.cpan.org/~shay/perl-5.20.1/pod/perl5200del
 Such feature corresponds to Perl 6 C<.list> and C<.hash> methods:
 
 =for code :lang<perl5>
-    # Perl 5.20
-        use experimental qw< postderef >;
-        my @a = $arrayref->@*;
-        my %h = $hashref->%*;
-        my @slice = $arrayref->@[3..7];
+# Perl 5.20
+    use experimental qw< postderef >;
+    my @a = $arrayref->@*;
+    my %h = $hashref->%*;
+    my @slice = $arrayref->@[3..7];
 
 =for code :preamble<no strict;>
-    # Perl 6
-        my @a = $arrayref.list;         # or @($arrayref)
-        my %h = $hashref.hash;          # or %($hashref)
-        my @slice = $arrayref[3..7];
+# Perl 6
+    my @a = $arrayref.list;         # or @($arrayref)
+    my %h = $hashref.hash;          # or %($hashref)
+    my @slice = $arrayref[3..7];
 
 The "Zen" slice does the same thing:
 
 =for code :preamble<no strict;>
-    # Perl 6
-        my @a = $arrayref[];
-        my %h = $hashref{};
+# Perl 6
+    my @a = $arrayref[];
+    my %h = $hashref{};
 
 See L<S32/Containers|https://design.perl6.org/S32/Containers.html>
 
@@ -587,9 +587,9 @@ order to append or prefix more items) one should use the C<|> operator
 (see also L<Slip|/type/Slip>). For instance:
 
 =for code
-    my @numbers = (100, 200, 300);
-    my @more_numbers = (500, 600, 700);
-    my @all_numbers = [|@numbers, 400, |@more_numbers];
+my @numbers = (100, 200, 300);
+my @more_numbers = (500, 600, 700);
+my @all_numbers = [|@numbers, 400, |@more_numbers];
 
 That way one can concatenate arrays.
 
@@ -624,15 +624,15 @@ In Perl 6, those single-character ops have been removed, and replaced by
 two-character ops which coerce their arguments to the needed context.
 
 =begin code :skip-test
-    # Infix ops (two arguments; one on each side of the op)
-    +&  +|  +^  And Or Xor: Numeric
-    ~&  ~|  ~^  And Or Xor: String
-    ?&  ?|  ?^  And Or Xor: Boolean
+# Infix ops (two arguments; one on each side of the op)
++&  +|  +^  And Or Xor: Numeric
+~&  ~|  ~^  And Or Xor: String
+?&  ?|  ?^  And Or Xor: Boolean
 
-    # Prefix ops (one argument, after the op)
-    +^  Not: Numeric
-    ~^  Not: String
-    ?^  Not: Boolean (same as the ! op)
+# Prefix ops (one argument, after the op)
++^  Not: Numeric
+~^  Not: String
+?^  Not: Boolean (same as the ! op)
 =end code
 
 =head2 C«<< >>» Numeric shift left|right ops
@@ -640,9 +640,9 @@ two-character ops which coerce their arguments to the needed context.
 Replaced by C«+<» and C«+>» .
 
 =for code :lang<perl5>
-    say 42 << 3; # Perl 5
+say 42 << 3; # Perl 5
 =for code
-    say 42 +< 3; # Perl 6
+say 42 +< 3; # Perl 6
 
 =head2 C«=>» Fat comma
 
@@ -671,31 +671,31 @@ expect L<Pair|/type/Pair>s; however, this requires you to change
 all sub calls at once.
 
 =begin code :lang<perl5>
-    # Perl 5
-    sub get_the_loot {
-        my $loot = shift;
-        my %options = @_;
-        # ...
-    }
-    # Note: no curly braces in this sub call
-    get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 );
+# Perl 5
+sub get_the_loot {
+    my $loot = shift;
+    my %options = @_;
+    # ...
+}
+# Note: no curly braces in this sub call
+get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 );
 =end code
 
 =begin code
-    # Perl 6, original API
-    sub get_the_loot( $loot, *%options ) { # The * means to slurp everything
-        ...
-    }
-    get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 ); # Note: no curly braces in this API
+# Perl 6, original API
+sub get_the_loot( $loot, *%options ) { # The * means to slurp everything
+    ...
+}
+get_the_loot( 'diamonds', quiet_level => 'very', quantity => 9 ); # Note: no curly braces in this API
 
-    # Perl 6, API changed to specify valid options
-    # The colon before the sigils means to expect a Pair,
-    # with the key having the same name as the variable.
-    sub get_the_loot( $loot, :$quiet_level?, :$quantity = 1 ) {
-        # This version will check for unexpected arguments!
-        ...
-    }
-    get_the_loot( 'diamonds', quietlevel => 'very' ); # Throws error for misspelled parameter name
+# Perl 6, API changed to specify valid options
+# The colon before the sigils means to expect a Pair,
+# with the key having the same name as the variable.
+sub get_the_loot( $loot, :$quiet_level?, :$quantity = 1 ) {
+    # This version will check for unexpected arguments!
+    ...
+}
+get_the_loot( 'diamonds', quietlevel => 'very' ); # Throws error for misspelled parameter name
 =end code
 
 =head2 C<? :> Ternary operator
@@ -716,9 +716,9 @@ Replaced by the tilde.
 Mnemonic: think of "stitching" together the two strings with needle and thread.
 
 =for code :lang<perl5>
-    $food = 'grape' . 'fruit'; # Perl 5
+$food = 'grape' . 'fruit'; # Perl 5
 =for code :preamble<no strict;>
-    $food = 'grape' ~ 'fruit'; # Perl 6
+$food = 'grape' ~ 'fruit'; # Perl 6
 
 =head2 C<x> List Repetition or String Repetition operator
 
@@ -735,15 +735,15 @@ Perl 6 uses two different Repetition operators to achieve the above:
 Mnemonic: C<x> is short and C<xx> is long, so C<xx> is the one used for lists.
 
 =for code :lang<perl5>
-    # Perl 5
-        print '-' x 80;             # Print row of dashes
-        @ones = (1) x 80;           # A list of 80 1's
-        @ones = (5) x @ones;        # Set all elements to 5
+# Perl 5
+    print '-' x 80;             # Print row of dashes
+    @ones = (1) x 80;           # A list of 80 1's
+    @ones = (5) x @ones;        # Set all elements to 5
 =for code :preamble<no strict;>
-    # Perl 6
-        print '-' x 80;             # Unchanged
-        @ones = 1 xx 80;            # Parentheses no longer needed
-        @ones = 5 xx @ones;         # Parentheses no longer needed
+# Perl 6
+    print '-' x 80;             # Unchanged
+    @ones = 1 xx 80;            # Parentheses no longer needed
+    @ones = 5 xx @ones;         # Parentheses no longer needed
 
 
 =head2 C<..> C<...> Two Dots or Three Dots, Range op or Flipflop op
@@ -774,9 +774,9 @@ used, must not immediately follow the keyword, or it will be taken as a function
 call instead.  Binding the conditional expression to a variable is also a little different:
 
 =for code :lang<perl5>
-    if (my $x = dostuff()) {...}  # Perl 5
+if (my $x = dostuff()) {...}  # Perl 5
 =for code :preamble<sub dostuff {};>
-    if dostuff() -> $x {...}      # Perl 6
+if dostuff() -> $x {...}      # Perl 6
 
 (You can still use the C<my> form in Perl 6, but it will scope to the
 outer block, not the inner.)
@@ -791,26 +791,26 @@ statements or like the C<switch>-C<case> construct in e.g. C.  It has the
 general structure:
 
 =for code :lang<pseudo>
-    given EXPR {
-        when EXPR { ... }
-        when EXPR { ... }
-        default { ... }
-    }
+given EXPR {
+    when EXPR { ... }
+    when EXPR { ... }
+    default { ... }
+}
 
 In its simplest form, the construct is as follows:
 
 =for code :preamble<no strict;>
-    given $value {
-        when "a match" {
-            # do-something();
-        }
-        when "another match" {
-            # do-something-else();
-        }
-        default {
-            # do-default-thing();
-        }
+given $value {
+    when "a match" {
+        # do-something();
     }
+    when "another match" {
+        # do-something-else();
+    }
+    default {
+        # do-default-thing();
+    }
+}
 
 This is simple in the sense that a scalar value is matched in the C<when>
 statements.  More generally, the matches are actually smart-matches on the
@@ -828,9 +828,9 @@ used, must not immediately follow the keyword, or it will be taken as a function
 call instead.  Binding the conditional expression to a variable is also a little different:
 
 =for code :lang<perl5>
-    while (my $x = dostuff()) {...}  # Perl 5
+while (my $x = dostuff()) {...}  # Perl 5
 =for code :preamble<sub dostuff {};>
-    while dostuff() -> $x {...}      # Perl 6
+while dostuff() -> $x {...}      # Perl 6
 
 (You can still use the C<my> form in Perl 6, but it will scope to the
 outer block, not the inner.)
@@ -845,35 +845,35 @@ In Perl 6, C<for> statement is B<lazy>, so we read line-by-line in a C<for>
 loop using the C<.lines> method.
 
 =for code :lang<perl5>
-    while (<IN_FH>)  { } # Perl 5
+while (<IN_FH>)  { } # Perl 5
 =for code :preamble<no strict;>
-    for $IN_FH.lines { } # Perl 6
+for $IN_FH.lines { } # Perl 6
 
 =head3 C<do> C<while>/C<until>
 
 =begin code :lang<perl5>
-    # Perl 5
-    do {
-        ...
-    } while $x < 10;
+# Perl 5
+do {
+    ...
+} while $x < 10;
 
-    do {
-        ...
-    } until $x >= 10;
+do {
+    ...
+} until $x >= 10;
 =end code
 
 The construct is still present, but C<do> was renamed to C<repeat>, to better
 represent what the construct does:
 
 =begin code :preamble<no strict;>
-    # Perl 6
-    repeat {
-        ...
-    } while $x < 10;
+# Perl 6
+repeat {
+    ...
+} while $x < 10;
 
-    repeat {
-        ...
-    } until $x >= 10;
+repeat {
+    ...
+} until $x >= 10;
 =end code
 
 =head3 C<for> C<foreach>
@@ -888,9 +888,9 @@ The C-style three-factor form now uses the C<loop> keyword, and is
 otherwise unchanged. The parentheses B<are> still required.
 
 =for code :lang<perl5>
-    for  ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 5
+for  ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 5
 =for code
-    loop ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 6
+loop ( my $i = 1; $i <= 10; $i++ ) { ... } # Perl 6
 
 
 The loop-iterator form is named C<for> in Perl 6 and C<foreach> is no longer a keyword.
@@ -906,19 +906,19 @@ variable to a C«<->». When translating from Perl 5, inspect the use of the lo
 read-write is needed.
 
 =for code :lang<perl5>
-    for my $car (@cars)  {...} # Perl 5; read-write
+for my $car (@cars)  {...} # Perl 5; read-write
 =for code :preamble<no strict;>
-    for @cars  -> $car   {...} # Perl 6; read-only
-    for @cars <-> $car   {...} # Perl 6; read-write
+for @cars  -> $car   {...} # Perl 6; read-only
+for @cars <-> $car   {...} # Perl 6; read-write
 
 If the default topic C<$_> is being used, but needs to be read-write,
 then just use C«<->» and explicitly specify C«$_».
 
 =for code :lang<perl5>
-    for (@cars)      {...} # Perl 5; $_ is read-write
+for (@cars)      {...} # Perl 5; $_ is read-write
 =for code :preamble<no strict;>
-    for @cars        {...} # Perl 6; $_ is read-only
-    for @cars <-> $_ {...} # Perl 6; $_ is read-write
+for @cars        {...} # Perl 6; $_ is read-only
+for @cars <-> $_ {...} # Perl 6; $_ is read-write
 
 It is possible to consume more than one element of the list in each iteration simply specifying
 more than one variable after the arrow operator:
@@ -937,14 +937,14 @@ Here is the equivalent to Perl 5’s C<while…each(%hash)> or C<while…each(@
 Perl 6:
 
 =for code :lang<perl5>
-    while (my ($i, $v) = each(@array)) { ... } # Perl 5
+while (my ($i, $v) = each(@array)) { ... } # Perl 5
 =for code :preamble<no strict;>
-    for @array.kv -> $i, $v { ... } # Perl 6
+for @array.kv -> $i, $v { ... } # Perl 6
 
 =for code :lang<perl5>
-    while (my ($k, $v) = each(%hash)) { ... } # Perl 5
+while (my ($k, $v) = each(%hash)) { ... } # Perl 5
 =for code :preamble<no strict;>
-    for %hash.kv -> $k, $v { ... } # Perl 6
+for %hash.kv -> $k, $v { ... } # Perl 6
 
 =head2 Flow Control statements
 
@@ -960,26 +960,26 @@ There is no longer a C<continue> block.
 Instead, use a C<NEXT> block within the body of the loop.
 
 =for code :lang<perl5>
-    # Perl 5
-        my $str = '';
-        for (1..5) {
-            next if $_ % 2 == 1;
-            $str .= $_;
-        }
-        continue {
-            $str .= ':'
-        }
+# Perl 5
+    my $str = '';
+    for (1..5) {
+        next if $_ % 2 == 1;
+        $str .= $_;
+    }
+    continue {
+        $str .= ':'
+    }
 
 =for code
-    # Perl 6
-        my $str = '';
-        for 1..5 {
-            next if $_ % 2 == 1;
-            $str ~= $_;
-            NEXT {
-                $str ~= ':'
-            }
+# Perl 6
+    my $str = '';
+    for 1..5 {
+        next if $_ % 2 == 1;
+        $str ~= $_;
+        NEXT {
+            $str ~= ':'
         }
+    }
 
 
 =head1 Functions
@@ -995,9 +995,9 @@ require a comma between the block and the arguments e.g. C<map>, C<grep>,
 etc.
 
 =for code :lang<perl5>
-    my @results = grep { $_ eq "bars" } @foo; # Perl 5
+my @results = grep { $_ eq "bars" } @foo; # Perl 5
 =for code :preamble<no strict;>
-    my @results = grep { $_ eq "bars" }, @foo; # Perl 6
+my @results = grep { $_ eq "bars" }, @foo; # Perl 6
 
 
 =head2 C<delete>
@@ -1007,14 +1007,14 @@ L<C<{}> hash subscripting|#{}_Hash_indexing/slicing>
 and L<C<[]> array subscripting|#[]_Array_indexing/slicing> operators.
 
 =for code :lang<perl5>
-    my $deleted_value = delete $hash{$key};  # Perl 5
+my $deleted_value = delete $hash{$key};  # Perl 5
 =for code :preamble<no strict;>
-    my $deleted_value = %hash{$key}:delete;  # Perl 6 - use :delete adverb
+my $deleted_value = %hash{$key}:delete;  # Perl 6 - use :delete adverb
 
 =for code :lang<perl5>
-    my $deleted_value = delete $array[$i];  # Perl 5
+my $deleted_value = delete $array[$i];  # Perl 5
 =for code :preamble<no strict;>
-    my $deleted_value = @array[$i]:delete;  # Perl 6 - use :delete adverb
+my $deleted_value = @array[$i]:delete;  # Perl 6 - use :delete adverb
 
 =head2 C<exists>
 
@@ -1023,14 +1023,14 @@ L<C<{}> hash subscripting|#{}_Hash_indexing/slicing>
 and L<C<[]> array subscripting|#[]_Array_indexing/slicing> operators.
 
 =for code :lang<perl5>
-    say "element exists" if exists $hash{$key};  # Perl 5
+say "element exists" if exists $hash{$key};  # Perl 5
 =for code :preamble<no strict;>
-    say "element exists" if %hash{$key}:exists;  # Perl 6 - use :exists adverb
+say "element exists" if %hash{$key}:exists;  # Perl 6 - use :exists adverb
 
 =for code :lang<perl5>
-    say "element exists" if exists $array[$i];  # Perl 5
+say "element exists" if exists $array[$i];  # Perl 5
 =for code :preamble<no strict;>
-    say "element exists" if @array[$i]:exists;  # Perl 6 - use :exists adverb
+say "element exists" if @array[$i]:exists;  # Perl 6 - use :exists adverb
 
 =head1 Regular Expressions ( Regex / Regexp )
 
@@ -1042,19 +1042,19 @@ C<=~> regexp-binding op.
 In Perl 6, the C<~~> smartmatch op is used instead.
 
 =for code :lang<perl5>
-    next if $line  =~ /static/  ; # Perl 5
+next if $line  =~ /static/  ; # Perl 5
 =for code :preamble<no strict;>
-    next if $line  ~~ /static/  ; # Perl 6
+next if $line  ~~ /static/  ; # Perl 6
 
 =for code :lang<perl5>
-    next if $line  !~ /dynamic/ ; # Perl 5
+next if $line  !~ /dynamic/ ; # Perl 5
 =for code :preamble<no strict;>
-    next if $line !~~ /dynamic/ ; # Perl 6
+next if $line !~~ /dynamic/ ; # Perl 6
 
 =for code :lang<perl5>
-    $line =~ s/abc/123/;          # Perl 5
+$line =~ s/abc/123/;          # Perl 5
 =for code :preamble<no strict;>
-    $line ~~ s/abc/123/;          # Perl 6
+$line ~~ s/abc/123/;          # Perl 6
 
 Alternately, the new C<.match> and C<.subst> methods can be used. Note that
 C<.subst> is non-mutating. See
@@ -1063,9 +1063,9 @@ L<S05/Substitution|https://design.perl6.org/S05.html#Substitution>.
 =head2 Captures start with 0, not 1
 
 =for code :lang<perl5>
-    /(.+)/ and print $1; # Perl 5
+/(.+)/ and print $1; # Perl 5
 =for code
-    /(.+)/ and print $0; # Perl 6
+/(.+)/ and print $0; # Perl 6
 
 =head2 Move modifiers
 
@@ -1073,9 +1073,9 @@ Move any modifiers from the end of the regex to the beginning. This may
 require you to add the optional C<m> on a plain match like C«/abc/».
 
 =for code :lang<perl5>
-    next if $line =~    /static/i ; # Perl 5
+next if $line =~    /static/i ; # Perl 5
 =for code :preamble<no strict;>
-    next if $line ~~ m:i/static/  ; # Perl 6
+next if $line ~~ m:i/static/  ; # Perl 6
 
 =head2 Add :P5 or :Perl5 adverb
 
@@ -1083,10 +1083,10 @@ If the actual regex is complex, you may want to use it as-is, by adding the
 C<P5> modifier.
 
 =for code :lang<perl5>
-    next if $line =~    m/[aeiou]/   ; # Perl 5
+next if $line =~    m/[aeiou]/   ; # Perl 5
 =for code :preamble<no strict;>
-    next if $line ~~ m:P5/[aeiou]/   ; # Perl 6, using P5 modifier
-    next if $line ~~ m/  <[aeiou]> / ; # Perl 6, native new syntax
+next if $line ~~ m:P5/[aeiou]/   ; # Perl 6, using P5 modifier
+next if $line ~~ m/  <[aeiou]> / ; # Perl 6, native new syntax
 
 =head2 Special matchers generally fall under the <> syntax
 
@@ -1171,15 +1171,15 @@ The functions which were altered by C<autodie> to throw exceptions on
 error, now throw exceptions by default unless you test the return value explicitly.
 
 =for code :lang<perl5>
-    # Perl 5
-    open my $i_fh, '<', $input_path;  # Fails silently on error
-    use autodie;
-    open my $o_fh, '>', $output_path; # Throws exception on error
+# Perl 5
+open my $i_fh, '<', $input_path;  # Fails silently on error
+use autodie;
+open my $o_fh, '>', $output_path; # Throws exception on error
 
 =for code :preamble<no strict;>
-    # Perl 6
-    my $i_fh = open $input_path,  :r; # Throws exception on error
-    my $o_fh = open $output_path, :w; # Throws exception on error
+# Perl 6
+my $i_fh = open $input_path,  :r; # Throws exception on error
+my $o_fh = open $output_path, :w; # Throws exception on error
 
 =head3 C<base>
 =head3 C<parent>
@@ -1188,13 +1188,13 @@ Both C<use base> and C<use parent> have been replaced in Perl 6 by the
 C<is> keyword, in the class declaration.
 
 =for code :lang<perl5>
-    # Perl 5
-    package Cat;
-    use base qw(Animal);
+# Perl 5
+package Cat;
+use base qw(Animal);
 
 =for code :preamble<class Animal {};>
-    # Perl 6
-    class Cat is Animal {};
+# Perl 6
+class Cat is Animal {};
 
 =head3 C<bigint> C<bignum> C<bigrat>
 
@@ -1214,14 +1214,14 @@ initialization expression (evaluated at compile time).
 So, change the C«=>» to C<=>.
 
 =for code :lang<perl5>
-    use constant DEBUG => 0; # Perl 5
+use constant DEBUG => 0; # Perl 5
 =for code :preamble<no strict;>
-    constant DEBUG = 0;      # Perl 6
+constant DEBUG = 0;      # Perl 6
 
 =for code :lang<perl5>
-    use constant pi => 4 * atan2(1, 1); # Perl 5
+use constant pi => 4 * atan2(1, 1); # Perl 5
 =for code
-     pi, e, i; # built-in constants in Perl 6
+ pi, e, i; # built-in constants in Perl 6
 
 =head3 C<encoding>
 
@@ -1295,23 +1295,23 @@ Replaced with the C<++BUG> metasyntactic option.
 Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
 
 =for code :lang<perl5>
-    # Perl 5
-        #!/usr/bin/perl -s
-        if ($xyz) { print "$xyz\n" }
-    ./example.pl -xyz=5
-    5
+# Perl 5
+    #!/usr/bin/perl -s
+    if ($xyz) { print "$xyz\n" }
+./example.pl -xyz=5
+5
 
 =for code
-    # Perl 6
-        sub MAIN( Int :$xyz ) {
-            say $xyz if $xyz.defined;
-        }
+# Perl 6
+    sub MAIN( Int :$xyz ) {
+        say $xyz if $xyz.defined;
+    }
 
 =for code :lang<shell>
-    perl6 example.p6 --xyz=5
-    5
-    perl6 example.p6 -xyz=5
-    5
+perl6 example.p6 --xyz=5
+5
+perl6 example.p6 -xyz=5
+5
 
 =item C<-t>
 
@@ -1334,9 +1334,9 @@ In Perl 5, a common idiom for reading the lines of a text file goes
 something like this:
 
 =for code :lang<perl5>
-    open my $fh, "<", "file" or die "$!";
-    my @lines = <$fh>;
-    close $fh;
+open my $fh, "<", "file" or die "$!";
+my @lines = <$fh>;
+close $fh;
 
 In Perl 6, this has been simplified to
 
@@ -1362,16 +1362,16 @@ e.g.:
 Whereas in Perl 5 you would do:
 
 =for code :lang<perl5>
-    my $arg = 'Hello';
-    my $captured = `echo \Q$arg\E`;
-    my $captured = qx(echo \Q$arg\E);
+my $arg = 'Hello';
+my $captured = `echo \Q$arg\E`;
+my $captured = qx(echo \Q$arg\E);
 
 Or using String::ShellQuote (because C<\Q…\E> is not completely right):
 
 =for code :lang<perl5>
-    my $arg = shell_quote 'Hello';
-    my $captured = `echo $arg`;
-    my $captured = qx(echo $arg);
+my $arg = shell_quote 'Hello';
+my $captured = `echo $arg`;
+my $captured = qx(echo $arg);
 
 In Perl 6, you will probably want to run commands without using the shell:
 
@@ -1400,24 +1400,24 @@ In Perl 5 one of the environment variables to specify extra search paths for
 Perl modules is C<PERL5LIB>.
 
 =for code :lang<shell>
-    $ PERL5LIB="/some/module/lib" perl program.pl
+$ PERL5LIB="/some/module/lib" perl program.pl
 
 In Perl 6 this is similar, one merely needs to change a number!  As you
 probably guessed, you just need to use X<C<PERL6LIB>|PERL6LIB>:
 
 =for code :lang<shell>
-    $ PERL6LIB="/some/module/lib" perl6 program.p6
+$ PERL6LIB="/some/module/lib" perl6 program.p6
 
 In Perl 5 one uses the ':' (colon) as a directory separator for C<PERL5LIB>, but in
 Perl 6 one uses the ',' (comma).  For example:
 
 =for code :lang<shell>
-    $ export PERL5LIB=/module/dir1:/module/dir2;
+$ export PERL5LIB=/module/dir1:/module/dir2;
 
 but
 
 =for code :lang<shell>
-    $ export PERL6LIB=/module/dir1,/module/dir2;
+$ export PERL6LIB=/module/dir1,/module/dir2;
 
 (Perl 6 does not recognize either the C<PERL5LIB> or the older Perl environment
 variable C<PERLLIB>.)
@@ -1426,7 +1426,7 @@ As with Perl 5, if you don't specify C<PERL6LIB>, you need to specify the
 library path within the program via the C<use lib> pragma:
 
 =for code :lang<perl5>
-    use lib '/some/module/lib'
+use lib '/some/module/lib'
 
 Note that C<PERL6LIB> is more of a developer convenience in Perl 6 (as
 opposed to the equivalent usage of C<PERL5LIB> in Perl5) and shouldn't be
@@ -1442,12 +1442,12 @@ Unlike Perl 5, a string containing nothing but zero ('0') is C<True>. As Perl 
 has types in core, that makes more sense. This also means the common pattern:
 
 =for code :lang<perl5>
-    ... if defined $x and length $x; # or just length() in modern perls
+... if defined $x and length $x; # or just length() in modern perls
 
 In Perl 6 becomes a simple
 
 =for code :preamble<no strict;>
-    ... if $x;
+... if $x;
 
 =head2 C<dump>
 
@@ -1470,7 +1470,7 @@ In Perl 5 it is possible to selectively import functions from a given module
 like so:
 
 =for code :lang<perl5>
-    use ModuleName qw{foo bar baz};
+use ModuleName qw{foo bar baz};
 
 In Perl 6 one specifies the functions which are to be exported by using the
 C<is export> role on the relevant subs and I<all> subs with this role are
@@ -1478,20 +1478,20 @@ then exported.  Hence, the following module C<Bar> exports the subs C<foo>
 and C<bar> but not C<baz>:
 
 =begin code :skip-test
-    unit module Bar;
+unit module Bar;
 
-    sub foo($a) is export { say "foo $a" }
-    sub bar($b) is export { say "bar $b" }
-    sub baz($z) { say "baz $z" }
+sub foo($a) is export { say "foo $a" }
+sub bar($b) is export { say "bar $b" }
+sub baz($z) { say "baz $z" }
 =end code
 
 To use this module, simply C<use Bar> and the functions C<foo> and C<bar>
 will be available
 
 =for code :skip-test
-    use Bar;
-    foo(1);    #=> "foo 1"
-    bar(2);    #=> "bar 2"
+use Bar;
+foo(1);    #=> "foo 1"
+bar(2);    #=> "bar 2"
 
 If one tries to use C<baz> an "Undeclared routine" error is raised at compile time.
 
@@ -1502,25 +1502,25 @@ module which specifies the functions to be exported and remove the C<module Bar>
 The module C<Bar> now is merely a file called C<Bar.pm> with the following contents:
 
 =begin code :preamble<no strict;>
-    use v6.c;
+use v6.c;
 
-    sub EXPORT(*@import-list) {
-        my %exportable-subs =
-            '&foo' => &foo,
-            '&bar' => &bar,
-            ;
-        my %subs-to-export;
-        for @import-list -> $import {
-            if grep $sub-name, %exportable-subs.keys {
-                %subs-to-export{$sub-name} = %exportable-subs{$sub-name};
-            }
+sub EXPORT(*@import-list) {
+    my %exportable-subs =
+        '&foo' => &foo,
+        '&bar' => &bar,
+        ;
+    my %subs-to-export;
+    for @import-list -> $import {
+        if grep $sub-name, %exportable-subs.keys {
+            %subs-to-export{$sub-name} = %exportable-subs{$sub-name};
         }
-        return %subs-to-export;
     }
+    return %subs-to-export;
+}
 
-    sub foo($a, $b, $c) { say "foo, $a, $b, $c" }
-    sub bar($a) { say "bar, $a" }
-    sub baz($z) { say "baz, $z" }
+sub foo($a, $b, $c) { say "foo, $a, $b, $c" }
+sub bar($a) { say "bar, $a" }
+sub baz($z) { say "baz, $z" }
 =end code
 
 Note that the subs are no longer explicitly exported via the C<is export>
@@ -1533,31 +1533,31 @@ selectively import the subs made available by the module.
 So, to import only the C<foo> routine, we do the following in the calling code:
 
 =for code :skip-test
-    use Bar <foo>;
-    foo(1);       #=> "foo 1"
+use Bar <foo>;
+foo(1);       #=> "foo 1"
 
 Here we see that even though C<bar> is able to be exported, if we don't
 explicitly import it, it's not available for use.  Hence this causes an
 "Undeclared routine" error at compile time:
 
 =for code :skip-test
-    use Bar <foo>;
-    foo(1);
-    bar(5);       #!> "Undeclared routine: bar used at line 3"
+use Bar <foo>;
+foo(1);
+bar(5);       #!> "Undeclared routine: bar used at line 3"
 
 however, this will work
 
 =for code :skip-test
-    use Bar <foo bar>;
-    foo(1);       #=> "foo 1"
-    bar(5);       #=> "bar 5"
+use Bar <foo bar>;
+foo(1);       #=> "foo 1"
+bar(5);       #=> "bar 5"
 
 Note also that C<baz> remains unimportable even if specified in the C<use>
 statement:
 
 =for code :skip-test
-    use Bar <foo bar baz>;
-    baz(3);       #!> "Undeclared routine: baz used at line 2"
+use Bar <foo bar baz>;
+baz(3);       #!> "Undeclared routine: baz used at line 2"
 
 In order to get this to work, one obviously has to jump through many hoops.
 In the standard use-case where one specifies the functions to be exported
@@ -1577,20 +1577,20 @@ In Perl 6, these tasks are accomplished with the C<.perl> method, which
 every object has.
 
 =begin code :lang<perl5>
-    # Given:
-        my @array_of_hashes = (
-            { NAME => 'apple',   type => 'fruit' },
-            { NAME => 'cabbage', type => 'no, please no' },
-        );
-    # Perl 5
-        use Data::Dumper;
-        $Data::Dumper::Useqq = 1;
-        print Dumper \@array_of_hashes; # Note the backslash.
+# Given:
+    my @array_of_hashes = (
+        { NAME => 'apple',   type => 'fruit' },
+        { NAME => 'cabbage', type => 'no, please no' },
+    );
+# Perl 5
+    use Data::Dumper;
+    $Data::Dumper::Useqq = 1;
+    print Dumper \@array_of_hashes; # Note the backslash.
 =end code
 
 =for code :preamble<no strict;>
-    # Perl 6
-        say @array_of_hashes.perl; # .perl on the array, not on its reference.
+# Perl 6
+    say @array_of_hashes.perl; # .perl on the array, not on its reference.
 
 
 In Perl 5, Data::Dumper has a more complex optional calling convention,
@@ -1600,31 +1600,31 @@ In Perl 6, placing a colon in front of the variable's sigil turns it into a
 Pair, with a key of the var name, and a value of the var value.
 
 =begin code :lang<perl5>
-    # Given:
-        my ( $foo, $bar ) = ( 42, 44 );
-        my @baz = ( 16, 32, 64, 'Hike!' );
-    # Perl 5
-        use Data::Dumper;
-        print Data::Dumper->Dump(
-            [     $foo, $bar, \@baz   ],
-            [ qw(  foo   bar   *baz ) ],
-        );
-    # Output
-        $foo = 42;
-        $bar = 44;
-        @baz = (
-                 16,
-                 32,
-                 64,
-                 'Hike!'
-               );
+# Given:
+    my ( $foo, $bar ) = ( 42, 44 );
+    my @baz = ( 16, 32, 64, 'Hike!' );
+# Perl 5
+    use Data::Dumper;
+    print Data::Dumper->Dump(
+        [     $foo, $bar, \@baz   ],
+        [ qw(  foo   bar   *baz ) ],
+    );
+# Output
+    $foo = 42;
+    $bar = 44;
+    @baz = (
+             16,
+             32,
+             64,
+             'Hike!'
+           );
 =end code
 
 =begin code :preamble<no strict;>
-    # Perl 6
-        say [ :$foo, :$bar, :@baz ].perl;
-    # Output
-        ["foo" => 42, "bar" => 44, "baz" => [16, 32, 64, "Hike!"]]
+# Perl 6
+    say [ :$foo, :$bar, :@baz ].perl;
+# Output
+    ["foo" => 42, "bar" => 44, "baz" => [16, 32, 64, "Hike!"]]
 =end code
 
 =head3 C<Getopt::Long>
@@ -1632,51 +1632,51 @@ Pair, with a key of the var name, and a value of the var value.
 Switch parsing is now done by the parameter list of the C<MAIN> subroutine.
 
 =begin code :lang<perl5>
-    # Perl 5
-        use 5.010;
-        use Getopt::Long;
-        GetOptions(
-            'length=i' => \( my $length = 24       ), # numeric
-            'file=s'   => \( my $data = 'file.dat' ), # string
-            'verbose'  => \( my $verbose           ), # flag
-        ) or die;
-        say $length;
-        say $data;
-        say 'Verbosity ', ($verbose ? 'on' : 'off') if defined $verbose;
-    perl example.pl
-        24
-        file.dat
-    perl example.pl --file=foo --length=42 --verbose
-        42
-        foo
-        Verbosity on
+# Perl 5
+    use 5.010;
+    use Getopt::Long;
+    GetOptions(
+        'length=i' => \( my $length = 24       ), # numeric
+        'file=s'   => \( my $data = 'file.dat' ), # string
+        'verbose'  => \( my $verbose           ), # flag
+    ) or die;
+    say $length;
+    say $data;
+    say 'Verbosity ', ($verbose ? 'on' : 'off') if defined $verbose;
+perl example.pl
+    24
+    file.dat
+perl example.pl --file=foo --length=42 --verbose
+    42
+    foo
+    Verbosity on
 
-    perl example.pl --length=abc
-        Value "abc" invalid for option length (number expected)
-        Died at c.pl line 3.
+perl example.pl --length=abc
+    Value "abc" invalid for option length (number expected)
+    Died at c.pl line 3.
 =end code
 
 =begin code
-    # Perl 6
-        sub MAIN( Int :$length = 24, :file($data) = 'file.dat', Bool :$verbose ) {
-            say $length if $length.defined;
-            say $data   if $data.defined;
-            say 'Verbosity ', ($verbose ?? 'on' !! 'off');
-        }
+# Perl 6
+    sub MAIN( Int :$length = 24, :file($data) = 'file.dat', Bool :$verbose ) {
+        say $length if $length.defined;
+        say $data   if $data.defined;
+        say 'Verbosity ', ($verbose ?? 'on' !! 'off');
+    }
 =end code
 
 =begin code :lang<shell>
-    perl6 example.p6
-        24
-        file.dat
-        Verbosity off
-    perl6 example.p6 --file=foo --length=42 --verbose
-        42
-        foo
-        Verbosity on
-    perl6 example.p6 --length=abc
-        Usage:
-          c.p6 [--length=<Int>] [--file=<Any>] [--verbose]
+perl6 example.p6
+    24
+    file.dat
+    Verbosity off
+perl6 example.p6 --file=foo --length=42 --verbose
+    42
+    foo
+    Verbosity on
+perl6 example.p6 --length=abc
+    Usage:
+      c.p6 [--length=<Int>] [--file=<Any>] [--verbose]
 =end code
 
 Note that Perl 6 auto-generates a full usage message on error in

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -56,7 +56,7 @@ You can, of course, use an already opened filehandle. Here, using the file
 handle C<$fh>, is an example, using the method syntax for the file test:
 
 =for code :preamble<my $fh;>
-    $fh.r
+$fh.r
 
 Most of the former filetests have colon equivalents for use with smart match:
 
@@ -76,9 +76,9 @@ All of these tests can be used as methods (without the colon).
 Three tests, however, I<only> have method equivalents:
 
 =for code :preamble<my $fh;>
-    $fh.modified; # -M $fh
-    $fh.accessed; # -A $fh
-    $fh.changed;  # -C $fh
+$fh.modified; # -M $fh
+$fh.accessed; # -A $fh
+$fh.changed;  # -C $fh
 
 The remaining filetests in Perl 5 do not appear to be implemented
 in Perl 6.
@@ -425,8 +425,8 @@ families.)
 In Perl 6, this is not a function, but an adverb:
 
 =for code :preamble<no strict;>
-    %hash{$key}:exists;
-    @array[$i]:exists;
+%hash{$key}:exists;
+@array[$i]:exists;
 
 =head2 exit
 
@@ -1067,9 +1067,9 @@ L<append method|/type/Array#method_append>.
 These survive the transition to Perl 6. Some notes:
 
 =for code
-    q/.../;  # is still equivalent to using single quotes.
-    qq/.../; # is still equivalent to using double quotes.
-    qw/.../; # is more commonly rendered as C<< <...> >> in Perl 6.
+q/.../;  # is still equivalent to using single quotes.
+qq/.../; # is still equivalent to using double quotes.
+qw/.../; # is more commonly rendered as C<< <...> >> in Perl 6.
 
 There are some added quoting constructs and equivalents, as explained at
 L<quoting|/language/quoting>.

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -250,12 +250,12 @@ for dumping, whose output is similar to L<perl>, but with more information.
 Examples:
 
 =begin code :ok-test<dd>
-    my $foo = %( foo => 'bar' );
-    say $foo.perl;   # OUTPUT: «${:foo("bar")}␤»
-    say $foo;        # OUTPUT: «{foo => bar}␤»
+my $foo = %( foo => 'bar' );
+say $foo.perl;   # OUTPUT: «${:foo("bar")}␤»
+say $foo;        # OUTPUT: «{foo => bar}␤»
 
-    # non-standard routine available in rakudo implementation:
-    dd $foo;         # OUTPUT: «Hash $foo = ${:foo("bar")}␤»
+# non-standard routine available in rakudo implementation:
+dd $foo;         # OUTPUT: «Hash $foo = ${:foo("bar")}␤»
 =end code
 
 There are also L<several ecosystem modules|https://modules.perl6.org/s/dump>
@@ -281,11 +281,11 @@ otherwise it's runtime.
 Example:
 
 =for code
-    say 1/0;   # Attempt to divide 1 by zero using div
+say 1/0;   # Attempt to divide 1 by zero using div
 
 =begin code :skip-test<compile time error>
-    sub foo( Int $a, Int $b ) {...}
-    foo(1)     # ===SORRY!=== Error while compiling ...
+sub foo( Int $a, Int $b ) {...}
+foo(1)     # ===SORRY!=== Error while compiling ...
 =end code
 
 =head2 What is C<(Any)>?

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -96,11 +96,11 @@ L<Complex>). This allows you to use such literals in places where
 expressions are not allowed, for example, as literals in signatures:
 
 =for code :skip-test
-    # Wrong, can't use an operator there:
-    multi foo (1/3) { say "It's one third!" }
+# Wrong, can't use an operator there:
+multi foo (1/3) { say "It's one third!" }
 =for code
-    # Right, a Rat literal:
-    multi foo (<1/3>) { say "It's one third!" }
+# Right, a Rat literal:
+multi foo (<1/3>) { say "It's one third!" }
 
 If you I<do> want an allomorph and not a literal L<Numeric>,
 then include whitespace around angle brackets:
@@ -881,10 +881,10 @@ a L<Seq>. The following code contains a bug; keeping reification in mind, try to
 spot it:
 
 =for code
-    my $fh = "/tmp/bar".IO.open;
-    my $lines = $fh.lines;
-    close $fh;
-    say $lines[0];
+my $fh = "/tmp/bar".IO.open;
+my $lines = $fh.lines;
+close $fh;
+say $lines[0];
 
 We open a L<file handle|/type/IO::Handle>, then assign return of
 L«C<.lines>|/type/IO::Handle#method_lines» to a L<Scalar> variable, so the
@@ -900,19 +900,19 @@ a C<@>-sigiled variable or call L«C<.elems>|/routine/elems» on C<$lines> befor
 closing the handle:
 
 =for code
-    my $fh = "/tmp/bar".IO.open;
-    my @lines = $fh.lines;
-    close $fh;
-    say @lines[0]; # no problem!
+my $fh = "/tmp/bar".IO.open;
+my @lines = $fh.lines;
+close $fh;
+say @lines[0]; # no problem!
 
 Also good:
 
 =for code
-    my $fh = "/tmp/bar".IO.open;
-    my $lines = $fh.lines;
-    say "Read $lines.elems() lines"; #reifying before closing handle
-    close $fh;
-    say $lines[0]; # no problem!
+my $fh = "/tmp/bar".IO.open;
+my $lines = $fh.lines;
+say "Read $lines.elems() lines"; #reifying before closing handle
+close $fh;
+say $lines[0]; # no problem!
 
 =head1 Repository
 X<|Repository>

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -24,8 +24,8 @@ with parentheses, so:
 There is one exception, empty lists are created with just parenthesis:
 
 =for code :skip-test
-    ();          # This is an empty List
-    (,);         # This is a syntax error
+();          # This is an empty List
+(,);         # This is a syntax error
 
 Note that hanging commas are just fine as long as the beginning and
 end of a list are clear, so feel free to use them for easy code editing.

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -940,12 +940,12 @@ In most cases, this behaves identically to the postfix mutator, but the
 precedence is lower:
 
 =for code :skip-test
-    my $a = -5
-    say ++$a.=abs
-    # OUTPUT: «6␤»
-    say ++$a .= abs
-    # OUTPUT: «Cannot modify an immutable Int␤
-    #           in block <unit> at <tmp> line 1␤␤»
+my $a = -5
+say ++$a.=abs
+# OUTPUT: «6␤»
+say ++$a .= abs
+# OUTPUT: «Cannot modify an immutable Int␤
+#           in block <unit> at <tmp> line 1␤␤»
 
 =head2 infix C«.»
 
@@ -2406,16 +2406,16 @@ item. In other words, L<notandthen> is a means to act when items aren't
 defined, whereas L<orelse> is a means to obtain the first defined item:
 
 =begin code
-    sub all-sensors-down     { [notandthen] |@_, True             }
-    sub first-working-sensor { [orelse]     |@_, 'default sensor' }
+sub all-sensors-down     { [notandthen] |@_, True             }
+sub first-working-sensor { [orelse]     |@_, 'default sensor' }
 
-    all-sensors-down Nil, Nil, Nil
-      and say 'OMG! All sensors are down!'; # OUTPUT:«OMG! All sensors are down!␤»
-    say first-working-sensor Nil, Nil, Nil; # OUTPUT:«default sensor␤»
+all-sensors-down Nil, Nil, Nil
+  and say 'OMG! All sensors are down!'; # OUTPUT:«OMG! All sensors are down!␤»
+say first-working-sensor Nil, Nil, Nil; # OUTPUT:«default sensor␤»
 
-    all-sensors-down Nil, 42, Nil
-      and say 'OMG! All sensors are down!'; # No output
-    say first-working-sensor Nil, 42, Nil;  # OUTPUT:«42␤»
+all-sensors-down Nil, 42, Nil
+  and say 'OMG! All sensors are down!'; # No output
+say first-working-sensor Nil, 42, Nil;  # OUTPUT:«42␤»
 =end code
 
 The C<andthen> operator is a close relative of
@@ -2424,10 +2424,10 @@ compile C<without> to C<notandthen>, meaning these two lines have equivalent
 behaviour:
 
 =begin code
-    sub good-things { fail }
+sub good-things { fail }
 
-    'boo'.say without good-things;
-    good-things() notandthen 'boo'.say;
+'boo'.say without good-things;
+good-things() notandthen 'boo'.say;
 =end code
 
 =head1 Loose OR Precedence

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -20,31 +20,31 @@ them respond to various control exceptions and exit values.
 Here is a summary:
 
 =begin code :skip-test
-      BEGIN {...} #  * at compile time, ASAP, only ever runs once
-      CHECK {...} #  * at compile time, ALAP, only ever runs once
-       INIT {...} #  * at run time, ASAP, only ever runs once
-        END {...} #  at run time, ALAP, only ever runs once
+  BEGIN {...} #  * at compile time, ASAP, only ever runs once
+  CHECK {...} #  * at compile time, ALAP, only ever runs once
+   INIT {...} #  * at run time, ASAP, only ever runs once
+    END {...} #  at run time, ALAP, only ever runs once
 
-      ENTER {...} #  * at every block entry time, repeats on loop blocks.
-      LEAVE {...} #  at every block exit time (even stack unwinds from exceptions)
-       KEEP {...} #  at every successful block exit, part of LEAVE queue
-       UNDO {...} #  at every unsuccessful block exit, part of LEAVE queue
+  ENTER {...} #  * at every block entry time, repeats on loop blocks.
+  LEAVE {...} #  at every block exit time (even stack unwinds from exceptions)
+   KEEP {...} #  at every successful block exit, part of LEAVE queue
+   UNDO {...} #  at every unsuccessful block exit, part of LEAVE queue
 
-      FIRST {...} #  at loop initialization time, before any ENTER
-       NEXT {...} #  at loop continuation time, before any LEAVE
-       LAST {...} #  at loop termination time, after any LEAVE
+  FIRST {...} #  at loop initialization time, before any ENTER
+   NEXT {...} #  at loop continuation time, before any LEAVE
+   LAST {...} #  at loop termination time, after any LEAVE
 
-        PRE {...} #  assert precondition at every block entry, before ENTER
-       POST {...} #  assert postcondition at every block exit, after LEAVE
+    PRE {...} #  assert precondition at every block entry, before ENTER
+   POST {...} #  assert postcondition at every block exit, after LEAVE
 
-      CATCH {...} #  catch exceptions, before LEAVE
-    CONTROL {...} #  catch control exceptions, before LEAVE
+  CATCH {...} #  catch exceptions, before LEAVE
+CONTROL {...} #  catch control exceptions, before LEAVE
 
-       LAST {...} #  supply tapped by whenever-block is done, runs very last
-       QUIT {...} #  catch async exceptions within a whenever-block, runs very last
+   LAST {...} #  supply tapped by whenever-block is done, runs very last
+   QUIT {...} #  catch async exceptions within a whenever-block, runs very last
 
-    COMPOSE {...} #  when a role is composed into a class
-    CLOSE   {...} #  appears in a supply block, called when the supply is closed
+COMPOSE {...} #  when a role is composed into a class
+CLOSE   {...} #  appears in a supply block, called when the supply is closed
 =end code
 
 Phasers marked with a C<*> have a run-time value, and if evaluated earlier than

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -123,7 +123,7 @@ C<strict> is the default behavior, and requires that you declare variables
 before using them. You can relax this restriction with C<no>.
 
 =for code
-    no strict; $x = 42; # OK
+no strict; $x = 42; # OK
 
 =item X<B<trace>|trace>
 

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -20,12 +20,12 @@ optional.  A return is added to the end of the line.
 Python 2
 
 =for code :lang<python>
-    print "Hello, world!"
+print "Hello, world!"
 
 Python 3
 
 =for code :lang<python>
-    print("Hello, world!")
+print("Hello, world!")
 
 Perl 6
 
@@ -70,10 +70,10 @@ is a closing curly brace followed by a newline.
 Python
 
 =for code :lang<python>
-    print 1 + 2 + \
-        3 + 4
-    print ( 1 +
-        2 )
+print 1 + 2 + \
+    3 + 4
+print ( 1 +
+    2 )
 
 Perl 6
 
@@ -89,10 +89,10 @@ uses curly braces.
 Python
 
 =for code :lang<python>
-    if 1 == 2:
-        print "Wait, what?"
-    else:
-        print "1 is not 2."
+if 1 == 2:
+    print "Wait, what?"
+else:
+    print "1 is not 2."
 
 Perl 6
 
@@ -110,8 +110,8 @@ conditionals, as shown above.
 In Python, variables are declared and initialized at the same time:
 
 =for code :lang<python>
-    foo = 12
-    bar = 19
+foo = 12
+bar = 19
 
 In Perl 6, C<my> declares a lexical variable.  A variable can be
 initialized with C<=>.  i.e. these can be written as two statements or one.
@@ -129,14 +129,14 @@ Immutable variables can be sigil-less, if they are declared with a C<\>.
 Python
 
 =begin code :lang<python>
-    s = 10
-    l = [1, 2, 3]
-    d = { a : 12, b : 99 }
+s = 10
+l = [1, 2, 3]
+d = { a : 12, b : 99 }
 
-    print s
-    print l[2]
-    print d['a']
-    # 10, 2, 12
+print s
+print l[2]
+print d['a']
+# 10, 2, 12
 =end code
 
 Perl 6
@@ -164,36 +164,36 @@ In Perl 6, every block creates a lexical scope.
 Python
 
 =for code :lang<python>
-    if True:
-        x = 10
-    print x
-    # x is now 10
+if True:
+    x = 10
+print x
+# x is now 10
 
 Perl 6
 
 =for code :skip-test<compile time error>
-    if True {
-        my $x = 10
-    }
-    say $x
-    # error, $x is not declared in this scope
+if True {
+    my $x = 10
+}
+say $x
+# error, $x is not declared in this scope
 
 =for code
-    my $x;
-    if True {
-        $x = 10
-    }
-    say $x
-    # ok, x is 10
+my $x;
+if True {
+    $x = 10
+}
+say $x
+# ok, x is 10
 
 Python
 
 =for code :lang<python>
-   x = 10
-   for x in 1, 2, 3:
-       pass
-   print x
-   # x is 3
+x = 10
+for x in 1, 2, 3:
+   pass
+print x
+# x is 3
 
 Perl 6
 
@@ -209,12 +209,12 @@ Lambdas in Python can be written as blocks or pointy blocks in Perl 6.
 Python
 
 =for code :lang<python>
-    l = lambda i: i + 12
+l = lambda i: i + 12
 
 Perl 6
 
 =for code :preamble<my $i>
-    my $l = -> $i { $i + 12 }
+my $l = -> $i { $i + 12 }
 
 Another Perl 6 idiom for constructing lambdas is the Whatever star, C<*>.
 
@@ -233,12 +233,12 @@ Another example (from the Python L<FAQ|https://docs.python.org/3/faq/programming
 Python
 
 =for code :lang<python>
-    squares = []
-    for x in range(5):
-        squares.append(lambda: x ** 2)
-    print squares[2]()
-    print squares[4]()
-    # both 16 since there is only one x
+squares = []
+for x in range(5):
+    squares.append(lambda: x ** 2)
+print squares[2]()
+print squares[4]()
+# both 16 since there is only one x
 
 Perl 6
 
@@ -268,14 +268,14 @@ or symbol that can be used in Perl 6 has an ASCII equivalent.
 Python has C<for> loops and C<while> loops:
 
 =for code :lang<python>
-    for i in 1, 2:
-        print i
-    j = 1
-    while j < 3:
-        print j
-        j += 1
+for i in 1, 2:
+    print i
+j = 1
+while j < 3:
+    print j
+    j += 1
 
-    # 1, 2, 1, 2
+# 1, 2, 1, 2
 
 Perl 6 also has C<for> loops and C<while> loops:
 
@@ -298,12 +298,12 @@ in Perl 6.
 Python
 
 =for code :lang<python>
-    for i in range(10):
-        if i == 3:
-            continue
-        if i == 5:
-            break
-        print i
+for i in range(10):
+    if i == 3:
+        continue
+    if i == 5:
+        break
+    print i
 
 Perl 6
 
@@ -323,12 +323,12 @@ in Perl 6.  These both print 1, 2, 3.
 Python
 
 =begin code :lang<python>
-    def count():
-        for i in 1, 2, 3:
-            yield i
+def count():
+    for i in 1, 2, 3:
+        yield i
 
-    for c in count():
-        print c
+for c in count():
+    print c
 =end code
 
 Perl 6
@@ -352,28 +352,28 @@ Declaring a function (subroutine) with C<def> in Python is accomplished
 with C<sub> in Perl 6.
 
 =begin code :lang<python>
-    def add(a, b):
-        return a + b
+def add(a, b):
+    return a + b
 
-    sub add(\a, \b) {
-        return a + b
-    }
+sub add(\a, \b) {
+    return a + b
+}
 =end code
 
 The C<return> is optional; the value of the last expression is used as
 the return value:
 
 =begin code
-    sub add(\a, \b) {
-        a + b
-    }
+sub add(\a, \b) {
+    a + b
+}
 =end code
 
 =begin code
-    # using variables with sigils
-    sub add($a, $b) {
-        $a + $b
-    }
+# using variables with sigils
+sub add($a, $b) {
+    $a + $b
+}
 =end code
 
 Python 2 functions can be called with positional arguments
@@ -385,11 +385,11 @@ by the signature of the routine.
 Python
 
 =begin code :lang<python>
-    def speak(word, times):
-        for i in range(times):
-            print word
-    speak('hi', 2)
-    speak(word='hi', times=2)
+def speak(word, times):
+    for i in range(times):
+        print word
+speak('hi', 2)
+speak(word='hi', times=2)
 =end code
 
 Perl 6
@@ -437,7 +437,7 @@ a pointy block.
 Python
 
 =for code :lang<python>
-    square = lambda x: x ** 2
+square = lambda x: x ** 2
 
 Perl 6
 
@@ -459,7 +459,7 @@ Postfix statement modifiers and blocks can be combined to make list comprehensio
 Python
 
 =for code :lang<python>
-    [ i * 2 for i in 3, 9 ]
+[ i * 2 for i in 3, 9 ]
 
 Perl 6
 
@@ -471,7 +471,7 @@ Conditionals can be applied, but the C<if> comes first,
 unlike in Python where the if comes second.
 
 =for code :lang<python>
-    [ x * 2 for x in 1, 2, 3 if x > 1 ]
+[ x * 2 for x in 1, 2, 3 if x > 1 ]
 
 vs
 
@@ -481,7 +481,7 @@ For nested loops, the cross product operator C<X>
 will help:
 
 =for code :lang<python>
-    [ i + j for i in 3,9 for j in 2,10 ]
+[ i + j for i in 3,9 for j in 2,10 ]
 
 becomes either of these:
 
@@ -499,9 +499,9 @@ First, "instance variables", aka attributes in Perl 6:
 Python:
 
 =for code :lang<python>
-    class Dog:
-        def __init__(self, name):
-            self.name = name
+class Dog:
+    def __init__(self, name):
+        self.name = name
 
 Perl 6:
 
@@ -515,10 +515,10 @@ and use the method C<new>.
 Python
 
 =for code :lang<python>
-    d = Dog('Fido')
-    e = Dog('Buddy')
-    print d.name
-    print e.name
+d = Dog('Fido')
+e = Dog('Buddy')
+print d.name
+print e.name
 
 Perl 6
 
@@ -534,16 +534,16 @@ is to just declare a lexical variable and a method for accessing it.
 Python:
 
 =for code :lang<python>
-    class Dog:
-        kind = 'canine'                # class attribute
-        def __init__(self, name):
-            self.name = name           # instance attribute
-    d = Dog('Fido')
-    e = Dog('Buddy')
-    print d.kind
-    print e.kind
-    print d.name
-    print e.name
+class Dog:
+    kind = 'canine'                # class attribute
+    def __init__(self, name):
+        self.name = name           # instance attribute
+d = Dog('Fido')
+e = Dog('Buddy')
+print d.kind
+print e.kind
+print d.name
+print e.name
 
 Perl 6:
 
@@ -565,11 +565,11 @@ To mutate attributes, in Perl 6 you"ll want to use C<is rw>:
 Python:
 
 =for code :lang<python>
-    class Dog:
-        def __init__(self, name):
-            self.name = name
-    d = Dog()
-    d.name = 'rover'
+class Dog:
+    def __init__(self, name):
+        self.name = name
+d = Dog()
+d.name = 'rover'
 
 Perl 6:
 
@@ -584,15 +584,15 @@ Inheritance is done using C<is>:
 Python
 
 =begin code :lang<python>
-    class Animal:
-        def jump(self):
-            print ("I am jumping")
+class Animal:
+    def jump(self):
+        print ("I am jumping")
 
-    class Dog(Animal):
-        pass
+class Dog(Animal):
+    pass
 
-    d = Dog()
-    d.jump()
+d = Dog()
+d.jump()
 =end code
 
 Perl 6
@@ -614,8 +614,8 @@ Multiple inheritance is possible by using C<is> multiple times, or with C<also>.
 Python
 
 =for code :lang<python>
-    class Dog(Animal, Friend, Pet):
-        pass
+class Dog(Animal, Friend, Pet):
+    pass
 
 Perl 6
 
@@ -643,17 +643,17 @@ in another one.  In Perl 6, this is done with C<wrap>.
 Python
 
 =begin code :lang<python>
-    def greeter(f):
-        def new():
-            print 'hello'
-            f()
-        return new
+def greeter(f):
+    def new():
+        print 'hello'
+        f()
+    return new
 
-    @greeter
-    def world():
-        print 'world'
+@greeter
+def world():
+    print 'world'
 
-    world();
+world();
 =end code
 
 Perl 6
@@ -696,14 +696,14 @@ Here's a python context manager that prints the strings
 'hello', 'world', and 'bye':
 
 =begin code :lang<python>
-    class hello:
-        def __exit__(self, type, value, traceback):
-            print 'bye'
-        def __enter__(self):
-            print 'hello'
+class hello:
+    def __exit__(self, type, value, traceback):
+        print 'bye'
+    def __enter__(self):
+        print 'hello'
 
-    with hello():
-        print 'world'
+with hello():
+    print 'world'
 =end code
 
 For enter and exit events, passing a block as

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -24,9 +24,9 @@ by leaving an operator dangling at the end of a line to ensure that the parsing
 will continue:
 
 =for code :lang<ruby>
-    foo +     # In Ruby a trailing operator means parsing should continue
-      bar +
-      baz
+foo +     # In Ruby a trailing operator means parsing should continue
+  bar +
+  baz
 
 In Perl 6 you must explicitly terminate statements with a C<;>, which allows
 for better feedback and more flexibility in breaking up long lines. Two
@@ -48,11 +48,11 @@ Ruby allows a surprising amount of flexibility in the use of whitespace,
 even with strict mode and warnings turned on:
 
 =for code :lang<ruby>
-    # unidiomatic but valid Ruby
-    puts"Hello "+
-    (people [ i]
-        . name
-        ) . upcase+"!"if$greeted[i]<1
+# unidiomatic but valid Ruby
+puts"Hello "+
+(people [ i]
+    . name
+    ) . upcase+"!"if$greeted[i]<1
 
 Perl 6 also endorses programmer freedom and creativity, but balanced syntactic
 flexibility against its design goal of having a consistent, deterministic,
@@ -73,8 +73,8 @@ coding styles:
 I<No space allowed before the opening parenthesis of an argument list.>
 
 =begin code :skip-test
-    foo (3, 4, 1); # Not right in Ruby or Perl 6 (in Perl 6 this would
-                   # try to pass a single argument of type List to foo)
+foo (3, 4, 1); # Not right in Ruby or Perl 6 (in Perl 6 this would
+               # try to pass a single argument of type List to foo)
 =end code
 
     foo(3, 4, 1);  # Ruby and Perl 6
@@ -87,21 +87,21 @@ I<Space is B<required> immediately after keywords>
 =end item
 
 =begin code :lang<ruby>
-    if(a < 0); ...; end         # OK in Ruby
+if(a < 0); ...; end         # OK in Ruby
 =end code
 =begin code
-    my $a; ...;
-    if ($a < 0) { ... }         # Perl 6
-    if $a < 0 { ... }           # Perl 6, more idiomatic
+my $a; ...;
+if ($a < 0) { ... }         # Perl 6
+if $a < 0 { ... }           # Perl 6, more idiomatic
 =end code
 
 =begin code :lang<ruby>
-    while(x > 5); ...; end      # OK in Ruby
+while(x > 5); ...; end      # OK in Ruby
 =end code
 =begin code
-    my $x; ...;
-    while ($x > 5) { ... }      # Perl 6
-    while $x > 5 { ... }        # Perl 6, more idiomatic
+my $x; ...;
+while ($x > 5) { ... }      # Perl 6
+while $x > 5 { ... }        # Perl 6, more idiomatic
 =end code
 
 
@@ -127,18 +127,18 @@ conflict with an existing postfix/postcircumfix operator.>
 Method call syntax uses a dot just like Ruby:
 
 =for code :lang<ruby>
-    person.name    # Ruby
+person.name    # Ruby
 =for code
-    my $person; ...;
-    $person.name   # Perl 6
+my $person; ...;
+$person.name   # Perl 6
 
 To call a method whose name is not known until runtime:
 
 =for code :lang<ruby>
-    object.send(methodname, args);  # Ruby
+object.send(methodname, args);  # Ruby
 =for code
-    my $object; my Str $methodname; my @args; ...;
-    $object."$methodname"(@args);   # Perl 6
+my $object; my Str $methodname; my @args; ...;
+$object."$methodname"(@args);   # Perl 6
 
 If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
 a C<Method> object, rather than the simple string name of the method.
@@ -170,13 +170,13 @@ Every place you see C<{ ... }> is a scope, including the body of a conditional
 or loop. The commonly used scope declarations:
 
 =for code :lang<ruby>
-    foo = 7        # Ruby, variable scope is defined by first assignment and
-                   # extends to the end of the current block
+foo = 7        # Ruby, variable scope is defined by first assignment and
+               # extends to the end of the current block
 
 =for code
-    my  $foo = 7;   # Perl 6, lexical scoped to the current block
-    our $foo = 7;   # Perl 6, package scoped
-    has $!foo = 7;  # Perl 6, instance scoped (attribute)
+my  $foo = 7;   # Perl 6, lexical scoped to the current block
+our $foo = 7;   # Perl 6, package scoped
+has $!foo = 7;  # Perl 6, instance scoped (attribute)
 
 =head3 C<$> Scalar
 
@@ -260,28 +260,28 @@ as a "noun" instead of a "verb". Variables using the C<&> sigil can only
 contain things that do the C<Callable> role.
 
 =begin code :lang<ruby>
-    add = -> n, m { n + m } # Ruby lambda for an addition function
-    add.(2, 3)              # => 5, Ruby invocation of a lambda
-    add.call(2, 3)          # => 5, Ruby invocation of a lambda
+add = -> n, m { n + m } # Ruby lambda for an addition function
+add.(2, 3)              # => 5, Ruby invocation of a lambda
+add.call(2, 3)          # => 5, Ruby invocation of a lambda
 =end code
 
 =begin code
-    my &add = -> $n, $m { $n + $m }; # Perl 6 addition function
-    &add(2, 3);                      # => 5, you can keep the sigil
-    add(2, 3);                       # => 5, and it works without it
+my &add = -> $n, $m { $n + $m }; # Perl 6 addition function
+&add(2, 3);                      # => 5, you can keep the sigil
+add(2, 3);                       # => 5, and it works without it
 =end code
 
 =for code :lang<ruby>
-    foo_method = &foo;     # Ruby
+foo_method = &foo;     # Ruby
 =for code
-    sub foo { ... };
-    my &foo_method = &foo; # Perl 6
+sub foo { ... };
+my &foo_method = &foo; # Perl 6
 
 =for code :lang<ruby>
-    some_func(&say) # Ruby pass a function reference
+some_func(&say) # Ruby pass a function reference
 =for code
-    sub some_func { ... };
-    some_func(&say) # Perl 6 passes function references the same way
+sub some_func { ... };
+some_func(&say) # Perl 6 passes function references the same way
 
 Often in Ruby we pass a block as the last parameter, which is especially used
 for DSLs. This can be an implicit parameter called by C<yield>, or an explicit
@@ -290,33 +290,33 @@ and called by the variable name (instead of yield), and there are a variety of
 ways of invoking the function.
 
 =begin code :lang<ruby>
-    # Ruby, declare a method and call the implicit block argument
-    def f
-      yield 2
-    end
+# Ruby, declare a method and call the implicit block argument
+def f
+  yield 2
+end
 
-    # Ruby, invoke f, pass it a block with 1 argument
-    f do |n|
-      puts "Hi #{n}"
-    end
+# Ruby, invoke f, pass it a block with 1 argument
+f do |n|
+  puts "Hi #{n}"
+end
 =end code
 
 =begin code
-    # Perl 6, declare a method with an explicit block argument
-    sub f(&g:($)) {
-      g(2)
-    }
+# Perl 6, declare a method with an explicit block argument
+sub f(&g:($)) {
+  g(2)
+}
 
-    # Perl 6, invoke f, pass it a block with 1 argument
-    # There are several other ways to do this
-    f(-> $n { say "Hi {$n}" }); # Explicit argument
-    f -> $n { say "Hi {$n}" };  # Explicit argument, no parenthesis
+# Perl 6, invoke f, pass it a block with 1 argument
+# There are several other ways to do this
+f(-> $n { say "Hi {$n}" }); # Explicit argument
+f -> $n { say "Hi {$n}" };  # Explicit argument, no parenthesis
 
-    # Additionally, if 'f' is a method on instance 'obj' you can use C<:>
-    # instead of parenthesis
-    my $obj; ...;
-    $obj.f(-> $n { say "Hi {$n}" });  # Explicit argument
-    $obj.f: -> $n { say "Hi {$n}" };  # Explicit argument, no parenthesis
+# Additionally, if 'f' is a method on instance 'obj' you can use C<:>
+# instead of parenthesis
+my $obj; ...;
+$obj.f(-> $n { say "Hi {$n}" });  # Explicit argument
+$obj.f: -> $n { say "Hi {$n}" };  # Explicit argument, no parenthesis
 =end code
 
 =head3 C<*> Slurpy params / argument expansion
@@ -325,21 +325,21 @@ In Ruby you can declare an argument to slurp the remainder of the passed
 parameters into an array using a C<*> prefix. It works the same way in Perl 6:
 
 =for code :lang<ruby>
-    def foo(*args); puts "I got #{args.length} args!"; end # Ruby
+def foo(*args); puts "I got #{args.length} args!"; end # Ruby
 =for code
-    sub foo(*@args) { say "I got #{@args.elems} args!" }   # Perl 6
+sub foo(*@args) { say "I got #{@args.elems} args!" }   # Perl 6
 
 You might want to expand an array into a set of arguments. In Perl 6 this is
 also done using C<*>:
 
 =for code :lang<ruby>
-    args = %w(a b c)         # Ruby
-    foo(*args)
+args = %w(a b c)         # Ruby
+foo(*args)
 
 =for code
-    sub foo($q, $r, $s) { ... };
-    my @args = <a b c>;       # Perl 6
-    foo(@*args);
+sub foo($q, $r, $s) { ... };
+my @args = <a b c>;       # Perl 6
+foo(@*args);
 
 Perl 6 has many more advanced ways of passing parameters and receiving
 arguments, see L<Signatures|/language/functions#Signatures> and
@@ -351,15 +351,15 @@ Perl 6 additionally uses "twigils", which are further indicators about the
 variable and go between the sigil and the rest of the variable name. Examples:
 
 =begin code :skip-test
-    $foo     # Scalar with no twigil
-    $!foo    # Private instance variable
-    $.foo    # Instance variable accessor
-    $*foo    # Dynamically scoped variable
-    $^foo    # A positional (placeholder) parameter to a block
-    $:foo    # A named parameter
-    $=foo    # POD (documentation) variables
-    $?FILE   # Current source filename. The ? twigil indicates a compile-time value
-    $~foo    # Sublanguage seen by parser, uncommon
+$foo     # Scalar with no twigil
+$!foo    # Private instance variable
+$.foo    # Instance variable accessor
+$*foo    # Dynamically scoped variable
+$^foo    # A positional (placeholder) parameter to a block
+$:foo    # A named parameter
+$=foo    # POD (documentation) variables
+$?FILE   # Current source filename. The ? twigil indicates a compile-time value
+$~foo    # Sublanguage seen by parser, uncommon
 =end code
 
 Though each of these examples use the C<$> sigil, most could use C<@>
@@ -371,22 +371,22 @@ Perl 6 generally uses strings in the places where Ruby uses symbols. A primary
 example of this is in hash keys.
 
 =for code :lang<ruby>
-    address[:joe][:street] # Typical Ruby nested hash with symbol keys
+address[:joe][:street] # Typical Ruby nested hash with symbol keys
 =for code
-    my %address; ...;
-    %address<joe><street>  # Typical Perl 6 nested hash with string keys
+my %address; ...;
+%address<joe><street>  # Typical Perl 6 nested hash with string keys
 
 Perl 6 has I<colon-pair> syntax, which can sometimes look like Ruby symbols.
 
 =for code :lang<ruby>
-    :age            # Ruby symbol
+:age            # Ruby symbol
 
 =begin code
-    # All of these are equivalent for Perl 6
-    :age            ;# Perl 6 pair with implicit True value
-    :age(True)      ;# Perl 6 pair with explicit True value
-    age => True     ;# Perl 6 pair using arrow notation
-    "age" => True   ;# Perl 6 pair using arrow notation and explicit quotes
+# All of these are equivalent for Perl 6
+:age            ;# Perl 6 pair with implicit True value
+:age(True)      ;# Perl 6 pair with explicit True value
+age => True     ;# Perl 6 pair using arrow notation
+"age" => True   ;# Perl 6 pair using arrow notation and explicit quotes
 =end code
 
 You could probably get away with using a colon-pair without an explicit value
@@ -451,10 +451,10 @@ some examples:
 An equivalent in Ruby would be
 
 =for code :lang<ruby>
-    $foo = 'bar';
-    puts "match 1!" if /bar/ === $foo;       # Regex match
-    puts "match 2!" if $foo === "bar";       # String match
-    puts "match 3!" if String === $foo;      # Class match
+$foo = 'bar';
+puts "match 1!" if /bar/ === $foo;       # Regex match
+puts "match 2!" if $foo === "bar";       # String match
+puts "match 3!" if String === $foo;      # Class match
 
 Please note that, in this case, C<===> is not symmetric; in the first and last case, the variable has to be in the right hand side. There is no equivalent to the signature class in Ruby, either.
 
@@ -467,15 +467,15 @@ In Perl 6, these single-character ops have been removed, and replaced by
 two-character ops which coerce their arguments to the needed context.
 
 =begin code :skip-test
-    # Infix ops (two arguments; one on each side of the op)
-    +&  +|  +^  And Or Xor: Numeric
-    ~&  ~|  ~^  And Or Xor: String
-    ?&  ?|  ?^  And Or Xor: Boolean
+# Infix ops (two arguments; one on each side of the op)
++&  +|  +^  And Or Xor: Numeric
+~&  ~|  ~^  And Or Xor: String
+?&  ?|  ?^  And Or Xor: Boolean
 
-    # Prefix ops (one argument, after the op)
-    +^  Not: Numeric
-    ~^  Not: String
-    ?^  Not: Boolean (same as the ! op)
+# Prefix ops (one argument, after the op)
++^  Not: Numeric
+~^  Not: String
+?^  Not: Boolean (same as the ! op)
 =end code
 
 =head2 C<&.> Conditional chaining operator
@@ -488,9 +488,9 @@ invocation returns nil. In Perl 6 use C<.?> for the same purpose.
 Replaced by C«+<» and C«+>» .
 
 =for code :lang<ruby>
-    puts 42 << 3  # Ruby
+puts 42 << 3  # Ruby
 =for code
-    say  42 +< 3; # Perl 6
+say  42 +< 3; # Perl 6
 
 Note that Ruby often uses the C«<<» operator as the "shovel operator", which is
 similar to C<.push>. This usage isn't common in Perl 6.
@@ -507,9 +507,9 @@ principle, but works the same in many situations.
 If you are using C«=>» in a hash literal, then the usage is very similar:
 
 =for code :lang<ruby>
-    hash = { "AAA" => 1, "BBB" => 2 }  # Ruby, though symbol keys are more common
+hash = { "AAA" => 1, "BBB" => 2 }  # Ruby, though symbol keys are more common
 =for code
-    my %hash = ( AAA => 1, BBB => 2 ); # Perl 6, uses ()'s though {} usually work
+my %hash = ( AAA => 1, BBB => 2 ); # Perl 6, uses ()'s though {} usually work
 
 =head2 C<? :> Ternary operator
 
@@ -519,19 +519,19 @@ common ternary operators disambiguates several situations and makes the
 false-case stand out more.
 
 =for code :lang<ruby>
-    result     = (  score > 60 )  ? 'Pass'  : 'Fail'; # Ruby
+result     = (  score > 60 )  ? 'Pass'  : 'Fail'; # Ruby
 =for code
-    my $score; ...;
-    my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
+my $score; ...;
+my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
 
 =head2 C<+> String Concatenation
 
 Replaced by the tilde. Mnemonic: think of "stitching" together the two strings with needle and thread.
 
 =for code :lang<ruby>
-    $food = 'grape' + 'fruit'  # Ruby
+$food = 'grape' + 'fruit'  # Ruby
 =for code
-    my $food = 'grape' ~ 'fruit'; # Perl 6
+my $food = 'grape' ~ 'fruit'; # Perl 6
 
 =head2 String interpolation
 
@@ -543,15 +543,15 @@ context.
 Simple variables can be interpolated into a double-quoted string without using the block syntax:
 
 =begin code :lang<ruby>
-    # Ruby
-    name = "Bob"
-    puts "Hello! My name is #{name}!"
+# Ruby
+name = "Bob"
+puts "Hello! My name is #{name}!"
 =end code
 
 =begin code :lang<ruby>
-    # Perl 6
-    my $name = "Bob";
-    say "Hello! My name is $name!"
+# Perl 6
+my $name = "Bob";
+say "Hello! My name is $name!"
 =end code
 
 The result of an embedded block in Ruby uses C<.to_s> to get string context.
@@ -567,35 +567,35 @@ This work very similarly between Ruby and Perl 6, but Perl 6 uses C<{ }> to
 clearly delineate the blocks.
 
 =begin code :lang<ruby>
-    # Ruby
-    if x > 5
-        puts "Bigger!"
-    elsif x == 5
-        puts "The same!"
-    else
-        puts "Smaller!"
-    end
+# Ruby
+if x > 5
+    puts "Bigger!"
+elsif x == 5
+    puts "The same!"
+else
+    puts "Smaller!"
+end
 =end code
 
 =begin code
-    # Perl 6
-    my $x; ...;
-    if $x > 5 {
-        say "Bigger!"
-    } elsif $x == 5 {
-        say "The same!"
-    } else {
-        say "Smaller!"
-    }
+# Perl 6
+my $x; ...;
+if $x > 5 {
+    say "Bigger!"
+} elsif $x == 5 {
+    say "The same!"
+} else {
+    say "Smaller!"
+}
 =end code
 
 Binding the conditional expression to a variable is a little different:
 
 =for code :lang<ruby>
-    if x = dostuff(); ...; end   # Ruby
+if x = dostuff(); ...; end   # Ruby
 =for code
-    sub dostuff() {...};
-    if dostuff() -> $x {...}     # Perl 6, block-assignment uses arrow
+sub dostuff() {...};
+if dostuff() -> $x {...}     # Perl 6, block-assignment uses arrow
 
 The C<unless> conditional only allows for a single block in Perl 6;
 it does not allow for an C<elsif> or C<else> clause.
@@ -611,11 +611,11 @@ It has the
 general structure:
 
 =begin code :lang<pseudo>
-    given EXPR {
-        when EXPR { ... }
-        when EXPR { ... }
-        default { ... }
-    }
+given EXPR {
+    when EXPR { ... }
+    when EXPR { ... }
+    default { ... }
+}
 =end code
 
 In its simplest form, the construct is as follows:
@@ -648,10 +648,10 @@ instead. Binding the conditional expression to a variable is also a little
 different:
 
 =for code :lang<ruby>
-    while x = dostuff(); ...; end    # Ruby
+while x = dostuff(); ...; end    # Ruby
 =for code
-    sub dostuff {...}; ...;
-    while dostuff() -> $x {...}      # Perl 6
+sub dostuff {...}; ...;
+while dostuff() -> $x {...}      # Perl 6
 
 =head3 C<for> C<.each>
 
@@ -660,27 +660,27 @@ enumerable. The most direct translation to Perl 6 would be to use C<.map> for
 both C<.each> and C<.map>, but we typically use a C<for> loop directly.
 
 =begin code :lang<ruby>
-    # Ruby for loop
-    for n in 0..5
-        puts "n: #{n}"
-    end
+# Ruby for loop
+for n in 0..5
+    puts "n: #{n}"
+end
 
-    # Ruby, more common usage of .each
-    (0..5).each do |n|
-        puts "n: #{n}"
-    end
+# Ruby, more common usage of .each
+(0..5).each do |n|
+    puts "n: #{n}"
+end
 =end code
 
 =begin code
-    # Perl 6
-    for 0..5 -> $n {
-        say "n: $n";
-    }
+# Perl 6
+for 0..5 -> $n {
+    say "n: $n";
+}
 
-    # Perl 6, misusing .map
-    (0..5).map: -> $n {
-        say "n: $n";
-    }
+# Perl 6, misusing .map
+(0..5).map: -> $n {
+    say "n: $n";
+}
 =end code
 
 In Ruby, the iteration variable for C<.each> is a copy of the list element, and
@@ -691,11 +691,11 @@ In Perl 6, that alias is read-only (for safety) and thus behaves exactly like
 Ruby, unless you change C«->» to C«<->».
 
 =for code :lang<ruby>
-    cars.each { |car| ... }    # Ruby; read-only reference
+cars.each { |car| ... }    # Ruby; read-only reference
 =for code
-    my @cars; ...;
-    for @cars  -> $car   {...} # Perl 6; read-only
-    for @cars <-> $car   {...} # Perl 6; read-write
+my @cars; ...;
+for @cars  -> $car   {...} # Perl 6; read-only
+for @cars <-> $car   {...} # Perl 6; read-write
 
 =head2 Flow Interruption statements
 
@@ -726,15 +726,15 @@ match operator or the C<.match> method. In Perl 6, the C<~~> smartmatch op is
 used instead, or the C<.match> method.
 
 =for code :lang<ruby>
-    next if line   =~ /static/   # Ruby
-    next if line  !~  /dynamic/; # Ruby
-    next if line.match(/static/) # Ruby
+next if line   =~ /static/   # Ruby
+next if line  !~  /dynamic/; # Ruby
+next if line.match(/static/) # Ruby
 
 =for code
-    my $line; ...;
-    next if $line  ~~ /static/;    # Perl 6
-    next if $line !~~ /dynamic/ ;  # Perl 6
-    next if $line.match(/static/); # Perl 6
+my $line; ...;
+next if $line  ~~ /static/;    # Perl 6
+next if $line !~~ /dynamic/ ;  # Perl 6
+next if $line.match(/static/); # Perl 6
 
 Alternately, the C<.match> and C<.subst> methods can be used. Note that
 C<.subst> is non-mutating. See
@@ -745,16 +745,16 @@ L<S05/Substitution|https://design.perl6.org/S05.html#Substitution>.
 In Perl 6 you typically use the C<s///> operator to do regex substitution.
 
 =for code :lang<ruby>
-    fixed = line.sub(/foo/, 'bar')        # Ruby, non-mutating
+fixed = line.sub(/foo/, 'bar')        # Ruby, non-mutating
 =for code
-    my $line; ...;
-    my $fixed = $line.subst(/foo/, 'bar') # Perl 6, non-mutating
+my $line; ...;
+my $fixed = $line.subst(/foo/, 'bar') # Perl 6, non-mutating
 
 =for code :lang<ruby>
-    line.sub!(/foo/, 'bar')   # Ruby, mutating
+line.sub!(/foo/, 'bar')   # Ruby, mutating
 =for code
-    my $line; ...;
-    $line ~~ s/foo/bar/;      # Perl 6, mutating
+my $line; ...;
+$line ~~ s/foo/bar/;      # Perl 6, mutating
 
 =head2 Regex options
 
@@ -762,10 +762,10 @@ Move any options from the end of the regex to the beginning. This may
 require you to add the optional C<m> on a plain match like C«/abc/».
 
 =for code :lang<ruby>
-    next if $line =~    /static/i # Ruby
+next if $line =~    /static/i # Ruby
 =for code
-    my $line; ...;
-    next if $line ~~ m:i/static/; # Perl 6
+my $line; ...;
+next if $line ~~ m:i/static/; # Perl 6
 
 =head2 Whitespace is ignored, most things must be quoted
 
@@ -773,13 +773,13 @@ In order to aid in readability and reusability, whitespace is not significant
 in Perl 6 regexes.
 
 =for code :lang<ruby>
-    /this is a test/ # Ruby, boring string
-    /this.*/         # Ruby, possibly interesting string
+/this is a test/ # Ruby, boring string
+/this.*/         # Ruby, possibly interesting string
 
 =for code
-    / this " " is " " a " " test /; # Perl 6, each space is quoted
-    / "this is a test" /;           # Perl 6, quoting the whole string
-    / this .* /;                    # Perl 6, possibly interesting string
+/ this " " is " " a " " test /; # Perl 6, each space is quoted
+/ "this is a test" /;           # Perl 6, quoting the whole string
+/ this .* /;                    # Perl 6, possibly interesting string
 
 =head2 Special matchers generally fall under the <> syntax
 
@@ -834,9 +834,9 @@ Both Ruby and Perl 6 make it easy to read all of the lines in a file into a
 single variable, and in both cases each line has the newline removed.
 
 =for code :lang<ruby>
-    lines = File.readlines("file")   # Ruby
+lines = File.readlines("file")   # Ruby
 =for code
-    my @lines = "file".IO.lines;     # Perl 6, create an IO object from a string
+my @lines = "file".IO.lines;     # Perl 6, create an IO object from a string
 
 =head2 Iterating over the lines of a text file
 
@@ -845,17 +845,17 @@ Perl 6 returns a lazy sequence, but assigning to an array forces the file to be
 read. It is better to iterate over the results:
 
 =begin code :lang<ruby>
-    # Ruby
-    File.foreach("file") do |line|
-        puts line
-    end
+# Ruby
+File.foreach("file") do |line|
+    puts line
+end
 =end code
 
 =begin code
-    # Perl 6
-    for "file".IO.lines -> $line {
-        say $line
-    }
+# Perl 6
+for "file".IO.lines -> $line {
+    say $line
+}
 =end code
 
 =head1 Object Orientation
@@ -866,21 +866,21 @@ Classes are defined similarly between Ruby and Perl 6, using the C<class>
 keyword. Ruby uses C<def> for methods, whereas Perl 6 uses C<method>.
 
 =begin code :lang<ruby>
-    # Ruby
-    class Foo
-        def greet(name)
-            puts "Hi #{name}!"
-        end
+# Ruby
+class Foo
+    def greet(name)
+        puts "Hi #{name}!"
     end
+end
 =end code
 
 =begin code
-    # Perl 6
-    class Foo {
-        method greet($name) {
-            say "Hi $name!"
-        }
+# Perl 6
+class Foo {
+    method greet($name) {
+        say "Hi $name!"
     }
+}
 =end code
 
 In Ruby you can use an attribute without declaring it beforehand, and you can
@@ -890,21 +890,21 @@ declaration and a variety of sigils. You can use the C<!> twigil for private
 attributes or C<.> to create an accessor.
 
 =begin code :lang<ruby>
-    # Ruby
-    class Person
-        attr_accessor :age    # Declare .age as an accessor method for @age
-        def initialize
-            @name = 'default' # Assign default value to private instance var
-        end
+# Ruby
+class Person
+    attr_accessor :age    # Declare .age as an accessor method for @age
+    def initialize
+        @name = 'default' # Assign default value to private instance var
     end
+end
 =end code
 
 =begin code
-    # Perl 6
-    class Person {
-        has $.age;              # Declare $!age and accessor methods
-        has $!name = 'default'; # Assign default value to private instance var
-    }
+# Perl 6
+class Person {
+    has $.age;              # Declare $!age and accessor methods
+    has $!name = 'default'; # Assign default value to private instance var
+}
 =end code
 
 Creating a new instance of the class uses the C<.new> method. In Ruby you must
@@ -915,29 +915,29 @@ you can override C<new> itself for more advanced functionality, but this is
 rare.
 
 =begin code :lang<ruby>
-    # Ruby
-    class Person
-        attr_accessor :name, :age
-        def initialize(attrs)
-            @name = attrs[:name] || 'Jill'
-            @age  = attrs[:age] || 42
-            @birth_year = Time.now.year - @age
-        end
+# Ruby
+class Person
+    attr_accessor :name, :age
+    def initialize(attrs)
+        @name = attrs[:name] || 'Jill'
+        @age  = attrs[:age] || 42
+        @birth_year = Time.now.year - @age
     end
-    p = Person.new( name: 'Jack', age: 23 )
+end
+p = Person.new( name: 'Jack', age: 23 )
 =end code
 
 =begin code
-    # Perl 6
-    class Person {
-        has $.name = 'Jill';
-        has $.age  = 42;
-        has $!birth_year;
-        method BUILD {
-            $!birth_year = now.Date.year - $.age;
-        }
+# Perl 6
+class Person {
+    has $.name = 'Jill';
+    has $.age  = 42;
+    has $!birth_year;
+    method BUILD {
+        $!birth_year = now.Date.year - $.age;
     }
-    my $p = Person.new( name => 'Jack', age => 23 )
+}
+my $p = Person.new( name => 'Jack', age => 23 )
 =end code
 
 =head2 Private Methods
@@ -946,32 +946,32 @@ Private methods in Perl 6 are declared with a C<!> prefixed in their name, and
 are invoked with a C<!> instead of a C<.>.
 
 =begin code :lang<ruby>
-    # Ruby
-    class Foo
-        def visible
-            puts "I can be seen!"
-            hidden
-        end
-
-        private
-        def hidden
-            puts "I cannot easily be called!"
-        end
+# Ruby
+class Foo
+    def visible
+        puts "I can be seen!"
+        hidden
     end
+
+    private
+    def hidden
+        puts "I cannot easily be called!"
+    end
+end
 =end code
 
 =begin code
-    # Perl 6
-    class Foo {
-        method visible {
-            say "I can be seen!";
-            self!hidden;
-        }
-
-        method !hidden {
-            say "I cannot easily be called!";
-        }
+# Perl 6
+class Foo {
+    method visible {
+        say "I can be seen!";
+        self!hidden;
     }
+
+    method !hidden {
+        say "I cannot easily be called!";
+    }
+}
 =end code
 
 An important note is that in Ruby child objects can see parent private methods
@@ -984,20 +984,20 @@ Here are a few examples of meta-programming. Note that Perl 6 separates the
 meta-methods from the regular methods with a carat.
 
 =for code :lang<ruby>
-    # Ruby
-    person = Person.new
-    person.class
-    person.methods
-    person.instance_variables
+# Ruby
+person = Person.new
+person.class
+person.methods
+person.instance_variables
 
 =for code
-    # Perl 6
-    class Person {};
-    ...
-    my $person = Person.new;
-    $person.^name;             # Perl 6, returns Person (class)
-    $person.^methods;          # Perl 6, using .^ syntax to access meta-methods
-    $person.^attributes;
+# Perl 6
+class Person {};
+...
+my $person = Person.new;
+$person.^name;             # Perl 6, returns Person (class)
+$person.^methods;          # Perl 6, using .^ syntax to access meta-methods
+$person.^attributes;
 
 
 Like Ruby, in Perl 6, everything is an object, but not all operations are
@@ -1006,11 +1006,11 @@ multi-dispatch (function signatures with types) to decide which implementation
 to use.
 
 =for code :lang<ruby>
-    5.send(:+, 3)    # => 8, Ruby
+5.send(:+, 3)    # => 8, Ruby
 =for code
-    &[+](5, 3)       # => 8, Perl 6, reference to infix addition operator
+&[+](5, 3)       # => 8, Perl 6, reference to infix addition operator
 
-    &[+].^candidates # Perl 6, lists all signatures for the + operator
+&[+].^candidates # Perl 6, lists all signatures for the + operator
 
 See L<Meta-Object Protocol|/language/mop> for lots of further details.
 
@@ -1050,29 +1050,29 @@ then exported. Hence, the following module C<Bar> exports the subs C<foo>
 and C<bar> but not C<baz>:
 
 =for code :skip-test
-    unit module Bar; # remainder of the file is in module Bar { ... }
+unit module Bar; # remainder of the file is in module Bar { ... }
 
 =for code :skip-test
-    sub foo($a) is export { say "foo $a" }
-    sub bar($b) is export { say "bar $b" }
-    sub baz($z) { say "baz $z" }
+sub foo($a) is export { say "foo $a" }
+sub bar($b) is export { say "bar $b" }
+sub baz($z) { say "baz $z" }
 
 To use this module, simply C<use Bar> and the functions C<foo> and C<bar>
 will be available
 
 =for code :skip-test
-    use Bar;
-    foo(1);    #=> "foo 1"
-    bar(2);    #=> "bar 2"
+use Bar;
+foo(1);    #=> "foo 1"
+bar(2);    #=> "bar 2"
 
 If you tries to use C<baz> an "Undeclared routine" error is raised at compile time.
 
 Some modules allow for selectively importing functions, which would look like:
 
 =for code :skip-test
-    use Bar <foo>; # Import only foo
-    foo(1);        #=> "foo 1"
-    bar(2);        # Error!
+use Bar <foo>; # Import only foo
+foo(1);        #=> "foo 1"
+bar(2);        # Error!
 
 =head2 C<OptionParser>, parsing command-line flags
 
@@ -1080,55 +1080,55 @@ Command line argument switch parsing in Perl 6 is done by the parameter list of
 the C<MAIN> subroutine.
 
 =begin code :lang<ruby>
-    # Ruby
-    require 'optparse'
-    options = {}
-    OptionParser.new do |opts|
-        opts.banner = 'Usage: example.rb --length=abc'
-        opts.on("--length", "Set the file") do |length|
-            raise "Length must be > 0" unless length.to_i > 0
-            options[:length] = length
-        end
-        opts.on("--filename", "Set the file") do |filename|
-            options[:file] = filename
-        end
-        opts.on("--verbose", "Increase verbosity") do |verbose|
-            options[:verbose] = true
-        end
-    end.parse!
+# Ruby
+require 'optparse'
+options = {}
+OptionParser.new do |opts|
+    opts.banner = 'Usage: example.rb --length=abc'
+    opts.on("--length", "Set the file") do |length|
+        raise "Length must be > 0" unless length.to_i > 0
+        options[:length] = length
+    end
+    opts.on("--filename", "Set the file") do |filename|
+        options[:file] = filename
+    end
+    opts.on("--verbose", "Increase verbosity") do |verbose|
+        options[:verbose] = true
+    end
+end.parse!
 
-    puts options[:length]
-    puts options[:filename]
-    puts 'Verbosity ', (options[:verbose] ? 'on' : 'off')
+puts options[:length]
+puts options[:filename]
+puts 'Verbosity ', (options[:verbose] ? 'on' : 'off')
 =end code
 
 =begin code :lang<shell>
-    ruby example.rb --filename=foo --length=42 --verbose
-        42
-        foo
-        Verbosity on
+ruby example.rb --filename=foo --length=42 --verbose
+    42
+    foo
+    Verbosity on
 
-    ruby example.rb --length=abc
-        Length must be > 0
+ruby example.rb --length=abc
+    Length must be > 0
 =end code
 
 =begin code
-    # Perl 6
-    sub MAIN ( Int :$length where * > 0, :$filename = 'file.dat', Bool :$verbose ) {
-        say $length;
-        say $filename;
-        say 'Verbosity ', ($verbose ?? 'on' !! 'off');
-    }
+# Perl 6
+sub MAIN ( Int :$length where * > 0, :$filename = 'file.dat', Bool :$verbose ) {
+    say $length;
+    say $filename;
+    say 'Verbosity ', ($verbose ?? 'on' !! 'off');
+}
 =end code
 
 =begin code :lang<shell>
-    perl6 example.p6 --file=foo --length=42 --verbose
-        42
-        foo
-        Verbosity on
-    perl6 example.p6 --length=abc
-        Usage:
-          example.p6 [--length=<Int>] [--file=<Any>] [--verbose]
+perl6 example.p6 --file=foo --length=42 --verbose
+    42
+    foo
+    Verbosity on
+perl6 example.p6 --length=abc
+    Usage:
+      example.p6 [--length=<Int>] [--file=<Any>] [--verbose]
 =end code
 
 Note that Perl 6 auto-generates a full usage message on error in

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -43,11 +43,11 @@ L<type smiley|/type/Signature#Constraining_Defined_and_Undefined_Values> or
 L«C<.DEFINITE>|/language/mop#index-entry-syntax_DEFINITE-DEFINITE» method:
 
 =begin code :ok-test<WHAT>
-    my $a = Int;
-    say $a ~~ Mu:U;
-    # OUTPUT: «True␤»
-    say not $a.DEFINITE;
-    # OUTPUT: «True␤»
+my $a = Int;
+say $a ~~ Mu:U;
+# OUTPUT: «True␤»
+say not $a.DEFINITE;
+# OUTPUT: «True␤»
 =end code
 
 C<.DEFINITE> will return C<True> if the invocant is an instance. If it returns C<False>, then
@@ -282,12 +282,12 @@ those names will silently fail. A dynamic call will work, what allows to call
 methods from foreign objects.
 
 =begin code :ok-test<WHAT>
-    class A {
-        method WHAT { "ain't gonna happen" }
-    };
+class A {
+    method WHAT { "ain't gonna happen" }
+};
 
-    say A.new.WHAT;    # OUTPUT: «(A)␤»
-    say A.new."WHAT"() # OUTPUT: «ain't gonna happen␤»
+say A.new.WHAT;    # OUTPUT: «(A)␤»
+say A.new."WHAT"() # OUTPUT: «ain't gonna happen␤»
 =end code
 
 =head4 Methods in package scope

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -22,12 +22,12 @@ What does this mean? For example á can be represented 2 ways. Either using
 one codepoint:
 
 =for code :lang<text>
-    á (U+E1 "LATIN SMALL LETTER A WITH ACUTE")
+á (U+E1 "LATIN SMALL LETTER A WITH ACUTE")
 
 Or two codepoints:
 
 =for code :lang<text>
-    a +  ́ (U+61 "LATIN SMALL LETTER A" + U+301 "COMBINING ACUTE ACCENT")
+a +  ́ (U+61 "LATIN SMALL LETTER A" + U+301 "COMBINING ACUTE ACCENT")
 
 Perl 6 will turn both these inputs into one codepoint, as is specified for
 Normalization Form C (B<X<NFC>>). In most cases this is useful and means

--- a/doc/Type/Blob.pod6
+++ b/doc/Type/Blob.pod6
@@ -190,7 +190,7 @@ This subroutine is considered B<experimental>,  in order to use it you will need
 use experimental :pack;
 
 =for code
-    sub pack(Str $template, *@items --> Buf)
+sub pack(Str $template, *@items --> Buf)
 
 Packs the given items according to the template and returns a buffer
 containing the packed bytes.

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1324,9 +1324,9 @@ Coerces the invocant to L<IO::Path>.
 Defined as:
 
 =for code
-    method EVAL(*%_)
+method EVAL(*%_)
 =for code
-    sub EVAL($code where Cool|Blob, :$lang = 'perl6')
+sub EVAL($code where Cool|Blob, :$lang = 'perl6')
 
 Method form calls subroutine form with invocant as C<$code>, passing along
 named args, if any. Subroutine form coerces L<Cool> C<$code> to L<Str>.

--- a/doc/Type/Dateish.pod6
+++ b/doc/Type/Dateish.pod6
@@ -183,7 +183,7 @@ has occurred so far during that month, the day itself included.
 Defined as:
 
 =for code :ok-test<dd>
-    method yyyy-mm-dd(Date:D: --> Str:D)
+method yyyy-mm-dd(Date:D: --> Str:D)
 
 Returns the date in C<YYYY-MM-DD> format (L<ISO 8601|https://en.wikipedia.org/wiki/ISO_8601>)
 

--- a/doc/Type/IO/Socket/INET.pod6
+++ b/doc/Type/IO/Socket/INET.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE TCP Socket
 
 =for code :skip-test
-    class IO::Socket::INET does IO::Socket {}
+class IO::Socket::INET does IO::Socket {}
 
 C<IO::Socket::INET> provides TCP sockets, both the server and the client side.
 

--- a/doc/Type/Numeric.pod6
+++ b/doc/Type/Numeric.pod6
@@ -11,11 +11,11 @@ Common role for numbers and types that can act as numbers.
 Binary numeric operations return an object of the "wider" type:
 
 =begin code :skip-test
-    Int         narrowest
-    Rat
-    FatRat
-    Num
-    Complex     widest
+Int         narrowest
+Rat
+FatRat
+Num
+Complex     widest
 =end code
 
 So for example the product of a L<Rat> and an L<Int> is a L<Rat>.

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -289,8 +289,8 @@ Calling C<can-turn-into> with an object instance as its second parameter
 will yield a constraint violation as intended:
 
 =for code :preamble< sub can-turn-into(Str $, Any:U $) {...}>
-    say can-turn-into("a string", 123);
-    # OUTPUT: «Parameter '$type' of routine 'can-turn-into' must be a type object of type 'Any', not an object instance of type 'Int'...»
+say can-turn-into("a string", 123);
+# OUTPUT: «Parameter '$type' of routine 'can-turn-into' must be a type object of type 'Any', not an object instance of type 'Int'...»
 
 For explicitly indicating the normal behaviour, C<:_> can be used, but this is
 unnecessary. C<:(Num:_ $)> is the same as C<:(Num $)>.

--- a/doc/Type/X/Temporal/InvalidFormat.pod6
+++ b/doc/Type/X/Temporal/InvalidFormat.pod6
@@ -11,9 +11,9 @@ This exception is thrown when code tries to create a C<DateTime> or C<Date> obje
 using an invalid format.
 
 =begin code :ok-test<dd>
-    my $dt = Date.new("12/25/2015");
-    CATCH { default { put .^name, ': ', .Str } };
-    # OUTPUT: «X::Temporal::InvalidFormat: Invalid Date string '12/25/2015'; use yyyy-mm-dd instead␤»
+my $dt = Date.new("12/25/2015");
+CATCH { default { put .^name, ': ', .Str } };
+# OUTPUT: «X::Temporal::InvalidFormat: Invalid Date string '12/25/2015'; use yyyy-mm-dd instead␤»
 =end code
 
 =head1 Methods


### PR DESCRIPTION
There are numerous instances of `=for` and `=begin` code blocks marking already indented code peppered through the documentation. This indentation is preserved in the rendered output, which is typically unintentional. So, for example:

    =for code
        say 'hello';

is rendered as

        say 'hello';

rather than

    say 'hello';

Although this is a fairly boring commit, it touches a lot of files—hence the PR rather than direct push. Note that If you ignore whitespace (`git diff master -w`), no content has changed. There're also no `test` or `xtest` regresssions.