### PR TITLE
Add the prefered terms to xt/word-variants.t

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -730,11 +730,11 @@ given $value {
 }
 
 This is simple in the sense that a scalar value is matched in the C<when>
-statements.  More generally, the matches are actually smart-matches on the
+statements.  More generally, the matches are actually smartmatches on the
 input value such that lookups using more complex entities such as regexps
 can be used instead of scalar values.
 
-See also the warnings on the smart-match op above.
+See also the warnings on the smartmatch op above.
 
 =head2 Loops
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -640,7 +640,7 @@ The output can look like this:
     Programmer
     =end code
 
-The first two tests each smart-match against a class name. If the object is
+The first two tests each smartmatch against a class name. If the object is
 of that class, or of an inheriting class, it returns true. So the object in
 question is of class C<Employee> or one that inherits from it, but not
 C<GeekCook>.

--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -68,7 +68,7 @@ In a I<string context>, values can be manipulated as strings. This context is us
 =for code :preamble<my $very-complicated-and-hairy-object>
     say $very-complicated-and-hairy-object; # OUTPUT: something meaningful
 
-Or when smart-matching to a regular expression:
+Or when smartmatching to a regular expression:
 
     say 333444777 ~~ /(3+)/; # OUTPUT: «｢333｣␤ 0 => ｢333｣␤»
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -116,7 +116,7 @@ sub f($x) {
     ...
 }
 
-Subtype checking is done by L<smart-matching|/language/operators#infix_~~>:
+Subtype checking is done by L<smartmatching|/language/operators#infix_~~>:
 
 =for code :preamble<my $type;>
 if $type ~~ Real {

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1783,7 +1783,7 @@ The smartmatch operator aliases the left-hand side to C<$_>, then evaluates
 the right-hand side and calls C<.ACCEPTS($_)> on it. The semantics are left
 to the type of the right-hand side operand.
 
-Here is a partial list of some of the built-in smart-matching functionality. For
+Here is a partial list of some of the built-in smartmatching functionality. For
 full details, see L<ACCEPTS|/routine/ACCEPTS> documentation
 for the type on the right-hand side of the operator.
 
@@ -2295,8 +2295,8 @@ knows about arithmetic and geometric sequences.
     say 2, 4, 6 ... 12;     # OUTPUT: «(2 4 6 8 10 12)␤»
     say 1, 2, 4 ... 32;     # OUTPUT: «(1 2 4 8 16 32)␤»
 
-If the endpoint is not C<*>, it's smart-matched against each generated
-element and the sequence is terminated when the smart-match succeeded.
+If the endpoint is not C<*>, it's smartmatched against each generated
+element and the sequence is terminated when the smartmatch succeeded.
 For the C<...> operator, the final element is included, for the C<...^>
 operator it's excluded.
 

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -606,7 +606,7 @@ it does not allow for an C<elsif> or C<else> clause.
 The Perl 6 C<given>-C<when> construct is like a chain of C<if>-C<elsif>-C<else>
 statements or like the C<case>-C<when> construct in Ruby. A big difference is
 that Ruby uses the C<==> comparison for each condition, but Perl 6 uses the
-more general smart-match C<~~> operator.
+more general smartmatch C<~~> operator.
 
 It has the
 general structure:
@@ -635,7 +635,7 @@ In its simplest form, the construct is as follows:
     }
 
 This is simple in the sense that a scalar value is matched in the C<when>
-statements. More generally, the matches are actually smart-matches on the
+statements. More generally, the matches are actually smartmatches on the
 input value such that lookups using more complex entities such as regexps
 can be used instead of scalar values.
 

--- a/doc/Language/temporal.pod6
+++ b/doc/Language/temporal.pod6
@@ -71,7 +71,7 @@ We will use the date in this variable to find out the period when the files were
 
     Date.new("2018-01-01")..^Date.new("2018-04-01")
 
