### PR TITLE
Xliff patch 20180725

### DIFF
--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1048,6 +1048,7 @@ A version of C<substr> that returns a L<Proxy|/type/Proxy> functioning as a
 writable reference to a part of a string variable. Its first argument, C<$from>
 specifies the index in the string from which a substitution should occur, and
 its last argument, C<$length> specifies how many characters are to be replaced.
+If not specified, C<$length> defaults to the length of the string.
 
 For example, in its method form, if one wants to take the string C<"abc">
 and replace the second character (at index 1) with the letter C<"z">, then

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -1042,7 +1042,7 @@ Also using a different value or an incorrect starting index won't match:
 
 =head2 method substr-rw
 
-    method substr-rw($from, $length?)
+    method substr-rw($from, $length = *)
 
 A version of C<substr> that returns a L<Proxy|/type/Proxy> functioning as a
 writable reference to a part of a string variable. Its first argument, C<$from>


### PR DESCRIPTION
## The problem
The method section for Str#substr-rw did not mention the default value of $length.

## Solution provided
Patch supplies the proper wording, as discussed on IRC, and on the pages for #2187 

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
