### PR TITLE
Update Language/regexes.pod6.  Fix confusing sentence about zero-width assertions

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -238,10 +238,10 @@ Examples of word characters:
 
 =end table
 
-Note that the last three character classes are so called zero-width
-assertions, which do not really match a character.
+Note that the character classes C«<same>», C«<wb>» and C«<ww>» are
+so called zero-width assertions, which do not really match a
+character.
 
-X<Unicode character properties>
 =head2 X«Unicode Properties|regex,<:property>»
 
 The character classes mentioned so far are mostly for convenience;


### PR DESCRIPTION
## The problem
In the [Regexes section Predefined Character Classes](https://docs.perl6.org/language/regexes#Predefined_Character_Classes), the sentence after the table of classes incorrectly
identifies the zero width assertions as "the last three" which is not true for any sorting of
the table.  The line after that appears to be a pasto.

## Solution provided

Fix confusing sentence about zero-width assertions included with character classes and remove likely pasto right after.

