### PR TITLE
m/ / and / / examples added

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -28,6 +28,11 @@ is forbidden because it clashes with adverbs, such as C<rx:i/abc/>
 (case insensitive regexes), and round parentheses indicate a function call
 instead.
 
+Example of difference between 'm/ /' and '/ /' operators:
+
+    $_ = "abc"; my $match = m/.+/; say $match;       # Output: ｢abc｣
+    $_ = "abc"; my $match =  /.+/; say $match;       # Output: /.+/
+
 Whitespace in regexes is generally ignored (except with the C<:s> or,
 completely, C<:sigspace> adverb).
 


### PR DESCRIPTION
Added examples to help illustrate difference between m/ / and / /.  Zoffix provided the examples.  I provided the learning.  An example for rx/ / is needed.  As a newbie, this info is very helpful and rare.  It is not in Think Perl 6, ttbomk.  And definitely not in Perl6Intro.com.  Needed info or something better.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->


