### PR TITLE
Fix Identifiers exmple

### DIFF
--- a/doc/Type/Grammar.pod6
+++ b/doc/Type/Grammar.pod6
@@ -10,11 +10,11 @@ Every type declared with C<grammar> and not explicitly stating its superclass,
 becomes a subclass of I<Grammar>.
 
     grammar Identifier {
-        token TOP     { <initial> <rest>* }
-        token initial { <:letter+[_]> }
-        token rest    { <:letter+:number+[_]>}
-        token letter { <[A..Za..z]> }
-        token number { <[0..9]> }
+        token TOP       { <initial> <rest>* }
+        token initial   { <+myletter +[_]> }
+        token rest      { <+myletter +mynumber +[_]> }
+        token myletter  { <[A..Za..z]> }
+        token mynumber  { <[0..9]> }
     }
 
     say Identifier.isa(Grammar);                # OUTPUT: «True␤»
@@ -112,10 +112,10 @@ are passed on to L<method parse|/routine/parse>.
     grammar Identifiers {
         token TOP        { [<identifier><.ws>]+ }
         token identifier { <initial> <rest>* }
-        token initial    { <:letter+[_]> }
-        token rest       { <:letter+:number+[_]>}
-        token letter     { <[A..Za..z]> }
-        token number     { <[0..9]> }
+        token initial    { <+myletter +[_]> }
+        token rest       { <+myletter +mynumber +[_]> }
+        token myletter   { <[A..Za..z]> }
+        token mynumber   { <[0..9]> }
     }
 
     say Identifiers.parsefile('users.txt', :enc('UTF-8'))


### PR DESCRIPTION
The previous one calls pre-defined tokens (See: https://docs.perl6.org/language/regexes#Unicode_properties) not user-defined one.
That is confusing since this example defines unused tokens as if it used.