### PR TITLE
Update META6.json documentation to include "api" field

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -537,6 +537,7 @@ lib
     {
         "perl" : "6.c",
         "name" : "Vortex::TotalPerspective",
+        "api" : "1",
         "version" : "0.0.1",
         "description" : "Wonderful simulation to get some perspective.",
         "authors" : [ "R<Your Name>" ],
@@ -566,6 +567,16 @@ lib
     available with C<use> or C<require> in other programs.
 
     Set C<perl> version to the minimum perl version your module works with.
+
+    Optionally, you can set an C<api> field. Incrementing this indicates that
+    the interface provided by your module is not backwards compatible with a
+    previous version.
+
+    If you want to adhere to L<Semantic Versioning | https://semver.org>, you
+    can use the C<api> field. Simply keep the C<api> field to the same value as
+    your major version number. A dependency can then depend on your module by
+    including a C<:api> part, which will ensure backwards incompatible releases
+    will not be pulled in.
 
     The C<resources> section is optional, but, if present, should contain a
     list of the files in your C<resources> directory that you wish to be


### PR DESCRIPTION
I'm considering to split up this section into a mandatory and optional section, to make it clearer what a user *needs*, and what they can additionally use to achieve certain goals (such as semantic versioning, in this case).