### PR TITLE
return type constraints also work for pointy blocks

### DIFF
--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -355,7 +355,7 @@ others, you need to use the long version:
 
 =head3 X«Constraining Return Types|-->;returns»
 
-There are multiple ways to constrain return types on a sub or method. All versions below
+There are multiple ways to constrain return types on a L<Routine|/type/Routine>. All versions below
 are currently valid and will force a type check on successful execution of a routine.
 
 L<C<Nil>|/type/Nil> and L<C<Failure>|/type/Failure> are always allowed as return types,


### PR DESCRIPTION
also, links are nice