### PR TITLE
Modify without example

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -302,7 +302,7 @@ As with C<unless>, you may use C<without> to check for undefinedness,
 but you may not add an C<else> clause:
 
     my $answer = Any;
-    without $answer { warn "Got: $_" }
+    without $answer { warn "Got: {$_.perl}" }
 
 There are also C<with> and C<without> statement modifiers:
 


### PR DESCRIPTION
 The update displays the type of `$answer` that seems more useful as an example.

## The problem

If you run the given code you'll get an error about default stringification which seems LTA

## Solution provided

Update the example code to use .perl which seems more useful.
