### PR TITLE
Mention attribute mutators by Proxy and refer to mutators.t in roast

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -289,6 +289,12 @@ The declared multi method C<notes> overrides the auto-generated
 methods implicit in the declaration of C<$.notes>, using a different
 signature for reading and writing.
 
+Many modern languages have “setters” or mutators that effectively
+overload the assignment operator to set an attribute. While this is
+possible to do with C<Proxy> objects, the approach is discouraged
+and method calls to mutators as above are preferred.  See
+L<mutators.t in roast|https://github.com/perl6/roast/blob/master/S12-attributes/mutators.t> for more explanation and an example.
+ 
 Method names can be resolved at runtime with the C<.""> operator.
 
     class A { has $.b };

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -297,25 +297,24 @@ Method names can be resolved at runtime with the C<.""> operator.
     # OUTPUT: «(Any)␤»
 
 The syntax used to update C<$.notes> changed in this section with respect
-to the previous L<#Attributes> section. Instead of:
+to the previous L<#Attributes> section. Instead of an assignment:
 
     $vacation.notes = 'Pack hiking gear and sunglasses!';
 
-we now:
+we now do a method call:
 
     $trip.notes("First steps");
 
 Overriding the default auto-generated accessor means it is no longer
-available to provide a mutable container on return, and the new update
-method is called to set the attribute rather than an assignment.
-Using a method call is the preferred approach to adding computation
-and logic to the update of an attribute.  Many modern languages can
-update an attribute by overloading assignment with a “setter” method.
-While Perl 6 can overload the assignment operator for this purpose
-with a
+available to provide a mutable container on return for an assignment.
+A method call is the preferred approach to adding computation and
+logic to the update of an attribute.  Many modern languages can update
+an attribute by overloading assignment with a “setter” method.  While
+Perl 6 can overload the assignment operator for this purpose with a
 L<C<Proxy>|https://github.com/perl6/roast/blob/master/S12-attributes/mutators.t>
 object, overloading assignment to set attributes with complex logic is
-currently discouraged as weaker OO design.
+currently discouraged as
+L<weaker object oriented design|https://6guts.wordpress.com/2016/11/25/perl-6-is-biased-towards-mutators-being-really-simple-thats-a-good-thing/>.
 
 =head2 Class and Instance Methods
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -289,18 +289,33 @@ The declared multi method C<notes> overrides the auto-generated
 methods implicit in the declaration of C<$.notes>, using a different
 signature for reading and writing.
 
-Many modern languages have “setters” or mutators that effectively
-overload the assignment operator to set an attribute. While this is
-possible to do with C<Proxy> objects, the approach is discouraged
-and method calls to mutators as above are preferred.  See
-L<mutators.t in roast|https://github.com/perl6/roast/blob/master/S12-attributes/mutators.t> for more explanation and an example.
- 
 Method names can be resolved at runtime with the C<.""> operator.
 
     class A { has $.b };
     my $name = 'b';
     A.new."$name"().say;
     # OUTPUT: «(Any)␤»
+
+The syntax used to update C<$.notes> changed in this section with respect
+to the previous L<#Attributes> section. Instead of:
+
+    $vacation.notes = 'Pack hiking gear and sunglasses!';
+
+we now:
+
+    $trip.notes("First steps");
+
+Overriding the default auto-generated accessor means it is no longer
+available to provide a mutable container on return, and the new update
+method is called to set the attribute rather than an assignment.
+Using a method call is the preferred approach to adding computation
+and logic to the update of an attribute.  Many modern languages can
+update an attribute by overloading assignment with a “setter” method.
+While Perl 6 can overload the assignment operator for this purpose
+with a
+L<C<Proxy>|https://github.com/perl6/roast/blob/master/S12-attributes/mutators.t>
+object, overloading assignment to set attributes with complex logic is
+currently discouraged as weaker OO design.
 
 =head2 Class and Instance Methods
 


### PR DESCRIPTION
Hopefully completion of issue #136 that I had to put aside for a while.  Python, Ruby, C# and Delphi all allow 'setters' for attributes that overload the assignment operator so other people from other languages may wonder about the feature.  Patch tries to give just enough to satisfy their curiosity.

Forgot to mention [March 24 IRC discussion](https://irclog.perlgeek.de/perl6/2018-03-24#i_15961290) with @timo when posting. 