### PR TITLE
add a page-order config tag to all Language docs

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a01>
 
 =TITLE Perl 5 to Perl 6 guide - In a Nutshell
 

--- a/doc/Language/5to6-overview.pod6
+++ b/doc/Language/5to6-overview.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a02>
 
 =TITLE Perl 5 to Perl 6 guide - Overview
 

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a03>
 
 =TITLE Perl 5 to Perl 6 guide - Functions
 

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a04>
 
 =TITLE Perl 5 to Perl 6 guide - Operators
 

--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a05>
 
 =TITLE Perl 5 to Perl 6 guide - Syntax
 

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a06>
 
 =TITLE Perl 5 to Perl 6 guide - Special Variables
 

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<self>
+=begin pod :tag<self> :page-order<a07>
 
 =TITLE About the Docs
 

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a08>
 
 =TITLE Classes and Objects
 

--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<self>
+=begin pod :tag<self> :page-order<a09>
 
 =TITLE Community
 X<|Community>

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a10>
 
 =TITLE Concurrency
 

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a11>
 
 =TITLE Containers
 

--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a12>
 
 =TITLE Contexts and contextualizers
 

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a13>
 
 =TITLE Control Flow
 

--- a/doc/Language/enumeration.pod6
+++ b/doc/Language/enumeration.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a14>
 
 =TITLE Enumeration
 

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a15>
 
 =TITLE Exceptions
 

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a16>
 
 =TITLE Experimental Features
 

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<index>
+=begin pod :tag<index> :page-order<a17>
 
 =TITLE FAQ
 

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a18>
 
 =TITLE Functions
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<list>
+=begin pod :tag<list> :page-order<a19>
 
 =TITLE Glossary
 

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a20>
 
 =TITLE Grammar Tutorial
 

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a21>
 
 =TITLE Grammars
 

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a22>
 
 =TITLE Hashes and maps
 

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a23>
 
 =TITLE Perl 6 from Haskell - Nutshell
 

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a24>
 
 =TITLE Input/Output The Definitive Guide
 

--- a/doc/Language/io.pod6
+++ b/doc/Language/io.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a25>
 
 =TITLE Input/Output
 

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a26>
 
 =TITLE Inter-Process Communication
 

--- a/doc/Language/iterating.pod6
+++ b/doc/Language/iterating.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a27>
 
 =TITLE Iterating
 

--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a28>
 
 =TITLE Perl 6 from Node.js - Nutshell
 

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a29>
 
 =TITLE Lists, Sequences, and Arrays
 

--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a30>
 
 =TITLE Doing math with Perl 6
 

--- a/doc/Language/module-packages.pod6
+++ b/doc/Language/module-packages.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a31>
 
 =TITLE Module Packages
 

--- a/doc/Language/modules-core.pod6
+++ b/doc/Language/modules-core.pod6
@@ -1,4 +1,4 @@
-=begin pod
+=begin pod :page-order<a32>
 
 =TITLE Core Modules
 

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a33>
 
 =TITLE Module Development Utilities
 

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a34>
 
 =TITLE Modules
 

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a35>
 
 =TITLE Meta-Object Protocol
 

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a36>
 
 =TITLE Native Calling Interface
 

--- a/doc/Language/nativetypes.pod6
+++ b/doc/Language/nativetypes.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a37>
 
 =TITLE Perl 6 native types
 

--- a/doc/Language/newline.pod6
+++ b/doc/Language/newline.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a38>
 
 =TITLE Newline handling in Perl 6
 

--- a/doc/Language/numerics.pod6
+++ b/doc/Language/numerics.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a39>
 
 =TITLE Numerics
 

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a40>
 
 =TITLE Object Orientation
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a41>
 
 =TITLE Operators
 

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a42>
 
 =TITLE Packages
 

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a43>
 
 =TITLE Performance
 

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a44>
 
 =TITLE Phasers
 

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a45>
 
 =TITLE Perl 6 Pod
 

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<index>
+=begin pod :tag<index> :page-order<a46>
 
 =TITLE Pragmas
 

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -1,4 +1,4 @@
-=begin pod
+=begin pod :page-order<a47>
 
 =TITLE Perl 6 from Python - Nutshell
 

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a48>
 
 =TITLE Quoting Constructs
 

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<convert>
+=begin pod :tag<convert> :page-order<a49>
 
 =TITLE Perl 6 from Ruby - Nutshell
 

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a50>
 
 =TITLE Regexes
 

--- a/doc/Language/routines.pod6
+++ b/doc/Language/routines.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a51>
 
 =TITLE Routines
 

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a52>
 
 =TITLE Sets, Bags, and Mixes
 

--- a/doc/Language/structures.pod6
+++ b/doc/Language/structures.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a53>
 
 =TITLE Data structures
 

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a54>
 
 =TITLE Subscripts
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a55>
 
 =TITLE Syntax
 

--- a/doc/Language/system.pod6
+++ b/doc/Language/system.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a56>
 
 =TITLE System interaction
 

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<pod6>
+=begin pod :tag<pod6> :page-order<a57>
 
 =TITLE Pod 6 Tables
 

--- a/doc/Language/temporal.pod6
+++ b/doc/Language/temporal.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a58>
 
 =TITLE Date and time functions
 

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a59>
 
 =TITLE Terms
 

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a60>
 
 =TITLE Testing
 

--- a/doc/Language/traits.pod6
+++ b/doc/Language/traits.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a61>
 
 =TITLE Traits
 

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<index>
+=begin pod :tag<index> :page-order<a62>
 
 =TITLE Traps to avoid
 

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a63>
 
 =TITLE Type system
 

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a64>
 
 =TITLE Unicode
 

--- a/doc/Language/unicode_ascii.pod6
+++ b/doc/Language/unicode_ascii.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<index>
+=begin pod :tag<index> :page-order<a65>
 
 =TITLE Unicode versus ASCII symbols
 

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<tutorial>
+=begin pod :tag<tutorial> :page-order<a66>
 
 =TITLE Entering Unicode Characters
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1,4 +1,4 @@
-=begin pod :tag<perl6>
+=begin pod :tag<perl6> :page-order<a67>
 
 =TITLE Variables
 


### PR DESCRIPTION
## The problem

Languages pages are not sorted in he desired order, and the current sort method, alpha on title,
gives little rational control over the order.

## Solution provided

This commit adds a unique :page-order config tag to better fine-tune the order.  Use
of the tag will require a modification to htmlify.p6.
