### PR TITLE
Document CArray.allocate

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -287,10 +287,8 @@ subroutine, otherwise the C function may stomp all over Perl's memory
 leading to possibly unpredictable behaviour:
 
 =begin code :skip-test
-my $ints = CArray[int32].new;
 my $number_of_ints = 10;
-$ints[$number_of_ints - 1] = 0; # extend the array to 10 items
-
+my $ints = CArray[int32].allocate($number_of_ints); # instantiates an array with 10 elements
 my $n = get_n_ints($ints, $number_of_ints);
 =end code
 


### PR DESCRIPTION
## The problem

CArray.allocate from https://github.com/rakudo/rakudo/pull/1779/commits/a02131d53d52bf96ba8f7bd56d04c45771dbb08c is undocumented

## Solution provided

The old example showing how to allocate a CArray was updated to use the new method

