### PR TITLE
Fixes typos in regexes:: Capture Markers

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1136,9 +1136,9 @@ C<\K>.
     say 'abc' ~~ / a <( b )> c/;            # OUTPUT: «｢b｣␤»
     say 'abc' ~~ / <(a <( b )> c)>/;        # OUTPUT: «｢bc｣␤»
 
-As the example above, you can see C«<(» sets the start point and C«)>» sets the
-endpoint; since they are actually independent each other, the inner-most start point
-wins (the one attache to C<b>) and the outer-most end wins (the one attached to C<c>).
+As in the example above, you can see C«<(» sets the start point and C«)>» sets the
+endpoint; since they are actually independent of each other, the inner-most start point
+wins (the one attached to C<b>) and the outer-most end wins (the one attached to C<c>).
 
 =head1 Substitution
 


### PR DESCRIPTION
Three typos fixed.

## The problem
Typos in the paragraph in the Capture Markers section of the regexes document

## Solution provided
Made what I considered to be sensible changes
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
