### PR TITLE
Implement Perl 6 NBSP linter script

### DIFF
--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -100,7 +100,7 @@ block in the body of the loop.
 
 =begin code :lang<perl5>
 
-# Perl 5
+# Perl 5
 my $str = '';
 for (1..5) {
     next if $_ % 2 == 1;
@@ -113,7 +113,7 @@ continue {
 =end code
 
 =begin code
-# Perl 6
+# Perl 6
 my $str = '';
 for 1..5 {
     next if $_ % 2 == 1;

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -814,8 +814,7 @@ many in the L<Perl Community|/language/community>.
 =head1 POD
 X<|POD>
 
-B<P>lain B<O>l' B<D>ocumentation, a documentation format understood by Perl
-6. See L<S26|https://design.perl6.org/S26.html> for details.
+B<P>lain B<O>l' B<D>ocumentation, a documentation format understood by Perl 6. See L<S26|https://design.perl6.org/S26.html> for details.
 
 =head1 Pull Request
 X<|Pull Request>

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -9,8 +9,7 @@ does not mean there are not similarities or shared ideas! This page attempts to
 get a Haskell user up and running with Perl 6. The Haskell user may find that they need
 not abandon all of their Haskelly thoughts while scripting in Perl 6.
 
-Note that this should not be mistaken for a beginner tutorial or overview of Perl
-6; it is intended as a technical reference for Perl 6 learners with a strong
+Note that this should not be mistaken for a beginner tutorial or overview of Perl 6; it is intended as a technical reference for Perl 6 learners with a strong
 Haskell background.
 
 

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -9,8 +9,7 @@ between Ruby and Perl 6. Whatever works in Ruby and must be written differently
 in Perl 6 should be listed here (whereas many Perl 6 features and idioms won't
 be).
 
-Hence this should not be mistaken for a beginner tutorial or overview of Perl
-6; it is intended as a technical reference for Perl 6 learners with a strong
+Hence this should not be mistaken for a beginner tutorial or overview of Perl 6; it is intended as a technical reference for Perl 6 learners with a strong
 Ruby background.
 
 

--- a/util/perl-nbsp.p6
+++ b/util/perl-nbsp.p6
@@ -1,0 +1,74 @@
+#!/usr/bin/env perl6
+
+use v6;
+use lib 'lib';
+use Test-Files;
+
+my $degree = %*ENV<TEST_THREADS> // 2;
+my @files = Test-Files.files
+    .grep({ .ends-with: '.pod6' | '.md' });
+
+enum Syntax (
+    CodeDoc => 0,
+    ForDoc  => 1,
+    Doc     => 2
+);
+
+sub check-line($line, $state) {
+    given $line {
+        when /^\=begin\scode/ { CodeDoc                         }
+        when /^\=for\scode/   { ForDoc                          }
+        when /^\=end\scode/   { Doc                             }
+        when /^\=\w+/         { Doc                             }
+        when /^\s ** 4/       { CodeDoc                         }
+        when /^.+$/           { $state !~~ Doc ?? $state !! Doc }
+        default               { $state                          }
+    }
+}
+ 
+my @promises = @files.map(-> $file {
+    Promise.start({
+        my Str        @contents;
+        my Str        @lines = $file.IO.lines;
+        my IO::Handle $fh    = $file.IO.open(:rw);
+        my Syntax     $state = Doc;
+        my Str        $buf;
+        my Bool       $logged;
+        for @lines -> $line {
+            next if $line === Nil;
+
+            $state = check-line($line, $state);
+            if $state !~~ Doc {
+                # Perl 5 or Perl 6 should keep regular spaces in code.
+                @contents.push($line);
+                next;
+            }
+
+            my $new-line = $line;
+            if $new-line.chars < 6 {
+                # Too short to contain Perl 5 or Perl 6.
+                @contents.push($line);
+                next;
+            }
+
+            $new-line ~~ s:g/Perl\x[0020](5||6)/Perl\x[00A0]$0/;
+            if $new-line ne $line and ~$/ {
+                $logged = True;
+                @contents.push($new-line);
+            } else {
+                @contents.push($line);
+            }
+        }
+
+        if $logged {
+            say "Corrected mentions of Perl 6 to use NBSP in '$file'.";
+            $logged = False;
+        }
+
+        $fh.spurt(@contents.join("\n"));
+        $fh.close;
+    })
+});
+
+@promises.race(:$degree).map(-> $p { await $p });
+


### PR DESCRIPTION
## The problem

Perl 6 is supposed to use U00A0 instead of a regular space, but this isn't always the case in the documentation.

## Solution provided

util/perl-nbsp.p6 lints each of the documentation files, checking for
cases where Perl 6 is written with a regular space instead of a
non-breaking one, and replaces it accordingly.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->