-creates a date L<Range> and C<$file-changed-date> is smart-matched against it. Dates can be used this way; in this case it creates a C<Range> that excludes its last element.
+creates a date L<Range> and C<$file-changed-date> is smartmatched against it. Dates can be used this way; in this case it creates a C<Range> that excludes its last element.
 
 This very variable is also used to compute the month of the year when the file was modified. L<Date> is obviously C<Dateish> and then has the C<month> method to extract that property from it.
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -954,7 +954,7 @@ C<given $var { ... }> bind to C<$_> by invoking the block.
     say $_ given 'a';       # same, even though it's not a block
 
 C<CATCH> blocks set C<$_> to the exception that was caught. The C<~~>
-smart-match operator sets C<$_> on the right-hand side expression to the
+smartmatch operator sets C<$_> on the right-hand side expression to the
 value of the left-hand side.
 
 Calling a method on C<$_> can be shortened by leaving off the variable name:

--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -437,7 +437,7 @@ Defined as:
 
     method ACCEPTS($other --> Bool:D)
 
-Used in smart-matching if the right-hand side is a C<Baggy>.
+Used in smartmatching if the right-hand side is a C<Baggy>.
 
 If the right-hand side is the type object, i.e. C<Baggy>, the method
 returns C<True> if C<$other> L<does|/routine/does#class_Mu> C<Baggy>

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -871,7 +871,7 @@ Defined as:
     method wordcase(:&filter = &tclc, Mu :$where = True)
 
 Coerces the invocant (or in sub form, the first argument) to L<Str|/type/Str>, and filters each word that
-smart-matches against C<$where> through the C<&filter>. With the default
+smartmatches against C<$where> through the C<&filter>. With the default
 filter (first character to upper case, rest to lower) and matcher (which
 accepts everything), this title-cases each word:
 

--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -497,7 +497,7 @@ Defined as:
     method dir(IO::Path:D: Mu :$test = none('.', '..'))
 
 Returns the contents of a directory as a lazy list of C<IO::Path> objects
-representing relative paths, filtered by L<smart-matching|
+representing relative paths, filtered by L<smartmatching|
 /language/operators#infix_~~> their names (as strings) against the C<:test>
 parameter.
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -330,7 +330,7 @@ Defined as:
     sub    grep(Mu $matcher, *@elems, :$k, :$kv, :$p, :$v --> Seq:D)
     method grep(List:D:  Mu $matcher, :$k, :$kv, :$p, :$v --> Seq:D)
 
-Returns a sequence of elements against which C<$matcher> smart-matches.
+Returns a sequence of elements against which C<$matcher> smartmatches.
 The elements are returned in the order in which they appear in the original
 list.
 
@@ -395,7 +395,7 @@ Defined as:
     sub    first(Mu $matcher, *@elems, :$k, :$kv, :$p, :$end)
     method first(List:D:  Mu $matcher?, :$k, :$kv, :$p, :$end)
 
-Returns the first item of the list which smart-matches against C<$matcher>,
+Returns the first item of the list which smartmatches against C<$matcher>,
 returns C<Nil> when no values match.  The optional named parameter C<:end>
 indicates that the search should be from the B<end> of the list, rather than
 from the start.

--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -87,7 +87,7 @@ Defined as:
     multi method ACCEPTS(Map:D: Regex      $topic)
     multi method ACCEPTS(Map:D: Any        $topic)
 
-Used in smart-matching if the right-hand side is an C<Map>.
+Used in smartmatching if the right-hand side is an C<Map>.
 
 If the topic is list-like (L<Positional>), returns True if
 any of the list elements exist as a key in the Map.

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -122,7 +122,7 @@ ones:
    say 'perl' ~~ 1..*;        # OUTPUT: «True␤»
 
 
-When smart-matching a C<Range> of integers with a L<Cool> (string)
+When smartmatching a C<Range> of integers with a L<Cool> (string)
 the C<ACCEPTS> methods exploits the  L<before|/routine/before>
 and L<after|/routine/after> operators in order to check that
 the C<Cool> value is overlapping the range:

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -140,7 +140,7 @@ and may produce surprising results if used. Also, the code of the C<where> claus
 than once for a single typecheck in some implementations.
 
 The C<where> clause doesn't need to be a code block, anything on the right of the
-C<where>-clause will be used to L<smart-match|/language/operators#infix_~~> the
+C<where>-clause will be used to L<smartmatch|/language/operators#infix_~~> the
 argument against it.  So you can also write:
 
     multi factorial(Int $ where 0) { 1 }
