### PR TITLE
revert file names to no number prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SELINUX_OPT          := $(shell [ $(DOCKER_SELINUX_LABEL) -eq 1 ] && echo "$(COL
 
 html: gen-pod6-source bigpage htmlify
 
-htmlify: init-highlights assets
+htmlify: gen-pod6-source init-highlights assets
 	perl6 htmlify.p6
 
 gen-pod6-source:
@@ -38,7 +38,7 @@ assets:
 webdev-build:
 	perl6 htmlify.p6 --no-highlight --sparse=200
 
-bigpage:
+bigpage: gen-pod6-source
 	pod2onepage --html -v --source-path=./build --exclude=404.pod6 > html/perl6.html
 
 # Common tests that are run by travis with every commit
@@ -127,9 +127,13 @@ clean-search:
 clean-build:
 	find build -name "*.pod6" -exec rm -f {} \;
 
-clean: clean-html clean-images clean-search
+remove-build:
+	rm -rf build
 
-distclean: clean
+clean: clean-html clean-images clean-search clean-build
+
+distclean: clean remove-build
+
 
 test-links: links.txt
 	./util/test-links.sh

--- a/util/manage-page-order.p6
+++ b/util/manage-page-order.p6
@@ -58,31 +58,21 @@ sub do-update () {
 
     # FIRST
     # write the auto-generated pod6 files used for the Language page
+    =begin comment
+    # visit later
     write-Language-files();
+    =end comment
 
     # THEN
     # copy all under the doc dir to the build dir
     # NOTE this assumes the sort order is alpha by file name
     # NOTE we exclude the Language dir
+    =begin comment
+    # visit later
     copy-dir-tree(:fromdir('doc'), :todir('build'), :exclude('Language'));
+    =end comment
+    copy-dir-tree :fromdir('doc'), :todir('build');
 }
-
-=begin comment
-sub copy-other-dirs-and-files(*@doc-subdirs) {
-    # The arguments are subdir names under 'doc' and
-    # the complete subdir trees are to be copied as
-    # subdir trees under 'build'.
-
-    for @doc-subdirs -> $sdir {
-        say "DEBUG: working subdir tree '$sdir'" if $debug;
-
-        # recursively copy tree to another tree
-        my $fromdir  = "doc/$sdir"; # complete path
-        my $todir    = "build/$sdir";
-        copy-dir-tree(:$fromdir, :$todir, :$exclude);
-    }
-}
-=end comment
 
 sub copy-dir-tree(:$fromdir, :$todir, :$exclude) {
     # recursively copy tree to another tree
@@ -90,7 +80,7 @@ sub copy-dir-tree(:$fromdir, :$todir, :$exclude) {
 
     say "DEBUG: \$fromdir: '$fromdir', \$exclude: '$exclude'" if $debug;
     # skip some dirs, e.g., Language
-    return if $fromdir ~~ /$exclude/;
+    return if $exclude && $fromdir ~~ /$exclude/;
 
     # create the target dir if need be
     mkdir $todir if !$todir.IO.d;


### PR DESCRIPTION
Keep reorg, but remove number prefixes from transformed files for now.
