### PR TITLE
Fix links to NativeCall

### DIFF
--- a/doc/Language/nativetypes.pod6
+++ b/doc/Language/nativetypes.pod6
@@ -22,7 +22,7 @@ Some simple types in Perl 6 have a I<native> representation, indicating that th
 =end table
 
 However, these types do not necessarily have the size that is required by the
-L<NativeCall|/lang/nativecall> interface (e.g., Perl 6's C<int> can be 8 bytes
+L<NativeCall|/language/nativecall> interface (e.g., Perl 6's C<int> can be 8 bytes
 but C's C<int> is only 4 bytes). Instead, the types below will have to be used
 instead of the types C<int> or C<num> listed above.
 
@@ -53,7 +53,7 @@ X<|int8>X<|int16>X<|int32>X<|int64>X<|uint8>X<|uint16>X<|uint32>X<|uint64>X<|num
 What has been mentioned about types with native representation also applies
 here; they will be auto-boxed to Perl 6 types and will not be boundable.
 However, these types, which are listed in the table below, have the
-characteristic of being usable in L<NativeCall> functions.
+characteristic of being usable in L<NativeCall|/language/nativecall#Passing_and_Returning_Values> functions.
 
 =begin table
     int8           (int8_t in C, also used for char)


### PR DESCRIPTION
There is currently no /type/NativeCall page, everything seems to be in /language/nativecall

## The problem
Broken links

## Solution provided
Link to /language/nativecall
