### PR TITLE
Clarify 'Bar.pm6' vs 'how to use Bar.pm6'

### DIFF
--- a/doc/Language/module-packages.pod6
+++ b/doc/Language/module-packages.pod6
@@ -161,7 +161,7 @@ say Foo::loud-greeting;  # OUTPUT: «GREETINGS, CAMELIA!␤»
 say friendly-greeting;   # OUTPUT: «Greetings, friend!␤»
 =end code
 
-and here's C<Bar.pm6>,
+and here's how we use C<Bar.pm6>,
 
 =begin code :skip-test<filesystem related>
 use Bar;


### PR DESCRIPTION
## The problem

Reference to Bar.pm6 is arguably ambiguous

## Solution provided

Added three words


