### PR TITLE
Update regexes.pod6 fix reversed suppress capture operators ".&"

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1384,10 +1384,10 @@ called with C«<named-regex>». At the same time, calling a named regex
 installs a named capture with the same name.
 
 To give the capture a different name from the regex, use the syntax
-C«<capture-name=named-regex>». If no capture is desired, a leading dot or
-ampersand will suppress it: C«<.named-regex>» if a regex declared in the same
-lexical context is used, C«<&named-regex>» if it is a method declared in the
-same class or grammar.
+C«<capture-name=named-regex>». If no capture is desired, a leading dot
+or ampersand will suppress it: C«<.named-regex>» if it is a method
+declared in the same class or grammar, C«<&named-regex>» for a regex
+declared in the same lexical context.
 
 Here's more complete code for parsing C<ini> files:
 


### PR DESCRIPTION
## The problem
I believe that an update to fix #2087 reversed the connection between "." for suppressing capture with grammars/methods and "&" to suppress capture with lexical rules.

## Solution provided

Rewrote relevant sentence.
