### PR TITLE
Change terms as suggested in #2015

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -929,7 +929,7 @@ L<Sigilless variables|/language/variables#index-entry-\_(sigilless_variables)> a
 =head1 Spesh
 X<|Spesh>
 
-A functionality of the L<#MoarVM> platform that uses run-time gathered data
+A functionality of the L<#MoarVM> platform that uses runtime gathered data
 to improve commonly used pieces of L<#bytecode>. It is much like a JIT
 compiler, except that those usually output machine code rather than
 bytecode.

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -150,7 +150,7 @@ a C<Failure>. The correct way is:
     # Use return value to test whether loading succeeded:
     (try require Foo) === Nil and say "Failed to load Foo!";
 
-    # Or use a run-time symbol lookup with require, to avoid compile-time
+    # Or use a runtime symbol lookup with require, to avoid compile-time
     # package installation:
     try require ::('Foo');
     if ::('Foo') ~~ Failure {

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1779,7 +1779,7 @@ also modify the other.
 X<|smartmatch operator>
 =head2 infix C«~~»
 
-The X<smart-match operator> aliases the left-hand side to C<$_>, then evaluates
+The smartmatch operator aliases the left-hand side to C<$_>, then evaluates
 the right-hand side and calls C<.ACCEPTS($_)> on it. The semantics are left
 to the type of the right-hand side operand.
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1779,7 +1779,7 @@ also modify the other.
 X<|smartmatch operator>
 =head2 infix C«~~»
 
-The X<smartmatch operator> aliases the left-hand side to C<$_>, then evaluates
+The X<smart-match operator> aliases the left-hand side to C<$_>, then evaluates
 the right-hand side and calls C<.ACCEPTS($_)> on it. The semantics are left
 to the type of the right-hand side operand.
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1779,7 +1779,7 @@ also modify the other.
 X<|smartmatch operator>
 =head2 infix C«~~»
 
-The X<smart-match operator> aliases the left-hand side to C<$_>, then evaluates
+The X<smartmatch operator> aliases the left-hand side to C<$_>, then evaluates
 the right-hand side and calls C<.ACCEPTS($_)> on it. The semantics are left
 to the type of the right-hand side operand.
 

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Performance
 
-=SUBTITLE Measuring and improving run-time or compile-time performance
+=SUBTITLE Measuring and improving runtime or compile-time performance
 
 This page is about L<computer performance|https://en.wikipedia.org/wiki/Computer_performance> in the context
 of Perl 6.
@@ -170,10 +170,10 @@ more efficient for that case.
 
 Most L<C<where> clauses|/type/Signature#Type_Constraints> – and thus most
 L<subsets|https://design.perl6.org/S12.html#Types_and_Subtypes> – force dynamic
-(run-time) type checking and call resolution for any call it I<might> match.
+(runtime) type checking and call resolution for any call it I<might> match.
 This is slower, or at least later, than compile-time.
 
-Method calls are generally resolved as late as possible (dynamically at run-time),
+Method calls are generally resolved as late as possible (dynamically at runtime),
 whereas sub calls are generally resolved statically at compile-time.
 
 =head2 Choose better algorithms

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -47,7 +47,7 @@ COMPOSE {...} #  when a role is composed into a class
   CLOSE {...} #  appears in a supply block, called when the supply is closed
 =end code
 
-Phasers marked with a C<*> have a run-time value, and if evaluated earlier than
+Phasers marked with a C<*> have a runtime value, and if evaluated earlier than
 their surrounding expression, they simply save their result for use in the
 expression later when the rest of the expression is evaluated:
 
@@ -72,7 +72,7 @@ but run the statements as a whole at the indicated time:
     ENTER our $random = rand;
 
 (Note, however, that the value of a variable calculated at compile time may not
-persist under run-time cloning of any surrounding closure.)
+persist under runtime cloning of any surrounding closure.)
 
 Most of the non-value-producing phasers may also be so used:
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -819,7 +819,7 @@ Zero-Width Assertions can help you implement your own anchor.
 
 A zero-width assertion turns another regex into an anchor, making
 them consume no characters of the input string. There are two variants:
