### PR TITLE
Change "file handle" to "filehandle"

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -290,7 +290,7 @@ foo(3); # /language/functions#index-entry-dispatch_callsame
          today, and refactor this section to list them (with translations).
 
 In Perl 5, the C<*> sigil referred to the GLOB structure that Perl uses to
-store non-lexical variables, file handles, subs, and formats.
+store non-lexical variables, filehandles, subs, and formats.
 
 (This should not be confused with the Perl 5 built-in C<glob()> function,
 which reads filenames from a directory).

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -311,7 +311,7 @@ Too complicated to apply a meta-op to. See L<operator|#Operator>.
 
 =head1 Handle
 
-A handle is a data structure used to store information about some input/output operation such as file or socket reading or writing. Perl 6 uses L<IO::Handle> as a base class for file handles, and L<IO::Socket> for sockets.
+A handle is a data structure used to store information about some input/output operation such as file or socket reading or writing. Perl 6 uses L<IO::Handle> as a base class for filehandles, and L<IO::Socket> for sockets.
 
 =head1 Huffmanize
 
@@ -938,14 +938,14 @@ my $lines = $fh.lines;
 close $fh;
 say $lines[0];
 
-We open a L<file handle|/type/IO::Handle>, then assign return of
+We open a L<filehandle|/type/IO::Handle>, then assign return of
 L«C<.lines>|/type/IO::Handle#method_lines» to a L<Scalar> variable, so the
 returned L<Seq> does not get reified right away. We then
-L«C<close>|/routine/close» the file handle, and try to print an element from
+L«C<close>|/routine/close» the filehandle, and try to print an element from
 C<$lines>.
 
 The bug in the code is by the time we reify the C<$lines> L<Seq> on the last
-line, we've I<already closed> the file handle. When the C<Seq's> iterator tries
+line, we've I<already closed> the filehandle. When the C<Seq's> iterator tries
 to generate the item we've requested, it results in the error about attempting
 to read from a closed handle. So, to fix the bug we can either assign to
 a C<@>-sigiled variable or call L«C<.elems>|/routine/elems» on C<$lines> before

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -8,7 +8,7 @@
 
 The vast majority of common IO work is done by the L<IO::Path> type. If you
 want to read from or write to a file in some form or shape, this is the class
-you want. It abstracts away the details of file handles (or "file descriptors")
+you want. It abstracts away the details of filehandles (or "file descriptors")
 and so you mostly don't even have to think about them.
 
 Behind the scenes, L<IO::Path> works with L<IO::Handle>; a class which you
@@ -119,7 +119,7 @@ with a lot of files, as many systems have limits to how many files a program
 can have open at the same time. If you don't close your handles, eventually
 you'll reach that limit and the L«C<.open>|/routine/open» call will fail.
 Note that unlike some other languages, Perl 6 does not use reference counting,
-so the file handles B<are NOT closed> when the scope they're defined in is left.
+so the filehandles B<are NOT closed> when the scope they're defined in is left.
 They will be closed only when they're garbage collected and failing to close
 the handles may cause your program to reach the file limit I<before> the open
 handles get a chance to get garbage collected.
@@ -165,7 +165,7 @@ loading it entirely:
 Note that we did this by passing a limit argument to
 L«C<.words>|/type/IO::Path#method_words» instead of, say, using
 L<a list indexing operation|/language/operators#index-entry-array_indexing_operator-array_subscript_operator-array_indexing_operator>.
-The reason for that is there's still a file handle in use under the hood, and
+The reason for that is there's still a filehandle in use under the hood, and
 until you fully consume the returned L<Seq>, the handle will remain open.
 If nothing references the L<Seq>, eventually the handle will get closed, during
 a garbage collection run, but in large programs that work with a lot of files,
@@ -231,7 +231,7 @@ introduce security issues (e.g. null characters)!
 
 The L«C<IO::Path>|/type/IO::Path» type is the workhorse of Perl 6 world. It
 caters to all the path manipulation needs as well as provides shortcut routines
-that let you avoid dealing with file handles. Use that instead of the
+that let you avoid dealing with filehandles. Use that instead of the
 L«C<$*SPEC>|/language/variables#Dynamic_variables» stuff.
 
 Tip: you can join path parts with C</> and feed them to

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -19,7 +19,7 @@ my $fh = open "testfile", :r;
 my $contents = $fh.slurp-rest;
 $fh.close;
 
