### PR TITLE
Do the correct Fahrenheit to Kelvin conversion.

### DIFF
--- a/doc/Type/Real.pod6
+++ b/doc/Type/Real.pod6
@@ -36,7 +36,7 @@ in one of the core numeric types:
         # Note: implementing .new() that handles $value of type Temperature is left as an exercise
 
         method Bridge {
-            when $!unit eq 'F' { ($!value + 459.67) × 9/5 }
+            when $!unit eq 'F' { ($!value + 459.67) × 5/9 }
             when $!unit eq 'C' {  $!value + 273.15 }
             $!value
         }
@@ -52,7 +52,7 @@ in one of the core numeric types:
     my $book  := 451℉;
     my $sun   := 5778K;
     say $human;                # OUTPUT: «36.6 degrees C␤»
-    say $human + $book + $sun; # OUTPUT: «7726.956␤»
+    say $human + $book + $sun; # OUTPUT: «6593.677777777778␤»
     say 123K + 456K;           # OUTPUT: «579␤»
 
 As we can see from the last two lines of the output, the type of the bridged result is not


### PR DESCRIPTION
Fix the Fahrenheit to Kelvin / Celsius factor, and update expected result.

## The problem
Example for Bridge uses the incorrect (inverted) factor for Temperature unit conversion.
The sum (expressed in Kelvin) was obviously wrong.

## Solution provided
Correct the conversion factor, and the example result

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