-look-ahead and look-behind assertions.
+lookahead and lookbehind assertions.
 
 Technically, anchors are also zero-width assertions, and they can look
 both ahead and behind.
@@ -861,7 +861,7 @@ For instance, the following lines all produce the very same result:
     my @ending_letters = <d e f>;
     say 'abcdefg' ~~ rx{ abc <?@ending_letters> };   # OUTPUT: ｢abc｣
 
-A practical use of look-ahead assertions is in substitutions, where
+A practical use of lookahead assertions is in substitutions, where
 you only want to substitute regex matches that are in a certain
 context. For example, you might want to substitute only numbers
 that are followed by a unit (like I<kg>), but not other numbers:
@@ -871,7 +871,7 @@ that are followed by a unit (like I<kg>), but not other numbers:
     s:g[\d+ <?before \s* @units>] = 5 * $/;
     say $_;         # OUTPUT: Please buy 2 packs of sugar, 5 kg each
 
-Since the look-ahead is not part of the match object, the unit
+Since the lookahead is not part of the match object, the unit
 is not substituted.
 
 =head2 X<Lookbehind assertions|regex,after>
@@ -901,7 +901,7 @@ would be matched by
 
     say "fotbar" ~~ / <!after foo> bar /;    # OUTPUT: «bar␤»
 
-These are, as in the case of look-ahead, zero-width assertions which do not I<consume> characters, like here:
+These are, as in the case of lookahead, zero-width assertions which do not I<consume> characters, like here:
 
     say "atfoobar" ~~ / (.**3) .**2 <?after foo> bar /;
     # OUTPUT: «｢atfoobar｣␤ 0 => ｢atf｣␤»

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -112,7 +112,7 @@ example, L<Match> objects support both (each accessing a different set of
 data). Also, to make list processing more convenient, class L<Any> provides a
 fallback implementation for positional subscripts which simply treats the
 invocant as a list of one element. (But there's no such fallback for
-associative subscripts, so they throw a run-time error when applied to an
+associative subscripts, so they throw a runtime error when applied to an
 object that does not implement support for them.)
 
     =begin code

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -604,7 +604,7 @@ See the L<Signatures|/type/Signature> documentation for more about signatures.
     my Int $x = 7;                  # declare the type
     my Int:D $x = 7;                # specify that the value must be defined (not undef)
     my Int $x where { $_ > 3 } = 7; # constrain the value based on a function
-    my Int $x where * > 3 = 7;      # same constraint, but using L<Whatever> short-hand
+    my Int $x where * > 3 = 7;      # same constraint, but using L<Whatever> shorthand
 
 See L<Variable Declarators and
 Scope|/language/variables#Variable_Declarators_and_Scope>

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1056,7 +1056,7 @@ X<|$?FILE>X<|$?LINE>X<|::?CLASS>X<|&?ROUTINE>X<|&?BLOCK>X<|%?LANG>X<|%?RESOURCES
 
 All compile time variables have a question mark as part of the twigil.
 Being I<compile time> they cannot
-be changed at run-time, however they are valuable in order to introspect
+be changed at runtime, however they are valuable in order to introspect
 the program.
 The most common compile time variables are the following:
 

--- a/doc/Type/Variable.pod6
+++ b/doc/Type/Variable.pod6
@@ -8,7 +8,7 @@
 
 Variables have a wealth of compile-time information, but at run time, accesses
 to a variable usually act on the value stored inside the variable, not the
-variable itself. The run-time class of a variable is L<Scalar>.
+variable itself. The runtime class of a variable is L<Scalar>.
 
 Class C<Variable> holds the compile-time information that traits can use to
 introspect and manipulate variables.


### PR DESCRIPTION
Terms fixed: runtime, shorthand, lookahead, lookbehind

## The problem
Looking for handles to solve #761, I have found that file handle appear at least in that form or in the filehandle form. We should try and normalize terminology across all the documents, and this is only an example. When normalization is done, we should turn it into a test later on.

## Solution provided

Changes applied: 
runtime, run-time → runtime
short-hand, shorthand →shorthand
look-ahead, lookahead →lookahead
look-behind, lookbehind →lookbehind

