### PR TITLE
- Fixes bad link in route page for nativecast.

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -787,7 +787,7 @@ a less specific type to a more specific one.
 As a special case, if a L<Signature|/type/Signature> is supplied as C<$target-type> then
 a C<subroutine> will be returned which will call the native function pointed to by C<$source>
 in the same way as a subroutine declared with the C<native> trait.  This is described in
-L<Function Pointers|#Function_Pointers>.
+L<Function Pointers|/langauge/nativecall#Function_Pointers>.
 
 =head2 sub cglobal
 


### PR DESCRIPTION
## The problem
A potential fix for #2178.
The link to "Function Pointers" in the nativecast page didn't point to the right location.

## Solution provided

This fixes the link, however I was not able to view the change properly due to the app interpreting forward slashes as "$SOLIDUS".