### PR TITLE
Improve MySQL installation process

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -802,26 +802,25 @@ The PostgreSQL examples in L<DBIish|https://github.com/perl6/DBIish/blob/master/
 
 =head2 MySQL
 
+B<NOTE:> Please bear in mind that, under the hood, Debian has substituted MySQL with MariaDB since the Stretch version, so if you want to install MySQL, use L<MySQL APT repository|https://dev.mysql.com/downloads/repo/apt/> instead of the default repository.
+
 You'll need to install MySQL server locally; on Debian-esque systems
 it can be installed with something like:
 
 =for code :lang<shell>
-sudo apt-get install mysql-server
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
+sudo dpkg -i mysql-apt-config_0.8.10-1_all.deb # Don't forget to select 5.6.x
+sudo apt-get update
+sudo apt-get install mysql-community-server -y
+sudo apt-get install libmysqlclient18 -y
 
 Prepare your system along these lines before trying out the examples:
 
 =for code :lang<shell>
 $ mysql -u root -p
-UPDATE mysql.user SET password=password('sa') WHERE user = 'root';
+SET PASSWROD = PASSWORD('sa');
+DROP DATABASE test;
 CREATE DATABASE test;
-
-Please bear in mind that, under the hood, Debian has substituted MySQL with MariaDB since the Stretch version, so if you want to install the dynamic library you will have to write:
-
-=for code :lang<shell>
-$ wget http://ftp.br.debian.org/debian/pool/main/m/mysql-5.5/libmysqlclient18_5.5.58-0+deb8u1_amd64.deb
-$ sudo dpkg -i libmysqlclient18_5.5.58-0+deb8u1_amd64.deb
-
-(Use the closest mirror instead of C<br> if you want).
 
 =head2 Microsoft Windows
 


### PR DESCRIPTION
I fixed this section for several reasons:

1) The previous example could install the dynamic library but the DBIish example also requires MySQL server.
2) The MySQL APT Repository officially supports debian stretch (also it supports jessie and wheezy).
3) Even if an user use an older distribution, he/she can install the current version of MySQL easily.

(and sorry for my confusing suggestion: https://github.com/perl6/doc/issues/1993 )
