### PR TITLE
Change use of WHAT to ^name

### DIFF
--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -257,15 +257,15 @@ say $str;           # def
 =end code
 
 While we are talking about C<instanceof>, the equivalent to C<typeof> or the
-C<constructor> property on Node.js objects in Perl 6 is the C<WHAT> attribute:
+C<constructor> property on Node.js objects in Perl 6 is the C<^name> meta-attribute:
 
 =begin code :lang<javascript>
 console.log(typeof 'foo');      // string
 console.log('foo'.constructor); // String
 =end code
 
-=begin code :ok-test<WHAT>
-say 'foo'.WHAT; # (Str)
+=begin code
+say 'foo'.^name; # Str
 =end code
 
 =head3 Numeric


### PR DESCRIPTION
It's the recommended way. WHAT is used to actually get a type object, which isn't what we want. We want the name of the class the object was instantiated from.