### PR TITLE
Add reference to vim-perl6 in the unicode_entry page

### DIFF
--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -106,8 +106,9 @@ characters|http://vim.wikia.com/wiki/Entering_special_characters>.
 =head3 vim-perl6
 
 The L<https://github.com/vim-perl/vim-perl6 | vim-perl6> plugin for Vim can be
-configured to replace ASCII based ops with their Unicode based equivalents.
-This will convert the ASCII based ops on the fly while typing them.
+configured to optionally replace ASCII based ops with their Unicode based
+equivalents. This will convert the ASCII based ops on the fly while typing
+them.
 
 =head2 Emacs
 

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -103,6 +103,12 @@ Further information about entering special characters in Vim can be found on
 the Vim Wikia page about L<entering special
 characters|http://vim.wikia.com/wiki/Entering_special_characters>.
 
+=head3 vim-perl6
+
+The L<https://github.com/vim-perl/vim-perl6 | vim-perl6> plugin for Vim can be
+configured to replace ASCII based ops to their Unicode based equivalent. This
+will convert the ASCII based ops on the fly while typing them.
+
 =head2 Emacs
 
 In L<Emacs|http://www.gnu.org/software/emacs/>, unicode characters are

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -106,8 +106,8 @@ characters|http://vim.wikia.com/wiki/Entering_special_characters>.
 =head3 vim-perl6
 
 The L<https://github.com/vim-perl/vim-perl6 | vim-perl6> plugin for Vim can be
-configured to replace ASCII based ops with their Unicode based equivalent. This
-will convert the ASCII based ops on the fly while typing them.
+configured to replace ASCII based ops with their Unicode based equivalents.
+This will convert the ASCII based ops on the fly while typing them.
 
 =head2 Emacs
 

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -105,7 +105,7 @@ characters|http://vim.wikia.com/wiki/Entering_special_characters>.
 
 =head3 vim-perl6
 
-The L<https://github.com/vim-perl/vim-perl6 | vim-perl6> plugin for Vim can be
+The L<vim-perl6|https://github.com/vim-perl/vim-perl6> plugin for Vim can be
 configured to optionally replace ASCII based ops with their Unicode based
 equivalents. This will convert the ASCII based ops on the fly while typing
 them.

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -106,7 +106,7 @@ characters|http://vim.wikia.com/wiki/Entering_special_characters>.
 =head3 vim-perl6
 
 The L<https://github.com/vim-perl/vim-perl6 | vim-perl6> plugin for Vim can be
-configured to replace ASCII based ops to their Unicode based equivalent. This
+configured to replace ASCII based ops with their Unicode based equivalent. This
 will convert the ASCII based ops on the fly while typing them.
 
 =head2 Emacs


### PR DESCRIPTION
I'm going to PR the https://github.com/vim-perl/vim-perl6 repository to add instruction on their `README.md` on how to configure this plugin to get the behaviour described here.

Edit: PR opened on `vim-perl6`: https://github.com/vim-perl/vim-perl6/pull/17