### PR TITLE
Fix missing nodejs dependency in the Dockerfile.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,11 +273,11 @@ documentation.
 You can skip all the above and just build and view documentation with these simple commands (if you have docker already installed):
 
     $ docker build -t perl6-doc .
-    $ docker run -p 3000:3000 -it -v `pwd`:/doc perl6-doc
+    $ docker run -p 3000:3000 -it -v `pwd`:/perl6/doc perl6-doc
 
 This will build the documentation for you by default and it will take some time, but for subsequent use you may want to skip build part if nothing has been changed:
 
-    $ docker run -p 3000:3000 -it -v `pwd`:/doc perl6-doc bash -c "perl app.pl daemon"
+    $ docker run -p 3000:3000 -it -v `pwd`:/perl6/doc perl6-doc ./app-start
 
 Now point your web browser to http://localhost:3000 to view the documentation.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,35 @@
 FROM rakudo-star:latest
 
-RUN buildDeps=' \
+RUN buildDeps='         \
         build-essential \
-        cpanminus \
-        npm \
-    ' \
+        cpanminus       \
+    '                   \
     runtimeDeps=' \
-        graphviz \
-        make \
-        nodejs \
+        graphviz  \
+        make      \
         ruby-sass \
-    ' \
+    '             \
     testDeps=' \
         aspell \
     ' \
-
+      \
     && set -x \
+              \
     && apt-get update \
     && apt-get --yes --no-install-recommends install $buildDeps $runtimeDeps $testDeps \
     && rm -rf /var/lib/apt/lists/* \
-
-    && cpanm -vn Mojolicious \
+                                   \
+    && cpanm -vn Mojolicious  \
     && zef install Test::META \
-
-    && ln -s /usr/bin/nodejs /usr/bin/node \
-    && npm cache clean -f \
-    && npm install -g n \
-    && n stable \
-
+                              \
+    && n=/usr/local/bin/n \
+    && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n > "$n" \
+    && chmod +x "$n"      \
+    && n stable           \
+                          \
     && apt-get purge --yes --auto-remove $buildDeps
 
-WORKDIR /perl6/doc/
+WORKDIR /perl6/doc
 EXPOSE  3000
 
-CMD bash -c 'make test && make html && ./app-start'
+CMD make test && make html && ./app-start

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -22,7 +22,7 @@ with a longer name to disambiguate.
 A I<name> is anything that is a legal part of a variable name (not counting the
 sigil). This includes:
 
-=for code
+=begin code
 class Foo {
     sub zape () { say "zipi" }
     class Bar {
@@ -39,6 +39,7 @@ my $bar = 'Bar';
 say $Foo::($bar)::quux; # compound identifiers with interpolations; OUTPUT: «42␤»
 $42;                    # numeric names
 $!;                     # certain punctuation variables
+=end code
 
 X<|::,package>
 C<::> is used to separate nested package names.


### PR DESCRIPTION
 - It appears that the nodejs package no longer exists for the base image
    used by the Dockerfile, and since it's already using the `n` script to
    install the latest stable version of nodejs, I simply use `n` to
    install nodejs in the first place instead.

- Also fixed a small code formatting issue in packages.pod6.

- Corrected the instructions on running the built docker image in CONTRIBUTING.md.


Initially, I was only trying to fix the formatting issue in packages.pod6, but couldn't get
Mojolicious working to be able to preview my changes, so I ended up building a docker
image from the Dockerfile.