-Here we explicitly close the file handle using the C<close> method on the
+Here we explicitly close the filehandle using the C<close> method on the
 C<IO::Handle> object. This is a very traditional way of reading the
 contents of a file. However, the same can be done more easily and clearly
 like so:
@@ -86,7 +86,7 @@ my $fh = open "testfile", :w;
 $fh.printf("formatted data %04d\n", 42);
 $fh.close;
 
-To append to a file, specify the C<:a> option when opening the file handle
+To append to a file, specify the C<:a> option when opening the filehandle
  explicitly,
 
 =for code

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -44,7 +44,7 @@ a variable, even anonymous one, to prevent the sinking:
 
     $ = run '/bin/false'; # does not sink the Proc and so does not throw
 
-You can tell the C<Proc> object to capture output as a file handle by passing
+You can tell the C<Proc> object to capture output as a filehandle by passing
 the C<:out> and C<:err> flags. You may also pass input via the C<:in> flag.
 
     my $echo = run 'echo', 'Hello, world', :out;

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -1095,7 +1095,7 @@ sub explicitly-return-ret () {
 =head2 Closing Open File Handles and Pipes
 
 Unlike some other languages, Perl 6 does not use reference counting,
-and so B<the file handles are NOT closed when they go out of scope>. You
+and so B<the filehandles are NOT closed when they go out of scope>. You
 have to explicitly close them either by using L<close> routine or using the
 C<:close> argument several of L<IO::Handle's|/type/IO::Handle> methods accept.
 See L«C<IO::Handle.close>|/type/IO::Handle#routine_close» for details.

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -44,7 +44,7 @@ One case where we don't default to this, is for the names of files. This is beca
 the names of files must be accessed exactly as the bytes are written on the disk.
 
 To avoid normalization you can use a special encoding format called L<UTF8-C8|#UTF8-C8>.
-Using this encoding with any file handle will allow you to read the exact bytes as they are
+Using this encoding with any filehandle will allow you to read the exact bytes as they are
 on disk, without normalization. They may look funny when printed out, if you print it out using a
 UTF8 handle. If you print it out to a handle where the output encoding is UTF8-C8,
 then it will render as you would normally expect, and be a byte for byte exact

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -179,7 +179,7 @@ Defined as:
     multi sub print(Junction:D --> True)
 
 Prints the given text on standard output (the
-L«C<$*OUT>|/language/variables#index-entry-%24%2AOUT» file handle), coercing non-L<Str> objects
+L«C<$*OUT>|/language/variables#index-entry-%24%2AOUT» filehandle), coercing non-L<Str> objects
 to L<Str> by calling L«C<.Str> method|/routine/Str». L<Junction> arguments
 L<autothread|/language/glossary#index-entry-Autothreading> and the order of printed strings
 is not guaranteed.

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -111,7 +111,7 @@ an explicit C<close> is I<recommended> on handles opened for reading as well, so
 that your program does not open too many files at the same time, triggering
 exceptions on further C<open> calls.
 
-B<Note (Rakudo versions 2017.09 and after):> Open file handles are
+B<Note (Rakudo versions 2017.09 and after):> Open filehandles are
 automatically closed on program exit, but it is still highly
 recommended that you C<close> opened handles explicitly.
 
@@ -213,7 +213,7 @@ Defined as:
     submethod DESTROY(IO::Handle:D:)
 
 Closes the filehandle, unless its L<native-descriptor> is C<2> or lower. This
-ensures the standard file handles do not get inadvertently closed.
+ensures the standard filehandles do not get inadvertently closed.
 
 Note that garbage collection is not guaranteed to
 happen, so you must NOT rely on C<DESTROY> for closing the handles you
@@ -269,7 +269,7 @@ Defined as:
     multi method encoding(IO::Handle:D: $enc --> Str:D)
 
 Returns a L<Str> representing the encoding currently used by
-the handle, defaulting to C<"utf8">. C<Nil> indicates the file handle is
+the handle, defaulting to C<"utf8">. C<Nil> indicates the filehandle is
 currently in binary mode. Specifying an optional positional C<$enc> argument
 switches the encoding used by the handle; specify C<Nil> as encoding to put the
 handle into binary mode.
@@ -766,9 +766,9 @@ Defined as:
     method close(IO::Handle:D: --> Bool:D)
     multi sub close(IO::Handle $fh)
 
-Closes an open file handle. It's not an error to call C<close> on an
+Closes an open filehandle. It's not an error to call C<close> on an
 already-closed filehandle. Returns C<True> on success. If you close
-one of the standard file handles (by default: C<$*IN>, C<$*OUT>, or C<$*ERR>),
+one of the standard filehandles (by default: C<$*IN>, C<$*OUT>, or C<$*ERR>),
 that is any handle with L<native-descriptor> C<2> or lower, you won't be
 able to re-open such a handle.
 
@@ -800,7 +800,7 @@ given "foo/bar".IO.open(:w) {
 =end code
 
 B<Note:> unlike some other languages, Perl 6 does not use reference counting,
-and so B<the file handles are NOT closed when they go out of scope>. While
+and so B<the filehandles are NOT closed when they go out of scope>. While
 they I<will> get closed when garbage collected, garbage collection isn't
 guaranteed to get run. This means B<you must> use an explicit C<close> on
 handles opened for writing, to avoid data loss, and an explicit C<close>
@@ -811,7 +811,7 @@ C<open> calls.
 Note several methods allow for providing C<:close> argument, to close the handle
 after the operation invoked by the method completes. As a simpler alternative,
 the L<IO::Path> type provides many reading and writing methods that let you work
-with files without dealing with file handles directly.
+with files without dealing with filehandles directly.
 
 =head2 method flush
 

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -763,7 +763,7 @@ L<Seq>.
 B<NOTE:> words are lazily read.
 The handle used under the hood is not closed until the returned L<Seq> is
 L<fully reified|/language/glossary#index-entry-Reify>, and this could lead
-to leaking open file handles. It is possible to avoid leaking open file handles
+to leaking open filehandles. It is possible to avoid leaking open filehandles
 using the L«C<$limit> argument|/type/IO::Handle#routine_words» to cut down
 the C<Seq> of words to be generated.
 
@@ -789,7 +789,7 @@ L<Seq>.
 B<NOTE:> the lines are ready lazily and the handle used under the hood won't
 get closed until the returned L<Seq> is
 L<fully reified|/language/glossary#index-entry-Reify>, so ensure it is,
-or you'll be leaking open file handles. (TIP: use the
+or you'll be leaking open filehandles. (TIP: use the
 L«C<$limit> argument|/type/IO::Handle#routine_lines»)
 
 =begin code

--- a/doc/Type/IO/Special.pod6
+++ b/doc/Type/IO/Special.pod6
@@ -7,7 +7,7 @@
 =for code
 class IO::Special does IO { }
 
-Used as a L«C<$.path>|/type/IO::Handle#method_path>» attribute in file handles
+Used as a L«C<$.path>|/type/IO::Handle#method_path>» attribute in filehandles
 for special standard input C<$*IN> and output C<$*OUT> and C<$*ERR>. Provides
 a bridged interface of L«C<IO::Handle>|/type/IO::Handle», mostly file tests
 and stringification.
@@ -112,7 +112,7 @@ The 'execute access' file test operator, always returns C<False>.
 
     method modified(IO::Special:D: --> Instant)
 
-The last modified time for the file handle.
+The last modified time for the filehandle.
 It always returns an L«C<Instant>|/type/Instant» type
 object.
 
@@ -120,7 +120,7 @@ object.
 
     method accessed(IO::Special:D: --> Instant)
 
-The last accessed time for the file handle.
+The last accessed time for the filehandle.
 It always returns an L«C<Instant>|/type/Instant» type
 object.
 
@@ -128,7 +128,7 @@ object.
 
     method changed(IO::Special:D: --> Instant)
 
-The last changed time for the file handle.
+The last changed time for the filehandle.
 It always returns an L«C<Instant>|/type/Instant» type
 object.
 
@@ -136,6 +136,6 @@ object.
 
     method mode(IO::Special:D: --> Nil)
 
-The mode for the file handle, it always returns L<Nil>
+The mode for the filehandle, it always returns L<Nil>
 
 =end pod


### PR DESCRIPTION
This is part of the fixes suggested in #2015

## The problem
Looking for handles to solve #761, I have found that file handle appear at least in that form or in the filehandle form. We should try and normalize terminology across all the documents, and this is only an example. When normalization is done, we should turn it into a test later on.

## Solution provided

 Change: file handle, filehandle, file-handle → filehandle
