### PR TITLE
Update htmlify.p6 to fix 'got empty filename' issue #1971.  

### DIFF
--- a/htmlify.p6
+++ b/htmlify.p6
@@ -556,6 +556,9 @@ sub find-definitions(:$pod, :$origin, :$min-level = -1, :$url) {
             when :(Str $ where /^(\w+) \s$/, Pod::FormattingCode $) {
                 # infix C<Foo>
                 @definitions = .[0].words[0], textify-guts .[1].contents[0];
+                proceed if ( # not looking for - baz X<baz>
+                    (@definitions[1] // '') eq '' and .[1].type eq 'X'
+                );
             }
             # XXX: Remove when extra "" have been purged
             when :(Str $ where /^(\w+) \s$/, Pod::FormattingCode $, "") {


### PR DESCRIPTION
## The problem
issue #1971 'got empty filename' error

## Solution provided
htmlify.p6 was looking for "infix C<foo>" and tried to process '=head1 baz X<|baz>' same way which results in empty document name.  Note 'infix X<C<foo>>' is sometimes used so need to check content as well as .type eq 'X'.

