### PR TITLE
mention hyped form of infix assignment ops in traps

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -875,6 +875,12 @@ in mind that C<+=> isn't defined as method on the left hand argument
 Here C<@a> is assigned the result of adding C<@a> (which has three elements)
 and C<10>; C<13> is therefore placed in C<@a>.
 
+Use the L<hyper form|https://docs.perl6.org/language/operators#Hyper_operators>
+of the assignment operators instead:
+
+    my @a = 1, 2, 3;
+    @a »+=» 10;
+    say @a;  # OUTPUT: «[11 12 13]␤»
 
 =head1 Regexes
 


### PR DESCRIPTION
The `Infix operator assignment` section in traps explains the problem but offers no solution. This PR fixes that.