@@ -164,7 +164,7 @@ The first version is wrong and will issue a warning about sub object coerced
 to string. The reason is the expression is equivalent to
 C<($y ~~ ($y.so && $y.name))>; that is "call C<.so>, and if that is C<True>,
 call C<.name>; if that is also C<True> use its value for smartmatching…". It's
-the B<result> of C<(.so && .name)> is will be smart-matched against, but we
+the B<result> of C<(.so && .name)> is will be smartmatched against, but we
 want to check that both C<.so> and C<.name> are truthy values. That is why
 an explicit Block or a L<Junction> is the right version.
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -300,7 +300,7 @@ possibly warning in such situations; e.g. treating C<0.0001> as C<0.001>.
     method grep(Supply:D: Mu $test --> Supply:D)
 
 Creates a new supply that only emits those values from the original supply
-that smart-match against C<$test>.
+that smartmatch against C<$test>.
 
     my $supplier = Supplier.new;
     my $all      = $supplier.Supply;

--- a/xt/word-variants.t
+++ b/xt/word-variants.t
@@ -19,7 +19,11 @@ my %variants = %(
                    "short-hand" => "shorthand",
                    "look-ahead" => "lookahead", 
                    "look-behind" => "lookbehind", 
-                   "smart-match" | "smartmatches" | "smartmatching" | "smartmatched" => "smartmatch", 
+                   "smart-match" => "smartmatch", 
+                   "smart-matches" => "smartmatches",
+                   "smart-matching" => "smartmatching",
+                   "smart-matched" => "smartmatched",
+                   "smart-match" => "smartmatch" 
                );
 plan +@files;
 

--- a/xt/word-variants.t
+++ b/xt/word-variants.t
@@ -13,7 +13,14 @@ Insure any text that mentions Perl uses a no-break space after it.
 
 my @files = Test-Files.pods;
 
-my %variants = %( "file handle" | "file-handle" => "filehandle" );
+my %variants = %( 
+                   "file handle" | "file-handle" => "filehandle",
+                   "run-time" => "runtime",
+                   "short-hand" => "shorthand",
+                   "look-ahead" => "lookahead", 
+                   "look-behind" => "lookbehind", 
+                   "smart-match" => "smartmatch", 
+               );
 plan +@files;
 
 for @files.sort -> $file {
@@ -30,11 +37,11 @@ for @files.sort -> $file {
             }
         }
     }
-    my $error = $file;
+    my $result = $file;
     if !$ok {
-        $error ~= " {@bad.join: ', '})";
+        $result ~= " {@bad.join: ', '}): Certain words should be normalized. ";
     }
-    ok $ok, "$error: Certain words should be normalized." ;
+    ok $ok, "$result" ;
 }
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/xt/word-variants.t
+++ b/xt/word-variants.t
@@ -22,8 +22,7 @@ my %variants = %(
                    "smart-match" => "smartmatch", 
                    "smart-matches" => "smartmatches",
                    "smart-matching" => "smartmatching",
-                   "smart-matched" => "smartmatched",
-                   "smart-match" => "smartmatch" 
+                   "smart-matched" => "smartmatched"
                );
 plan +@files;
 

--- a/xt/word-variants.t
+++ b/xt/word-variants.t
@@ -19,7 +19,7 @@ my %variants = %(
                    "short-hand" => "shorthand",
                    "look-ahead" => "lookahead", 
                    "look-behind" => "lookbehind", 
-                   "smart-match" => "smartmatch", 
+                   "smart-match" | "smartmatches" | "smartmatching" | "smartmatched" => "smartmatch", 
                );
 plan +@files;
 


### PR DESCRIPTION
Change all the smart-match* matches as suggested in #2015
Change xt/word-variants.t to just display the filename an error message when
the test fails

## The problem
Looking for handles to solve #761, I have found that file handle appear at least in that form or in the filehandle form. We should try and normalize terminology across all the documents, and this is only an example. When normalization is done, we should turn it into a test later on.

## Solution provided
Change smart-match -> smartwatch
Add terms in the xt/word-variants.t test



