### PR TITLE
Fix p6doc build errors

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -2,6 +2,7 @@
 # need this to install pod under .../share/perl6/doc
 # This fixes p6doc command line use.
 
+use v6;
 use File::Find;
 
 class Build {
@@ -11,7 +12,7 @@ class Build {
         mkdir($dest-pref) unless $dest-pref.d;
 
         my @files = find(dir => "$workdir/doc", type => 'file').list;
-
+        my $copied-all = True;
         for @files -> $file {
             next if $file.basename eq 'HomePage.pod6';
 
@@ -23,7 +24,11 @@ class Build {
             say "Copying {$rel-dest} to {$abs-dest}";
 
             copy($file, $abs-dest);
+            $copied-all = False unless $abs-dest.IO.e;
         }
+
+        # Zef considers the build to have passed only if a truthy value is returned.
+        $copied-all;
     }
     method isa($what) { # Only needed for older panda compatibility
         return True if $what.^name eq 'Panda::Builder';


### PR DESCRIPTION
## The problem
`zef install p6doc` fails after building.

## Solution provided
After looking through zef's code, I found that it considers the build to have passed only if a truthy value is returned, so I made the build method return `True`.
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->


