### PR TITLE
add missing 'class' keyword for consistency with other types

### DIFF
--- a/doc/Type/X/Method/NotFound.pod6
+++ b/doc/Type/X/Method/NotFound.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE  X::Method::NotFound
+=TITLE class X::Method::NotFound
 
 =SUBTITLE Error due to calling a method that isn't there
 

--- a/doc/Type/X/Parameter/MultipleTypeConstraints.pod6
+++ b/doc/Type/X/Parameter/MultipleTypeConstraints.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE X::Parameter::MultipleTypeConstraints
+=TITLE class X::Parameter::MultipleTypeConstraints
 
 =SUBTITLE Compilation error due to a parameter with multiple type constraints
 

--- a/doc/Type/X/Parameter/WrongOrder.pod6
+++ b/doc/Type/X/Parameter/WrongOrder.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE X::Parameter::WrongOrder
+=TITLE class X::Parameter::WrongOrder
 
 =SUBTITLE Compilation error due to passing parameters in the wrong order
 

--- a/doc/Type/X/Placeholder/Mainline.pod6
+++ b/doc/Type/X/Placeholder/Mainline.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE X::Placeholder::Mainline
+=TITLE class X::Placeholder::Mainline
 
 =SUBTITLE Compilation error due to a placeholder in the mainline
 


### PR DESCRIPTION
## The problem
`X::Method::NotFound`, `X::Parameter::MultipleTypeConstraints`, `X::Parameter::WrongOrder` and `X::Placeholder::Mainline` have no `class` keyword in their `=TITLE`. All other classes do.

## Solution provided
Add `class` keyword in their `=TITLE`
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
