### PR TITLE
Non breaking space inserted in some 'Pod 6' and 'Perl 6'. This fixed …

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -30,7 +30,7 @@ Running C<perl6 -v> will display the language version your compiler implements:
 =for code :lang<shell>
 $ perl6 -v
 This is Rakudo version 2017.07 built on MoarVM version 2017.07
-implementing Perl 6.c.
+implementing Perl 6.c.
 
 X<|v6.d (FAQ)>
 =head2 When is v6.d going to be released?

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -400,7 +400,7 @@ class MyStruct is repr('CStruct') {
         $arr[0] = 0.9e0;
         $arr[1] = 0.2e0;
         $!arr := $arr;
-        $!str := 'Perl 6 is fun';
+        $!str := 'Perl 6 is fun';
         $!point := Point.new;
     }
 }

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -1,18 +1,18 @@
 =begin pod :tag<pod6>
 
-=TITLE Pod 6 Tables
+=TITLE Pod 6 Tables
 
 =SUBTITLE The Good, the Bad, and the Ugly
 
 The official specification for Perl 6 POD tables is located in the
 Documentation specification here:
 L<Tables|https://raw.githubusercontent.com/perl6/specs/master/S26-documentation.pod>.
-Although Pod 6 specifications are not completely handled properly yet,
+Although Pod 6 specifications are not completely handled properly yet,
 several projects are ongoing to correct the situation; one such
-project is ensuring the proper handling of Pod 6 tables.
+project is ensuring the proper handling of Pod 6 tables.
 
 As part of that effort, this document explains the current state of
-Pod 6 tables by example: valid tables, invalid tables, and ugly tables
+Pod 6 tables by example: valid tables, invalid tables, and ugly tables
 (i.e., valid tables that, because of sloppy construction, may result
 in something different than the user expects).
 

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -90,8 +90,8 @@ including L<Methods|/type/Method> and L<Blocks|/type/Block>:
 
     my &learner = {
         "It took me $:months months to learn $^lang"
-    }.assuming: 'Perl 6';
-    say learner :6months;  # OUTPUT: «It took me 6 months to learn Perl 6␤»
+    }.assuming: 'Perl 6';
+    say learner :6months;  # OUTPUT: «It took me 6 months to learn Perl 6␤»
 
 =head2 method count
 

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -387,8 +387,8 @@ will throw. If you wish to ignore such failures, simply use L<run> in non-sink c
 
 To capture output or error you can use the C<:out> or C<:err> arguments respectively:
 
-    my $proc = run 'echo', 'Perl 6 is Great!', :out, :err;
-    $proc.out.slurp(:close).say; # OUTPUT: «Perl 6 is Great!␤»
+    my $proc = run 'echo', 'Perl 6 is Great!', :out, :err;
+    $proc.out.slurp(:close).say; # OUTPUT: «Perl 6 is Great!␤»
     $proc.err.slurp(:close).say; # OUTPUT: «␤»
 
 See L<Proc|/type/Proc> and L<Proc::Async|/type/Proc::Async> for more details.

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -281,7 +281,7 @@ phaser is usually a better choice.
         quit    => -> $ex { say "Supply finished with error $ex" },
     );
 
-    $s.emit('Perl 6');
+    $s.emit('Perl 6');
     $tap.close;        # OUTPUT: «Tap closed␤»
 
 =head2 method interval


### PR DESCRIPTION
…#1923

## The problem

Missing non-breaking space before the 6

## Solution provided

Insert non-breaking space before the 6
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->


