### PR TITLE
Sentence case for titles/subtitles/heads in Language docs

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - In a nutshell
+=TITLE Perl 5 to Perl 6 guide - in a nutshell
 
 =SUBTITLE How do I do what I used to do? (Perl 6 in a nutshell)
 

--- a/doc/Language/5to6-overview.pod6
+++ b/doc/Language/5to6-overview.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - Overview
+=TITLE Perl 5 to Perl 6 guide - overview
 
 =SUBTITLE How do I do what I used to do?
 
@@ -9,7 +9,7 @@ promotional overview of Perl 6; it is intended as a technical reference
 for Perl 6 learners with a strong Perl 5 background and for anyone
 porting Perl 5 code to Perl 6.
 
-=head1 Perl 6 in a Nutshell
+=head1 Perl 6 in a nutshell
 
 L<Perl 6 in a Nutshell|/language/5to6-nutshell> provides a quick overview of
 things changed in syntax, operators, compound statements, regular expressions,
@@ -36,7 +36,7 @@ also provides references to ecosystem modules that provide the Perl 5 behaviour
 of functions, either existing in Perl 6 with slightly different semantics
 (such as C<shift>), or non-existing in Perl 6 (such as C<tie>).
 
-=head1 Special Variables in Perl 6
+=head1 Special variables in Perl 6
 
 The L<Special Variables section|/language/5to6-perlvar> describes if and how
 a lot of Perl 5's special (punctuation) variables are supported in Perl 6.

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - Functions
+=TITLE Perl 5 to Perl 6 guide - functions
 
 =SUBTITLE Builtin functions in Perl 5 to Perl 6
 
@@ -29,7 +29,7 @@ Also, unless otherwise stated, the use of the term "function" here will mean a
 function in the style of C<func(@args)>, while "method" will refer to a
 function in the style of C<@args.func>.
 
-=head1 Alphabetical Listing of Perl Functions
+=head1 Alphabetical listing of Perl functions
 
 =head2 Filetests
 

--- a/doc/Language/5to6-perlop.pod6
+++ b/doc/Language/5to6-perlop.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - Operators
+=TITLE Perl 5 to Perl 6 guide - operators
 
 =SUBTITLE Operators in Perl 5 to Perl 6: equivalencies and variations
 
@@ -16,14 +16,14 @@ This document is an attempt to guide you from the operators in Perl 5's C<perlo
 document to their equivalents in Perl 6. For full documentation on the Perl 6
 equivalents, please see the L<Perl 6 documentation|/language/operators>.
 
-=head2 Operator Precedence and Associativity
+=head2 Operator precedence and associativity
 
 The operator precedence table is somewhat different in Perl 6 than it is in
 Perl 5, so it will not be detail  here. If you need to know the precedence and
 associativity of a given operator in Perl 6, refer to
 L<Operator Precedence|/language/operators#Operator_Precedence>.
 
-=head2 Terms and List Operators
+=head2 Terms and list operators
 
 The things listed in Perl 5's C<perlop> document as unary and list operators in
 this section tend to be things that can also be thought of as functions, such
@@ -40,7 +40,7 @@ my $scalar = (1);      # *not* a list, as there is no comma
 my $list   = (1,);     # a List in a scalar container
 =end code
 
-=head2 The Arrow Operator
+=head2 The arrow operator
 
 As you typically will not be using references in Perl 6, the arrow is
 probably less useful as a dereferencing operator. If you do need to
@@ -50,7 +50,7 @@ C<$arrayref.[7]> in Perl 6 and, similarly, C<< $user->name >> becomes
 C<$user.name>. The C<< => >> arrow is used for constructing Pairs, see
 L<Pair term documentation|/language/terms#Pair>.
 
-=head2 Auto-increment and Auto-decrement
+=head2 Auto-increment and auto-decrement
 
 Work as in Perl 5. The one possible caveat is that they function by
 calling the C<succ> method for C<++> and the C<pred> method for C<-->.
@@ -65,7 +65,7 @@ Works as you would expect. The caveat in Perl 5's perlop about C<**>
 binding more tightly than unary minus (i. e. "-2**4" evaluates as "-(2**4)"
 rather than "(-2)**4)") is also true for Perl 6.
 
-=head2 Symbolic Unary Operators
+=head2 Symbolic unary operators
 
 As in Perl 5, unary C<!> and C<-> do logical and arithmetic negation,
 respectively. C<?^> is used for bitwise logical negation, which the
@@ -89,7 +89,7 @@ You can get a "reference" to a named subroutine by using the C<&> sigil:
 C<$sref = &foo>.  Anonymous arrays, hashes, and subs return the underlying
 object during creation I<right away>: C<$sref = sub { }>.
 
-=head2 Binding Operators
+=head2 Binding operators
 
 C<=~> and C<!~> have been replaced by C<~~> and C<!~~>, respectively. Those of
 you who consider smartmatching broken in Perl 5 will be happy to hear that it
@@ -97,7 +97,7 @@ works much better in Perl 6, as the stronger typing means less guesswork.
 See L<the smartmatch documentation|language/operators#index-entry-smartmatch_operator>
 for a more extensive explanation of how smartmatch works in Perl 6.
 
-=head2 Multiplicative Operators
+=head2 Multiplicative operators
 
 Binary C<*>, C</>, and C<%> do multiplication, division, and modulo,
 respectively, as in Perl 5.
@@ -107,7 +107,7 @@ C<print '-' x 80;> gives you a string of 80 dashes, but for the Perl 5
 behavior of C<@ones = (1) x 80;> giving you a list of 80 "1"s, you would
 use C<@ones = 1 xx 80;>.
 
-=head2 Additive Operators
+=head2 Additive operators
 
 Binary C<+> and C<-> do addition and subtraction, respectively, as you would
 expect.
@@ -115,20 +115,20 @@ expect.
 As C<.> is the method call operator, so binary C<~> acts as the
 concatenation operator in Perl 6.
 
-=head2 Shift Operators
+=head2 Shift operators
 
 C« << » and C« >> » have been replaced by C<< +< >> and C<< +> >>.
 
-=head2 Named Unary Operators
+=head2 Named unary operators
 
 As noted above, you'll find these in the L<functions|/language/5to6-perlfunc>
 guide.
 
-=head2 Relational Operators
+=head2 Relational operators
 
 These all work as in Perl 5.
 
-=head2 Equality Operators
+=head2 Equality operators
 
 C<==> and C<!=> both work as in Perl 5.
 
@@ -145,7 +145,7 @@ C<~~> is the smartmatch operator as in Perl 5, but it's also I<just>
 the match operator in Perl 6, as noted above. For how smartmatching
 works in Perl 6, see L<the smartmatch documentation|language/operators#index-entry-smartmatch_operator>.
 
-=head2 Smartmatch Operator
+=head2 Smartmatch operator
 
 See L<the smartmatch documentation|language/operators#index-entry-smartmatch_operator>
 for a more extensive explanation of how smartmatch works in Perl 6.
@@ -173,7 +173,7 @@ Remains in Perl 6 as C<//>. Returns the first defined operand, or else
 the last operand. Also, there is a low precedence version, called
 C<orelse>.
 
-=head2 Range Operators
+=head2 Range operators
 
 In list context, C<..> operates as the range operator and should not
 need to be changed. That said, there are exclusionary range operators
@@ -199,7 +199,7 @@ as flip-flop operators, even if they are little-known and probably
 less used. Those operators have been replaced in Perl 6
 by L<ff|/routine/ff> and L<fff|/routine/fff> respectively.
 
-=head2 Conditional Operator
+=head2 Conditional operator
 
 The conditional operator C<? :> has been replaced
 by C<?? !!>:
@@ -209,7 +209,7 @@ $x = $ok  ? $yes  : $no;  # Perl 5
 =for code :preamble<my $x;my $ok;my $yes;my $no>
 $x = $ok ?? $yes !! $no;  # Perl 6
 
-=head2 Assignment Operators
+=head2 Assignment operators
 
 Although not fully documented, S03 indicates that the mathematical and
 logical assignment operators should work as you would expect. The one
@@ -233,7 +233,7 @@ not separated into numeric and string versions (C<&=>, etc., vs. C<&.=>, etc.),
 as that feature is currently experimental in Perl 5 itself - although, again,
 this is not specifically documented.
 
-=head2 Comma Operator
+=head2 Comma operator
 
 The comma operator works mostly as expected, but technically it
 creates L<Lists|/type/List>) or separates arguments in function
@@ -246,7 +246,7 @@ but in Perl 6 constructs Pair objects, rather than just functioning as
 a separator. If you are trying to just literally translate a line of
 Perl 5 code to Perl 6, it should behave as expected.
 
-=head2 List Operators (Rightward)
+=head2 List operators (rightward)
 
 Like the Named Unary Operators, you'll find these discussed under
 L<Functions|/language/5to6-perlfunc>.
@@ -267,7 +267,7 @@ version of C<^^>.
 
 Additionally, there is a low precedence version of C<//>, called C<orelse>.
 
-=head2 Quote and Quote-like Operators
+=head2 Quote and quote-like operators
 
 For all the gory details on quoting constructs, see
 L<quoting|/language/quoting>.
@@ -326,7 +326,7 @@ Similarly, you get escaping and interpolation based on your quoting operator,
 i. e. literals with C<Q>, backslash escapes with C<q>, and interpolation with
 C<qq>.
 
-=head2 I/O Operators
+=head2 I/O operators
 
 The full details on Input/Output in Perl 6 can be found at
 L<io|/language/io>.
@@ -370,7 +370,7 @@ C<1 while foo();> works in the same way as it does in Perl 5, however it
 generates a warning. In Perl 6 the idiom is now written as
 C<Nil while foo();> instead.
 
-=head2 Bitwise String Operators
+=head2 Bitwise string operators
 
 Documented individually above, but to summarize...
 

--- a/doc/Language/5to6-perlsyn.pod6
+++ b/doc/Language/5to6-perlsyn.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - Syntax
+=TITLE Perl 5 to Perl 6 guide - syntax
 
 =SUBTITLE Syntactic differences between Perl 5 and Perl 6
 
@@ -19,7 +19,7 @@ attempt to guide you from how things work in Perl 5 to the equivalents
 in Perl 6. For full documentation on the Perl 6 syntax, please see the
 Perl 6 documentation.
 
-=head1 Free Form
+=head1 Free form
 
 Perl 6 is still I<largely> free form. However, there are a few instances
 where the presence or lack of whitespace is now significant. For
@@ -63,7 +63,7 @@ if #`( why would I ever write an inline comment here? ) True {
 As in Perl 5, you can use pod directives to create multiline comments, with
 C<=begin comment> before and C<=end comment> after the comment.
 
-=head2 Truth and Falsehood
+=head2 Truth and falsehood
 
 The one difference between Perl 5 truth and Perl 6 truth is that,
 unlike Perl 5, Perl 6 treats the string C<"0"> as true. Numeric C<0>
@@ -72,7 +72,7 @@ numeric to get it to be false. Perl 6, additionally has an actual
 Boolean type, so, in many cases, True and False may be available to
 you without having to worry about what values count as true and false.
 
-=head2 Statement Modifiers
+=head2 Statement modifiers
 
 Mostly, statement modifiers still work, with a few exceptions.
 
@@ -84,13 +84,13 @@ In Perl 6, you cannot use the form C<do {...} while $x>. You will want
 to replace C<do> in that form with C<repeat>. Similarly for C<do {...}
 until $x>.
 
-=head2 Compound Statements
+=head2 Compound statements
 
 The big change from Perl 5 is that C<given> is not experimental or disabled by
 default in Perl 6. For the details on C<given> see
 L<this page|/language/control#given>.
 
-=head2 Loop Control
+=head2 Loop control
 
 C<next>, C<last>, and C<redo> have not changed from Perl 5 to Perl 6.
 
@@ -123,20 +123,20 @@ for 1..5 {
 }
 =end code
 
-=head2 For Loops
+=head2 For loops
 
 As noted above, C-style C<for> loops are not called C<for> loops in
 Perl 6. They are just C<loop> loops. To write an infinite loop, you do
 not need to use the C idiom of C<loop (;;) {...}>, but may just omit
 the spec completely: C<loop {...}>
 
-=head2 Foreach Loops
+=head2 Foreach loops
 
 In Perl 5, C<for>, in addition to being used for C-style C<for> loops, is a
 synonym for C<foreach>. In Perl 6, C<for> is just used for C<foreach> style
 loops.
 
-=head2 Switch Statements
+=head2 Switch statements
 
 Perl 6 has actual switch statements, provided by C<given> with the individual
 cases handled by C<when> and C<default>. The basic syntax is:
@@ -173,7 +173,7 @@ for ^10 {
 
 For what is planned for C<goto>, see L<https://design.perl6.org/S04.html#The_goto_statement>.
 
-=head2 The Ellipsis Statement
+=head2 Ellipsis statement
 
 C<...> (along with C<!!!> and C<???>) are used to create stub
 declarations. This is a bit more complicated than the use of C<...> in
@@ -183,7 +183,7 @@ details. That said, there doesn't seem to be an I<obvious> reason why it
 shouldn't still fulfill the role it did in Perl 5, despite its role
 being expanded in Perl 6.
 
-=head2 PODs: Embedded Documentation
+=head2 PODs: embedded documentation
 
 Pod has changed between Perl 5 and Perl 6. Probably the biggest
 difference is that you need to enclose your pod between C<=begin pod>

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Perl 5 to Perl 6 guide - Special Variables
+=TITLE Perl 5 to Perl 6 guide - special variables
 
 =SUBTITLE A comparison of special variables in Perl 5 and Perl 6
 
@@ -21,7 +21,7 @@ please see the Perl 6 documentation for each of them.
 
 X<|Special Variables (Perl 5)>
 
-=head2 General Variables
+=head2 General variables
 
 =item $ARG
 
@@ -534,7 +534,7 @@ Not implemented in Perl 6.
 
 There are no built-in formats in Perl 6.
 
-=head2 Error Variables
+=head2 Error variables
 
 Because of how error variables have changed in Perl 6, they will not be detailed
 here individually.

--- a/doc/Language/concurrency.pod6
+++ b/doc/Language/concurrency.pod6
@@ -768,7 +768,7 @@ C<protect> returns whatever the code block returns.
 Because C<protect> will block any threads that are waiting to execute
 the critical section the code should be as quick as possible.
 
-=head1 Safety Concerns
+=head1 Safety concerns
 
 Some shared data concurrency issues are less obvious than others.
 For a good general write-up on this subject see this L<blog post|https://6guts.wordpress.com/2014/04/17/racing-to-writeness-to-wrongness-leads/>.

--- a/doc/Language/containers.pod6
+++ b/doc/Language/containers.pod6
@@ -315,7 +315,7 @@ Methods generally don't care whether their invocant is in a scalar, so
 
 maps over a list of three elements, not of one.
 
-=head1 Self-Referential Data
+=head1 Self-referential data
 
 Containers types, including C<Array> and C<Hash>, allow you to create
 self-referential structures.
@@ -366,7 +366,7 @@ and C<%> sigiled variables gives the constraint for values:
     my Int %h;
     say %h.VAR.of;  # OUTPUT: «(Int)␤»
 
-=head2 Definedness Constraints
+=head2 Definedness constraints
 
 A container can also enforce a variable to be defined. Put a smiley in the declaration:
 

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Control Flow
+=TITLE Control flow
 
 =SUBTITLE Statements used to control the flow of execution
 

--- a/doc/Language/exceptions.pod6
+++ b/doc/Language/exceptions.pod6
@@ -84,7 +84,7 @@ Note that the match target is a role. To allow user defined exceptions to match
 in the same manner, they must implement the given role. Just existing in the
 same namespace will look alike but won't match in a C<CATCH> block.
 
-=head2  Exception handlers and enclosing blocks
+=head2 Exception handlers and enclosing blocks
 
 After a CATCH has handled the exception, the block enclosing the C<CATCH> block
 is exited.

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Experimental Features
+=TITLE Experimental features
 
 =SUBTITLE New features for brave users
 

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -234,7 +234,7 @@ while target C<ast> gives the AST before that step. To get the full list of
 available targets, run C<perl6 --stagestats -e "">
 
 X<|Precompile (FAQ)>
-=head2 What is Precompilation?
+=head2 What is precompilation?
 
 When you load a module for the first time, Rakudo compiles it into bytecode,
 and both stores it on disk, and uses the compiled bytecode. On subsequent
@@ -264,7 +264,7 @@ dependencies within a single compilation unit (e.g. file) are possible
 through stubbing. Therefore another possible solution is to move
 classes into the same compilation unit.
 
-=head1 Language Features
+=head1 Language features
 
 X<|Data::Dumper (FAQ)>
 =head2 How can I dump Perl 6 data structures
@@ -669,14 +669,14 @@ C<OpaquePointer> is deprecated and has been replaced with C<Pointer>.
 
 L<Identifiers can include colon pairs, which become part of their name|https://docs.perl6.org/language/syntax#Identifiers>. According to L<Larry Wall's answer to the issue|https://github.com/perl6/doc/issues/1753#issuecomment-362875676>, I<We already had the colon pair mechanism available, so it was a no-brainer to use that to extend any name that needs to be able to quote uniquefying but non-standard characters (or other information with a unique stringification to such characters)>.
 
-=head2 How does most people enter Unicode characters?
+=head2 How do most people enter unicode characters?
 
 It depends on the operating system, windowing environment and/or editors. L<This page on entering Unicode characters|/language/unicode_entry> specifies how it is done in the most popular operating systems and editors.
 
 X<|Perl 6 Implementation (FAQ)>
-=head1 Perl 6 Implementation
+=head1 Perl 6 implementation
 
-=head2 What Perl 6 Implementations are available?
+=head2 What Perl 6 implementations are available?
 
 Currently the best developed is Rakudo (using multiple Virtual Machine
 backends). Historic implementations include Niecza (.NET) and Pugs (Haskell).
@@ -702,7 +702,7 @@ bootstrapping files created by earlier runs of the build process.
     (not (not Nil))
 
 X<|Perl 6 Distribution (FAQ)>
-=head1 Perl 6 Distribution
+=head1 Perl 6 distribution
 
 X<|Rakudo Star release cycle (FAQ)>
 =head2 When will the next version of Rakudo Star be released?
@@ -710,7 +710,7 @@ X<|Rakudo Star release cycle (FAQ)>
 A Rakudo Star release is produced usually quarterly.
 See L<rakudo.org About|http://rakudo.org/about/> for more information.
 
-=head1 Meta Questions and Advocacy
+=head1 Meta questions and advocacy
 
 =head2 Why is Perl 6 called Perl?
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Glossary of Perl 6 terminology
 
-=head1 Abstract Class
+=head1 Abstract class
 X<|Abstract Class>
 
 The generic Computer Science term "abstract class" defines the
@@ -19,7 +19,7 @@ using L<roles|#Roles> with L<stubbed|#Stub> methods.
         method bark { say "woof" }   # *MUST* be implemented by class
     }
 
-=head1 Advent Calendar
+=head1 Advent calendar
 X<|Advent Calendar>
 
 In the context of Perl 6, a yearly set of blog posts for each day from
@@ -52,7 +52,7 @@ followed by a name (for the key):
 
 Also see L<#Colon Pair and Colon List>.
 
-=head1 Adverbial Pair
+=head1 Adverbial pair
 X<|Adverbial Pair>
 
 A generalized form of C<pair notation>.  They all start with the colon, like:
@@ -246,7 +246,7 @@ X<|Camelia>
 
 A butterfly image intended primarily to represent Perl 6, The Language.
 
-=head1 Colon Pair and Colon List
+=head1 Colon pair and colon list
 X<|Colon Pair> X<|Colon List>
 
 A colon pair is a shorthand syntax used to create or visually present
@@ -441,7 +441,7 @@ Some L<#IRC> clients then easily allow you to copy/paste the codepoint in
 question, which can be sometimes be easier than other unicode codepoint
 input methods.
 
-=head1 IRC Lingo
+=head1 IRC lingo
 
 The following terms are often used on the Perl 6 related L<#IRC> channels:
 
@@ -796,7 +796,7 @@ AST from the parse subtree.
         <O('%conditional, :reducecheck<ternary>, :pasttype<if>')>
 
 
-=head1 Parse Tree
+=head1 Parse tree
 X<|Parse Tree>
 
 A L<parse tree|https://en.wikipedia.org/wiki/Parse_tree> represents the structure of a string or sentence according to a grammar. L<Grammar>s in Perl 6 output parse trees when they successfully match a string.
@@ -971,7 +971,7 @@ Also sigiled variables allow short conventions for L<variable
 interpolation|#Variable Interpolation> in a double quoted string, or even
 postcircumfix expressions starting with such a variable.
 
-=head1 Sigilless Variable
+=head1 Sigilless variable
 X<|Sigilless Variable>
 
 L<Sigilless variables|/language/variables#index-entry-\_(sigilless_variables)> are actually aliases to the value it is assigned to them, since they are not containers. Once you assign a sigilless variable (using the escape C<\>), its value cannot be changed.
@@ -1021,7 +1021,7 @@ by L<#roast>, its L<#test suite>, not the synopses where speculative material
 is not always so flagged or more recent additions have not been documented.
 This is even more true of material that has not been yet implemented.
 
-=head1 Syntax Analysis
+=head1 Syntax analysis
 X<|Syntax Analysis>
 
 A syntax or syntactic analysis is equivalent to L<parsing|https://en.wikipedia.org/wiki/Parsing> a string to generate its L<Parse Tree>.
@@ -1116,7 +1116,7 @@ X<|Variable>
 
 A variable is a name for a L<container|/language/containers>.
 
-=head1 Variable Interpolation
+=head1 Variable interpolation
 X<|Variable Interpolation>
 
 The value of variables is interpolated into strings by simply inserting that variable into the string:
@@ -1131,7 +1131,7 @@ This might need curly braces in case it precedes some alphanumeric characters
 
 Interpolation occurs in L<string context|/language/contexts#String>, so a valid stringification method must exist for the class. More general interpolation can be achieved using the L<double q|/language/quoting#Interpolation:_qq> quoting constructs.
 
-=head1 Virtual Machine
+=head1 Virtual machine
 X<|Virtual Machine>
 
 A virtual machine is the Perl compiler entity that executes the

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -1,10 +1,10 @@
 =begin pod :tag<tutorial>
 
-=TITLE Grammar Tutorial
+=TITLE Grammar tutorial
 
 =SUBTITLE An introduction to grammars
 
-=head1 Before We Start
+=head1 Before we start
 
 =head2 Why grammars?
 
@@ -35,7 +35,7 @@ When working with HTML, you could define a grammar to recognize HTML tags, both
 the opening and closing elements, and the text in between. You could then
 organize these elements into data structures, such as arrays or hashes.
 
-=head1 Getting More Technical
+=head1 Getting more technical
 
 =head2 The conceptual overview
 
@@ -105,7 +105,7 @@ the grammar parse will fail and we'll get an empty match. This is great for
 recognizing a malformed string that should be discarded.
 
 
-=head1 Learning By Example - a REST Contrivance
+=head1 Learning by example - a REST contrivance
 
 Let's suppose we'd like to parse a URI into the component parts that make up a
 RESTful request. We want the URIs to work like this:
@@ -416,7 +416,7 @@ The I<data> token returns the entire end of the URI as one string. The 4 is
 fine. However from the '7/notify', we only want the 7. To get just the 7,
 we'll use another feature of grammar classes: I<actions>.
 
-=head1 Grammar Actions
+=head1 Grammar actions
 
 Grammar actions are used within grammar classes to do things with matches.
 Actions are defined in their own classes, distinct from grammar classes.

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Working with associative arrays/dictionaries/hashes
 
-=head1 The Associative role and associative classes
+=head1 The associative role and associative classes
 
 The L<Associative> role underlies hashes and maps, as well as other classes such
 as L<MixHash>. It defines the two types that will be used in associative

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -1,8 +1,8 @@
 =begin pod :tag<convert>
 
-=TITLE Haskell to Perl 6 - Nutshell
+=TITLE Haskell to Perl 6 - nutshell
 
-=SUBTITLE Learning Perl 6 from Haskell, in a nutshell: What do I already know?
+=SUBTITLE Learning Perl 6 from Haskell, in a nutshell: what do I already know?
 
 Haskell and Perl 6 are I<very> different languages. This is obvious.
 However, that does not mean there are not similarities or shared ideas!
@@ -17,7 +17,7 @@ strong Haskell background.
 
 =head1 Types
 
-=head2 Types vs Values
+=head2 Types vs values
 
 In Haskell, you have type level programming and then value level programming.
 
@@ -133,7 +133,7 @@ TODO: include a better example for andthen that makes sense. Maybe using promise
 
 So in practice, Perl 6 does not have the concept of a null type, but rather of defined or undefined types.
 
-=head2 Data Definitions
+=head2 Data definitions
 
 Perl 6 is fundamentally an Object Oriented language. However, it also gives you the freedom
 to write in virtually any paradigm you wish. If you only want to pure functions that take an
@@ -184,7 +184,7 @@ constraints on types.
     say test-animal Horse;
     =end code
 
-=head2 Type Aliases and Subsets
+=head2 Type aliases and subsets
 
 In Haskell, you can alias an existing type to simply increase clarity of intent and re-use
 existing types.
@@ -225,7 +225,7 @@ explain how Perl 6 roles compare to Haskell typeclasses
 
 =head1 Functions
 
-=head2 Definitions and Signatures
+=head2 Definitions and signatures
 
 =Pattern Matching
 
@@ -332,7 +332,7 @@ TODO
 
 show function composition operator. Maybe explain a more perl6ish way to do this though.
 
-=head1 Case / Matching
+=head1 Case / matching
 
 Haskell makes heavy use of case matching like the below:
 
@@ -368,7 +368,7 @@ to the C<@> sigil. Explain how you can convert an Array to a flattened list of o
 
 data shapes become quite intuitive, but it takes a bit of practice.
 
-=head2 List Comprehensions
+=head2 List comprehensions
 
 There are no explicit list comprehensions in Perl6. But rather, you can achieve list comprehensions
 a couple of different ways.
@@ -496,7 +496,7 @@ Haskell and Perl 6 both allow you to specify ranges of values.
     my $range3 = 'a'..'h';  # Letters work too
     =end code
 
-=head2 Laziness vs Eagerness
+=head2 Laziness vs eagerness
 
 In the examples above, you have the concept of laziness displayed very plainly. Perl 6 has laziness
 only where it makes the most sense. For example, in the range 10..100, this is eager because it has
@@ -525,7 +525,7 @@ compare it to let/in and where constructs maybe?
 
 =head1 Parsers
 
-=head2 Parser Combinators vs Grammars
+=head2 Parser combinators vs grammars
 
 TODO
 

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -1,10 +1,10 @@
 =begin pod :tag<perl6>
 
-=TITLE Input/Output The Definitive Guide
+=TITLE Input/Output the definitive guide
 
 =SUBTITLE Correctly use Perl 6 IO
 
-=head1 The Basics
+=head1 The basics
 
 The vast majority of common IO work is done by the L<IO::Path> type. If you
 want to read from or write to a file in some form or shape, this is the class
@@ -29,9 +29,9 @@ functional programming style or in Perl 6 one liners.
 While L<IO::Socket> and its subclasses also have to do with Input and Output,
 this guide does not cover them.
 
-=head1 Navigating Paths
+=head1 Navigating paths
 
-=head2 What's an IO::Path Anyway?
+=head2 What's an IO::Path anyway?
 
 To represent paths as either files or directories, use L<IO::Path> type.
 The simplest way to obtain an object of that type is to coerce a L<Str> by
@@ -60,7 +60,7 @@ However, don't be in a rush to stringify anything. Pass paths around as
 L<IO::Path|/type/IO::Path> objects. All the routines that operate on paths
 can handle them, so there's no need to convert them.
 
-=head2 Working with Files
+=head2 Working with files
 
 =head3 Writing into files
 
@@ -212,11 +212,11 @@ L«C<will leave> trait|/language/phasers#index-entry-will_trait», or the
 C<does auto-close> trait provided by the
 L«C<Trait::IO>|https://modules.perl6.org/dist/Trait::IO» module.
 
-=head1 The Wrong Way To Do Things
+=head1 The wrong way to do things
 
 This section describes how NOT to do Perl 6 IO.
 
-=head2 Leave $*SPEC Alone
+=head2 Leave $*SPEC alone
 
 You may have heard of L«C<$*SPEC>|/language/variables#Dynamic_variables» and
 seen some code or books show its usage for splitting and joining path fragments.

--- a/doc/Language/ipc.pod6
+++ b/doc/Language/ipc.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Inter-Process Communication
+=TITLE Inter-process communication
 
 =SUBTITLE Programs running other programs and communicating with them
 

--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<convert>
 
-=TITLE Javascript (Node) to Perl 6 - Nutshell
+=TITLE Javascript (Node) to Perl 6 - nutshell
 
 =SUBTITLE Learning Perl 6 from Node.js, in a nutshell
 

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Lists, Sequences, and Arrays
+=TITLE Lists, sequences, and arrays
 
 =SUBTITLE Positional data constructs
 
@@ -10,7 +10,7 @@ were actually one of the hardest parts of Perl 6 to design, but through
 persistence and patience, Perl 6 has arrived with an elegant system for handling
 them.
 
-=head1 Literal Lists
+=head1 Literal lists
 
 Literal L<C<List>s|/type/List> are created with commas and semicolons B<not>
 with parentheses, so:
@@ -98,7 +98,7 @@ value must support the L<Positional|/type/Positional> role which guarantees that
 
 
 
-=head1 Reset a List Container
+=head1 Reset a list container
 
 To remove all elements from a Positional container assign
 L<C<Empty>|/type/Slip#Empty>, the empty list C<()> or a C<Slip> of the empty
@@ -150,7 +150,7 @@ for @list -> @element {
 
 Since what C<for> receives is a single argument, it will be treated as a list of elements to iterate over. The rule of thumb is that L<if there's a comma, anything preceding it is an element|https://perl6advent.wordpress.com/2015/12/14/day-15-2015-the-year-of-the-great-list-refactor/> and the list thus created becomes the I<single element>. That happens in the case of the two arrays separated by a comma which are the third in the C<Array> we are iterating. In general, quoting the article linked above, the single argument rule I<... makes for behave as the programmer would expect>.
 
-=head1 Testing for Elements
+=head1 Testing for elements
 
 To test for elements in a C<List> or C<Array>, you can use the
 L<"is element of"|https://docs.perl6.org/language/setbagmix#infix_(elem)>
@@ -313,12 +313,12 @@ that is, it is only the list structure itself – how many elements there are
 and each element's identity – that is immutable.  The immutability is not
 contagious past the identity of the element.
 
-=head1 List Contexts
+=head1 List contexts
 
 So far we have mostly dealt with lists in neutral contexts.  Lists are actually
 very context sensitive on a syntactical level.
 
-=head2 List Assignment Context
+=head2 List assignment context
 
 When a list appears on the right-hand side of an assignment into a C<@>-sigiled
 variable, it is "eagerly" evaluated.  This means that a C<Seq> will be iterated
@@ -352,7 +352,7 @@ flattening:
     my @a = 2, (3, 4);                 # Arrays are special, see below
     for (1, @a, 5).flat { .say };      # OUTPUT: «1␤2␤(3 4)␤5␤»
 
-=head2 Argument List (Capture) Context
+=head2 Argument list (Capture) context
 
 When a list appears as arguments to a function or method call, special
 syntax rules are at play: the list is immediately converted into a
@@ -389,7 +389,7 @@ as named parameters:
     my %a = "c" => 3;
     Array.new(1, |%a, 4);    # Array contains 1, 4
 
-=head2 Slice Indexing Context
+=head2 Slice indexing context
 
 From the perspective of the C<List> inside a L<slice subscript|/language/subscripts#Slices>,
 is only remarkable in that it is unremarkable: because
@@ -421,7 +421,7 @@ Slices can be taken also across several dimensions using I<semilists>, which are
 
 which is selecting the 4 to 6th element from the three  first dimensions (C<^3>).
 
-=head2 Range as Slice
+=head2 Range as slice
 
 A L<C<Range>|/type/Range> is a container for a lower and a upper boundary.
 Generating a slice with a C<Range> will include any index between those bounds,
@@ -435,7 +435,7 @@ mathematicians that C<Inf> equals C<Inf-1>.
     say @a[0..^*];    # OUTPUT: «(1 2 3 4 5)␤»
     say @a[0..Inf-1]; # OUTPUT: «(1 2 3 4 5)␤»
 
-=head2 Array Constructor Context
+=head2 Array constructor context
 
 Inside an Array Literal, the list of initialization values is not in capture
 context and is just a normal list.  It is, however, eagerly evaluated just as
@@ -550,7 +550,7 @@ an undefined C<Any>:
     @n.default.perl.say;            # OUTPUT: «Real␤»
     @n[0].say;                      # OUTPUT: «(Real)␤»
 
-=head2 Fixed Size Arrays
+=head2 Fixed size arrays
 
 To limit the dimensions of an C<Array> provide the dimensions separated by C<,>
 or C<;> in brackets after the name of the array container. The values of such
@@ -631,7 +631,7 @@ is more a gentleman's agreement than a universally enforced rule, and it is
 less well enforced that typechecks in typed arrays.  See the section below
 on binding to Array slots.
 
-=head2 Literal Arrays
+=head2 Literal arrays
 
 Literal Arrays are constructed with a List inside square brackets.  The List is
 eagerly iterated (at compile time if possible) and values in the list are each

--- a/doc/Language/module-packages.pod6
+++ b/doc/Language/module-packages.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Module Packages
+=TITLE Module packages
 
 =SUBTITLE Creating module packages for code reuse
 

--- a/doc/Language/modules-core.pod6
+++ b/doc/Language/modules-core.pod6
@@ -7,7 +7,7 @@
 The Rakudo implementation has a few modules included you may want to use. The
 following is a list of them, along with links to their source code.
 
-=head2 C<CompUnit::*> modules and Roles
+=head2 C<CompUnit::*> modules and roles
 X<|CompUnit (Rakudo classes)>
 
 These modules are mostly used by distribution build tools, and are not intended

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<tutorial>
 
-=TITLE Module Development Utilities
+=TITLE Module development utilities
 
 =SUBTITLE What can help you write/test/improve your module(s)
 
@@ -9,7 +9,7 @@ which aim to make the experience of developing Perl 6 modules
 more fun.
 
 
-=head1 Module builder and Authoring tools
+=head1 Module builder and authoring tools
 
 Some modules and tools to help you with generating files that are part
 of a module distribution.
@@ -30,7 +30,7 @@ Some tests of module quality.
 =item L<Test::Screen|https://modules.perl6.org/dist/Proc::Screen>  Use B<GNU screen> to test full screen VT applications
 =item L<Test::When|https://modules.perl6.org/dist/Test::When>  Control when your tests are run (author testing, online testing, etc.)
 
-=head1 NativeCall
+=head1 NativECall
 
 Here some modules to help you work with NativeCall.
 

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE How to create, use and distribute Perl 6 modules
 
-=head1 Creating and Using Modules
+=head1 Creating and using modules
 
 A module is usually a source file or set of source files
 N<Technically a module is a set of I<compunits> which are usually files but could come from anywhere as long as there is a I<compunit repository> that can provide it. See L<S11|https://design.perl6.org/S11.html>.>
@@ -34,7 +34,7 @@ will return a list of modules that includes WWW in their name, for instance. The
 will install the module with that particular name, if it is not already installed.
 
 
-=head2 Basic Structure
+=head2 Basic structure
 
 Module distributions (in the I<set of related source files> sense) in Perl 6
 have the same structure as any distribution in the Perl family of languages:
@@ -50,7 +50,7 @@ Source files generally use the C<.pm6> extension, and scripts or
 executables use the C<.p6>. Test files use the C<.t> extension. Files which contain documentation use the C<.pod6> extension.
 
 X<|compunit>
-=head2 Loading and Basic Importing
+=head2 Loading and basic importing
 
 Loading a module makes the packages in the same namespace declared
 within available in the file scope of the loader. Importing from a
@@ -216,7 +216,7 @@ So if you suddenly get an "Undeclared name: Bar" error message after upgrading
 to a newer Perl 6 compiler, you will most probably just need to add a: "use
 Bar;" to your code.
 
-=head2 Exporting and Selective Importing
+=head2 Exporting and selective importing
 
 =head3 is export
 
@@ -483,7 +483,7 @@ export sub:
     unit module Bar;
 =end code
 
-=head2 Finding Modules
+=head2 Finding modules
 
 It is up to the module installer to know where C<compunit> expects modules to
 be placed. There will be a location provided by the distribution and in the
@@ -510,7 +510,7 @@ The include path will be searched recursively for any modules when Rakudo is
 started. Directories that start with a dot are ignored and symlinks are
 followed.
 
-=head1 Distributing Modules
+=head1 Distributing modules
 
 If you've written a Perl 6 module and would like to share it with the
 community, we'd be delighted to have it listed in the L<Perl 6 modules directory|https://modules.perl6.org>. C<:)>
@@ -530,7 +530,7 @@ capability for versioning.
 The process of sharing your module consists of two steps, preparing the module
 and uploading the module to one of the ecosystems.
 
-=head2 Preparing the Module
+=head2 Preparing the module
 
 For a module to work in any of the ecosystems, it needs to follow a certain
 structure. Here is how to do that:
@@ -703,7 +703,7 @@ zef install ./your-module-folder
 
 =end item
 
-=head2 Upload your Module to CPAN
+=head2 Upload your module to CPAN
 
 Uploading a module to CPAN is the preferred way of distributing Perl 6 modules.
 
@@ -744,7 +744,7 @@ L<Upload a file to CPAN|https://pause.perl.org/pause/authenquery?ACTION=add_uri>
 
     =end item
 
-=head2 Upload your Module to p6c
+=head2 Upload your module to p6c
 
 If you want to use the I<p6c> ecosystem you need to use git for your module's
 version control. The instructions herein assume that you have a
@@ -791,12 +791,12 @@ To use C<Vortex::TotalPerspective> from your scripts, just write
 C<use Vortex::TotalPerspective>, and your Perl 6 implementation will
 know where to look for the module file(s).
 
-=head1 Modules and Tools Related to Module Authoring
+=head1 Modules and tools related to module authoring
 
 You can find a list of modules and tools that aim to improve the experience of
 writing/test modules at L<Modules Extra|/language/modules-extra>
 
-=head2 Contact Information
+=head2 Contact information
 
 To discuss module development in general, or if your module would
 fill a need in the ecosystem, naming, etc., you can use the

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -1,6 +1,6 @@
 =begin pod :tag<perl6>
 
-=TITLE Meta-Object Protocol
+=TITLE Meta-object protocol
 
 =SUBTITLE Introspection and the Perl 6 object system
 
@@ -176,7 +176,7 @@ the method resolution order, publish a method cache, and other house-keeping
 tasks. Meddling with types after they have been composed is sometimes
 possible, but usually a recipe for disaster. Don't do it.
 
-=head2 Power and Responsibility
+=head2 Power and responsibility
 
 The meta object protocol offers much power that regular Perl 6 code
 intentionally limits, such as calling private methods on classes that don't
@@ -190,7 +190,7 @@ obviously be bugs.
 
 So be extra careful and thoughtful when writing meta types.
 
-=head2 Power, Convenience and Pitfalls
+=head2 Power, convenience and pitfalls
 
 The meta object protocol is designed to be powerful enough to implement the
 Perl 6 object system. This power occasionally comes at the cost of convenience.

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -1,10 +1,10 @@
 =begin pod :tag<perl6>
 
-=TITLE Native Calling Interface
+=TITLE Native calling interface
 
 =SUBTITLE Call into dynamic libraries that follow the C calling convention
 
-=head1 Getting Started
+=head1 Getting started
 
 X<|nativecall>
 
@@ -52,7 +52,7 @@ creating a module called Foo and we'd rather call the routine as C<Foo::init>,
 we use the C<symbol> trait to specify the name of the symbol in C<libfoo>
 and call the subroutine whatever we want ("init" in this case).
 
-=head1 Passing and Returning Values
+=head1 Passing and returning values
 
 Normal Perl 6 signatures and the C<returns> trait are used in order to convey
 the type of arguments a native function expects and what it returns. Here is
@@ -134,7 +134,7 @@ exactly the kind of pointer C<clock_gettime> expects. This way, data can be
 transferred seamlessly to and from the native interface.
 
 
-=head1 Basic use of Pointers
+=head1 Basic use of pointers
 
 When the signature of your native function needs a pointer to some native type
 (C<int32>, C<uint32>, etc.) all you need to do is declare the argument C<is rw> :
@@ -200,7 +200,7 @@ better type safety and more readable code.
 
 Once again, type objects are used to represent NULL pointers.
 
-=head1 Function Pointers
+=head1 Function pointers
 
 C libraries can expose pointers to C functions as return values of functions and as
 members of Structures like, e.g., structs and unions.
@@ -439,7 +439,7 @@ class MyStruct2 is repr('CStruct') {
 say nativesizeof(MyStruct2.new);  # 24, ie. sizeof(struct Point) + sizeof(int32_t)
 =end code
 
-=head2 Notes on Memory management
+=head2 Notes on memory management
 
 When allocating a struct for use as a struct, make sure that you allocate your
 own memory in your C functions. If you're passing a struct into a C function
@@ -447,7 +447,7 @@ which needs a C<Str>/C<char*> allocated ahead of time, be sure to assign a
 container for a variable of type C<Str> prior to passing your struct into the
 function.
 
-=head3 In your Perl6 code...
+=head3 In your Perl 6 code...
 
 =begin code :skip-test
 
@@ -507,7 +507,7 @@ say "foo is {$foo.a_string} and {$foo.an_int32}";
 # OUTPUT: «foo is str and 123␤»
 =end code
 
-=head1 Typed Pointers
+=head1 Typed pointers
 
 You can type your C<Pointer> by passing the type as a parameter. It works with
 the native type but also with C<CArray> and C<CStruct> defined types. NativeCall
@@ -659,7 +659,7 @@ Note: the native code is responsible for memory management of values passed to
 Perl 6 callbacks this way. In other words, NativeCall will not free() strings passed
 to callbacks.
 
-=head1 Library Paths and Names
+=head1 Library paths and names
 
 The C<native> trait accepts the library name, the full path, or a subroutine
 returning either of the two. When using the library name, the name is assumed
@@ -695,7 +695,7 @@ that depends on a dynamic variable like:
 This will keep the value given at compile time. A module will be precompiled and C<LIBMYSQL> will
 keep the value it acquires when the module gets precompiled.
 
-=head2 ABI/API Version
+=head2 ABI/API version
 
 If you write C<native('foo')> NativeCall will search libfoo.so under Unix like system (libfoo.dynlib on OS X, foo.dll on win32).
 In most modern system it will require you or the user of your module to install
@@ -762,14 +762,14 @@ redirects all its accesses to the integer variable named "errno" as
 exported by the "libc.so.6" library.
 
 
-=head1 C++ Support
+=head1 C++ support
 
 NativeCall offers support to use classes and methods from C++ as shown in
 L<https://github.com/rakudo/rakudo/blob/master/t/04-nativecall/13-cpp-mangling.t>
 (and its associated C++ file).
 Note that at the moment it's not as tested and developed as C support.
 
-=head1 Helper Functions
+=head1 Helper functions
 
 The C<NativeCall> library exports several subroutines to help you work with
 data from native libraries.
@@ -859,7 +859,7 @@ sub MessageBoxA(int32, Str, Str, int32)
 MessageBoxA(0, "We have NativeCall", "ohai", 64);
 =end code
 
-=head2 Short Tutorial on calling a C function
+=head2 Short tutorial on calling a C function
 
 This is an example for calling a standard function and using the returned
 information in a Perl 6 program.

--- a/doc/Language/numerics.pod6
+++ b/doc/Language/numerics.pod6
@@ -240,7 +240,7 @@ sub infix:<🙼> { FatRat.new: $^a, $^b }
 say (1🙼3).perl; # OUTPUT: «FatRat.new(1, 3)␤»
 =end code
 
-=head2 Printing Rationals
+=head2 Printing rationals
 
 Keep in mind that output routines like L<say> or L<put> do not try very hard to
 distinguish between how L<Numeric> types are output and may choose to display
@@ -264,7 +264,7 @@ say ⅓.perl;     # OUTPUT: «<1/3>␤»
 say <4/2>.nude; # OUTPUT: «(2 1)␤»
 =end code
 
-=head1 Division By Zero
+=head1 Division by zero
 
 In many languages division by zero is an immediate exception. In Perl 6, what
 happens depends on what you're dividing and how you use the result.
@@ -285,7 +285,7 @@ when you're dividing by zero). This means such division never produces
 an L<Exception> or a L<Failure>. The result is a Zero-Denominator Rational,
 which can be explosive.
 
-=head2 Zero-Denominator Rationals
+=head2 Zero-denominator rationals
 
 A Zero-Denominator Rational is a numeric that does role L<Rational>, which
 among core numerics would be L<Rat> and L<FatRat> objects, which
@@ -364,7 +364,7 @@ brackets. The same isn't true for operator-using numbers as some constructs,
 such as signature literals, do not let you use operators, so you can't just omit
 angle brackets for such numeric literals).
 
-=head2 Available Allomorphs
+=head2 Available allomorphs
 
 The core language offers the following allomorphs:
 
@@ -381,7 +381,7 @@ The core language offers the following allomorphs:
 
 Note: there is no C<FatRatStr> type.
 
-=head2 Coercion of Allomorphs
+=head2 Coercion of allomorphs
 
 Keep in mind that allomorphs are simply subclasses of the two (or three) types they represent. Just
 as a variable or parameter type-constrained to C<Foo> can accept any subclass of C<Foo>, so will
@@ -429,7 +429,7 @@ say map *.^name, +«<42 50e0 100>;  # OUTPUT: «(Int Num Int)␤»
 say map *.^name, ~«<42 50e0 100>;  # OUTPUT: «(Str Str Str)␤»
 =end code
 
-=head2 Object Identity
+=head2 Object identity
 
 The above discussion on coercing allomorphs becomes more important when we consider object
 identity. Some constructs utilize it to ascertain whether two objects are "the same". And while
@@ -462,7 +462,7 @@ say 42 ∈ +«<42 100 200>; # OUTPUT: «True␤»
 
 Be mindful of these object identity differences and coerce your allomorphs as needed.
 
-=head1 Native Numerics
+=head1 Native numerics
 
 As the name suggests, native numerics offer access to native numerics—i.e. those offered directly
 by your hardware. This in turn offers two features: overflow/underflow and better performance.
@@ -471,7 +471,7 @@ B<NOTE:> at the time of this writing (2018.05), certain implementations (such as
 somewhat spotty details on native types, such as whether C<int64> is available and is of 64-bit
 size on 32-bit machines, and how to detect when your program is running on such hardware.
 
-=head2 Available Native Numerics
+=head2 Available native numerics
 
 =begin table
 
@@ -507,7 +507,7 @@ size on 32-bit machines, and how to detect when your program is running on such 
 
 =end table
 
-=head2 Creating Native Numerics
+=head2 Creating native numerics
 
 To create a natively-typed variable or parameter, simply use the name of one of the available
 numerics as the type constraint:
@@ -608,7 +608,7 @@ my int $a-native = -42;
 { for ^1000_000 { abs $a-native }; say now - ENTER now } # OUTPUT: «0.3088305␤»
 =end code
 
-=head2 Default Values
+=head2 Default values
 
 Since there are no classes behind native types, there are no type objects you'd
 normally get with variables that haven't been initialized. Thus, native types
@@ -617,7 +617,7 @@ types (C<num>, C<num32>, and C<num64>) are initialized to value C<NaN>; in 6.d l
 the default is C<0e0> (early implementation available in Rakudo 2018.08, under C<use v6.d.PREVIEW>
 pragma).
 
-=head2 Native Dispatch
+=head2 Native dispatch
 
 It is possible to have native candidates alongside non-native candidates to, for example,
 offer faster algorithms with native candidates when sizes are predictable, but to fallback
@@ -686,7 +686,7 @@ This way you do not have to constantly write, for example, C«$n +> 2» as C«$n
 (my int $ = 2)». The compiler knows the literal is small enough to fit to a
 native type and converts it to a native.
 
-=head2 Atomic Operations
+=head2 Atomic operations
 
 The language offers L<some operations|https://docs.perl6.org/type/atomicint>
 that are guaranteed to be performed atomically, i.e. safe to be executed
@@ -715,7 +715,7 @@ C<atomicint>, plain C<int>, and the sized C<int> variants are all considered
 to be the same by the dispatcher and cannot be differentiated through
 multi-dispatch.
 
-=head1 Numeric Infectiousness
+=head1 Numeric infectiousness
 
 Numeric "infectiousness" dictates the resultant type when two numerics of
 different types are involved in some mathematical operations. A type is said to

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -22,7 +22,7 @@ Objects do allow for both L<inheritance|https://en.wikipedia.org/wiki/Object-ori
 L<encapsulation|https://en.wikipedia.org/wiki/Object-oriented_programming#Encapsulation>.
 
 
-=head1 Using Objects
+=head1 Using objects
 
 To call a method on an object, add a dot, followed by the method name:
 
@@ -79,7 +79,7 @@ and assign to the container it returned with the L<C<=>|=> operator.
 All objects support methods from class L<Mu>, which is the type hierarchy root.
 All objects derive from C<Mu>.
 
-=head2 Type Objects
+=head2 Type objects
 
 Types themselves are objects and you can get the I<type object> by writing its name:
 
@@ -329,7 +329,7 @@ object, overloading assignment to set attributes with complex logic is
 currently discouraged as
 L<weaker object oriented design|https://6guts.wordpress.com/2016/11/25/perl-6-is-biased-towards-mutators-being-really-simple-thats-a-good-thing/>.
 
-=head2 Class and Instance Methods
+=head2 Class and instance methods
 
 A method's signature can have an I<invocant> as its first parameter
 followed by a colon, which allows for the method to refer to the object
@@ -423,7 +423,7 @@ called on instances, in different stages of initialization. In the latter two
 submethods, submethods of the same name from subclasses have not yet run, so
 you should not rely on potentially virtual method calls inside these methods.
 
-=head2 Private Methods
+=head2 Private methods
 
 Methods with an exclamation mark C<!> before the method name are not callable
 from anywhere outside the defining class; such methods are private in the sense
@@ -654,7 +654,7 @@ say RectangleWithCachedArea.new( x2 => 5, x1 => 1, y2 => 1, y1 => 0).area;
 # OUTPUT: «4␤»
 =end code
 
-=head2 Object Cloning
+=head2 Object cloning
 
 The cloning is done using L<clone> method available on all objects, which
 shallow-clones both public and private attributes. New values for I<public>
@@ -708,7 +708,7 @@ objects and roles are meant for managing behavior and code reuse.
 Roles are immutable as soon as the compiler parses the closing curly brace of
 the role declaration.
 
-=head2 Application of Role
+=head2 Application of role
 
 Role application differs significantly from class inheritance. When a role
 is applied to a class, the methods of that role are copied into the class.
@@ -902,7 +902,7 @@ the above only applies if two such candidates have the same signature.
 Otherwise, there is no conflict, and the candidate is just added to the
 multi-method.
 
-=head2 Automatic Role Punning
+=head2 Automatic role punning
 
 Any attempt to directly instantiate a role or use it as a type object
 will automatically create a class with the same name as the role,
@@ -926,7 +926,7 @@ Punning is not caused by most L<meta-programming|/language/mop> constructs,
 however, as those are sometimes used to work directly with roles.
 
 X<|Parameterized Roles>
-=head2 Parameterized Roles
+=head2 Parameterized roles
 
 
 Roles can be parameterized, by giving them a signature in square brackets:
@@ -985,7 +985,7 @@ You can have multiple roles of the same name, but with different signatures;
 the normal rules of multi dispatch apply for choosing multi candidates.
 
 X<|but>
-=head2 X<Mixins> of Roles
+=head2 X<Mixins> of roles
 
 Roles can be mixed into objects. A role's given attributes and methods will be
 added to the methods and attributes the object already has. Multiple mixins and
@@ -1049,7 +1049,7 @@ Roles can be anonymous.
     say %seen<not-there>.defined;  # OUTPUT: «True␤» (0 may be False but is well defined)
     say Int.new(%seen<not-there>); # OUTPUT: «0␤»
 
-=head1 Meta-Object Programming and Introspection
+=head1 Meta-object programming and introspection
 
 Perl 6 has a meta object system, which means that the behavior of objects,
 classes, roles, grammars, enums, etc. are themselves controlled by other

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2181,7 +2181,7 @@ For the non-sed version, see L<C<^ff^>|/routine/^ff^>.
 
 This operator cannot be overloaded, as it's handled specially by the compiler.
 
-=head1 Item Assignment precedence
+=head1 Item assignment precedence
 
 =head2 X<infix C«=»|item =>
 
@@ -2366,7 +2366,7 @@ well, so the are also checked against the endpoint:
     say 1, 2, 4, 8, 16 ... $end;
     # OUTPUT: «(1 2 4)␤»
 
-=head1 List Prefix precedence
+=head1 List prefix precedence
 
 =head2 X<infix C«=»|list =>
 

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -120,7 +120,7 @@ tiebreaking principle is that initializing phasers execute in order declared,
 while finalizing phasers execute in the opposite order, because setup and
 teardown usually want to happen in the opposite order from each other.
 
-=head2 Execution Order
+=head2 Execution order
 
 Compilation Begins
 
@@ -184,7 +184,7 @@ Program terminating
 =for code :skip-test
         END {...} #  at runtime, ALAP, only ever runs once
 
-=head1 Program Execution Phasers
+=head1 Program execution phasers
 
 =head2 X<BEGIN|Phasers, BEGIN>
 
@@ -249,7 +249,7 @@ phasers are only installed the first time they're noticed.)
 
 Appears in a supply block. Called when the supply is closed.
 
-=head1 Block Phasers
+=head1 Block phasers
 
 Execution in the context of a block has its own phases.
 
@@ -363,7 +363,7 @@ The exceptions thrown by failing C<PRE> and C<POST> phasers cannot be caught by
 a C<CATCH> in the same block, which implies that C<POST> phaser are not run if
 a C<PRE> phaser fails.
 
-=head1 Loop Phasers
+=head1 Loop phasers
 
 C<FIRST>, C<NEXT>, and C<LAST> are meaningful only within the lexical scope of
 a loop, and may occur only at the top level of such a loop block.
@@ -388,7 +388,7 @@ evaluation of C<NEXT> phasers.
 Runs when loop is aborted (either through C<last>, or C<return>, or because you
 got to the bottom of the loop and are done), after LEAVE.
 
-=head1 Exception Handling Phasers
+=head1 Exception handling phasers
 
 =head2 X<CATCH|Phasers, CATCH>
 
@@ -416,7 +416,7 @@ C<warn>, C<proceed> and C<succeed>.
 =begin comment
 
 # NYI
-# =head1 Object Phasers
+# =head1 Object phasers
 #
 # =head2 X<COMPOSE|Phasers, COMPOSE>
 #
@@ -424,7 +424,7 @@ C<warn>, C<proceed> and C<succeed>.
 
 =end comment
 
-=head1 Asynchronous Phasers
+=head1 Asynchronous phasers
 
 =head2 X<LAST|Asynchronous Phasers, LAST>
 

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -19,7 +19,7 @@ A very simple Perl 6 Pod document
 =end pod
 =end code
 
-=head1 Block Structure
+=head1 Block structure
 
 A Pod document may consist of multiple Pod blocks.
 There are four ways to define a block (delimited, paragraph, abbreviated, and declarator);
@@ -103,7 +103,7 @@ B<cannot> be specified for an I<abbreviated> block. The block ends at the next P
 first blank line.
 
 =begin code
-=head1 Top Level Heading
+=head1 Top level heading
 =end code
 
 =head2 Declarator blocks
@@ -173,11 +173,11 @@ Headings can be defined using C<=headN>,
 where N is greater than zero (e.g., C<=head1>, C<=head2>, …).
 
 =begin code
-=head1 A Top Level Heading
+=head1 A top level heading
 
-=head2 A Second Level Heading
+=head2 A second level heading
 
-=head3 A Third Level Heading
+=head3 A third level heading
 =end code
 
 =head2 Ordinary paragraphs
@@ -282,7 +282,7 @@ which should also be rendered without re-justification or whitespace-squeezing.
 
 =head2 Lists
 
-=head3 Unordered Lists
+=head3 Unordered lists
 
 Lists in Pod are specified as a series of C<=item> blocks.
 
@@ -302,7 +302,7 @@ The three suspects are:
 =item  Sleepy
 =item  Grumpy
 
-=head3 Definition Lists
+=head3 Definition lists
 
 Lists that define terms or commands use C<=defn>, equivalent to the C<DL> lists in HTML
 
@@ -324,7 +324,7 @@ When you're not happy.
 
 Which, for the time being, is a simple HTML paragraph, but the format might change in the future.
 
-=head3 Multi-level Lists
+=head3 Multi-level lists
 
 Lists may be multi-level, with items at each level specified using the C<=item1>, C<=item2>, C<=item3>, etc. blocks.
 
@@ -352,7 +352,7 @@ For example:
 =item2     Liquid
 =item2     Gas
 
-=head3 Multi-paragraph Lists
+=head3 Multi-paragraph lists
 
 Using the delimited form of the C<=item> block (C<=begin item> and C<=end item>),
 we can specify items that contain multiple paragraphs.
@@ -436,7 +436,7 @@ publishing, source components, or meta-information.
 =SUBTITLE
 =end code
 
-=head1 Formatting Codes
+=head1 Formatting codes
 
 Formatting codes provide a way to add inline mark-up to a piece of text.
 
@@ -521,7 +521,7 @@ Enter your name K<John Doe>
 
 Z<If used will bust Pod::To::BigPage>
 
-=head2 Terminal Output
+=head2 Terminal output
 
 To flag text as terminal output enclose it in C<T< >>
 =for code :skip-test

--- a/doc/Language/py-nutshell.pod6
+++ b/doc/Language/py-nutshell.pod6
@@ -1,6 +1,6 @@
 =begin pod
 
-=TITLE Python to Perl 6 - Nutshell
+=TITLE Python to Perl 6 - nutshell
 
 =SUBTITLE Learning Perl 6 from Python, in a nutshell
 
@@ -9,7 +9,7 @@ for folks coming from a Python background.  We discuss
 the equivalent syntax in Perl 6 for a number of Python
 constructs and idioms.
 
-=head1 Basic Syntax
+=head1 Basic syntax
 
 =head2 Hello, world
 
@@ -53,7 +53,7 @@ Perl 6
     say 'Hello, $planet';   # Hello, $planet
     say "Hello, planet number { 1 + 2 }"; # Hello, planet number 3
 
-=head2 Statement Separators
+=head2 Statement separators
 
 In Python, a newline signifies the end of a statement.
 There are a few exceptions: A backslash before a newline
@@ -263,7 +263,7 @@ Many of the other unicode operators work as you would expect
 (exponents, fractions, π), but every unicode operator
 or symbol that can be used in Perl 6 has an ASCII equivalent.
 
-=head2 Control Flow
+=head2 Control flow
 
 Python has C<for> loops and C<while> loops:
 
@@ -346,7 +346,7 @@ Perl 6
     }
 
 
-=head2 Lambdas, Functions and Subroutines
+=head2 Lambdas, functions and subroutines
 
 Declaring a function (subroutine) with C<def> in Python is accomplished
 with C<sub> in Perl 6.
@@ -452,7 +452,7 @@ i.e. these are the same:
     my $power = { $^x ** $^y };
     my $power = -> $x, $y { $x ** $y };
 
-=head2 List Comprehensions
+=head2 List comprehensions
 
 Postfix statement modifiers and blocks can be combined to make list comprehensions.
 
@@ -491,7 +491,7 @@ becomes either of these:
 Using C<map> (which is just like Python's C<map>) and
 C<grep> (which is like Python's C<filter>) is an alternative.
 
-=head2 Classes and Objects
+=head2 Classes and objects
 
 Here's an example from the Python L<docs|https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables>.
 First, "instance variables", aka attributes in Perl 6:
@@ -685,7 +685,7 @@ An alternative would be to use a trait:
 
     world;
 
-=head2 Context Managers
+=head2 Context managers
 X<|Context Managers (Python)>
 X<|with (Python)>
 

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Writing strings, word lists, and regexes in Perl 6
 
-=head1 The Q Lang
+=head1 The Q lang
 
 Strings are usually represented in Perl 6 code using some form of quoting
 construct. The most minimalistic of these is C<Q>, usable via the shortcut

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -1,8 +1,8 @@
 =begin pod :tag<convert>
 
-=TITLE Ruby to Perl 6 - Nutshell
+=TITLE Ruby to Perl 6 - nutshell
 
-=SUBTITLE Learning Perl 6 from Ruby, in a nutshell: What do I already know?
+=SUBTITLE Learning Perl 6 from Ruby, in a nutshell: what do I already know?
 
 This page attempts to index the high-level differences in syntax and semantics
 between Ruby and Perl 6. Whatever works in Ruby and must be written differently
@@ -142,7 +142,7 @@ $object."$methodname"(@args);   # Perl 6
 If you leave out the quotes, then Perl 6 expects C<$methodname> to contain
 a C<Method> object, rather than the simple string name of the method.
 
-=head2 Variables, Sigils, Scope, and Common Types
+=head2 Variables, sigils, scope, and common types
 
 In Ruby, variables use sigils primarily to indicate scope. C<$> for global
 scope, C<@@> for class scope, C<@> for instance scope, and no sigil for local
@@ -158,7 +158,7 @@ of them as part of the variable's name.
 The scope of a variable is instead indicated by the declaration itself (C<my>,
 C<has>, C<our>, etc).
 
-=head3 Variable Scope
+=head3 Variable scope
 
 For local variables, Ruby uses implicit variable declaration upon assignment
 and limited to the current block. In Ruby the content of an C<if> or C<while>
@@ -474,7 +474,7 @@ no equivalent to the signature class in Ruby, either.
 
 See L<S03/Smartmatching|https://design.perl6.org/S03.html#Smart_matching> for more information on this feature.
 
-=head2 C<& | ^> Numeric Bitwise ops
+=head2 C<& | ^> Numeric bitwise ops
 =head2 C<& | ^> Boolean ops
 
 In Perl 6, these single-character ops have been removed, and replaced by
@@ -509,7 +509,7 @@ say  42 +< 3; # Perl 6
 Note that Ruby often uses the C«<<» operator as the "shovel operator", which is
 similar to C<.push>. This usage isn't common in Perl 6.
 
-=head2 C«=>» and C<:> Key-Value Separators
+=head2 C«=>» and C<:> Key-value separators
 
 In Ruby, C«=>» is used in the context of key/value pairs for Hash literal
 declaration and parameter passing. C<:> is used as a shorthand when the left
@@ -538,7 +538,7 @@ result     = (  score > 60 )  ? 'Pass'  : 'Fail'; # Ruby
 my $score; ...;
 my $result = ( $score > 60 ) ?? 'Pass' !! 'Fail'; # Perl 6
 
-=head2 C<+> String Concatenation
+=head2 C<+> String concatenation
 
 Replaced by the tilde. Mnemonic: think of "stitching" together the two strings with needle and thread.
 
@@ -571,7 +571,7 @@ say "Hello! My name is $name!"
 The result of an embedded block in Ruby uses C<.to_s> to get string context.
 Perl 6 uses C<.Str>, or C<.gist> for the same affect.
 
-=head1 Compound Statements
+=head1 Compound statements
 
 =head2 Conditionals
 
@@ -711,7 +711,7 @@ my @cars; ...;
 for @cars  -> $car   {...} # Perl 6; read-only
 for @cars <-> $car   {...} # Perl 6; read-write
 
-=head2 Flow Interruption statements
+=head2 Flow interruption statements
 
 Same as Ruby:
 
@@ -722,7 +722,7 @@ Same as Ruby:
 
 This is C<last> in Perl 6.
 
-=head1 Regular Expressions ( Regex / Regexp )
+=head1 Regular expressions ( regex / regexp )
 
 Regular expressions in Perl 6 are significantly different, and more powerful,
 than in Ruby. By default whitespace is ignored and all characters must be
@@ -872,7 +872,7 @@ for "file".IO.lines -> $line {
 }
 =end code
 
-=head1 Object Orientation
+=head1 Object orientation
 
 =head2 Basic classes, methods, attributes
 
@@ -954,7 +954,7 @@ class Person {
 my $p = Person.new( name => 'Jack', age => 23 )
 =end code
 
-=head2 Private Methods
+=head2 Private methods
 
 Private methods in Perl 6 are declared with a C<!> prefixed in their name, and
 are invoked with a C<!> instead of a C<.>.
@@ -992,7 +992,7 @@ An important note is that in Ruby child objects can see parent private methods
 (so they are more like "protected" methods in other languages). In Perl 6 child
 objects cannot call parent private methods.
 
-=head2 Going Meta
+=head2 Going meta
 
 Here are a few examples of meta-programming. Note that Perl 6 separates the
 meta-methods from the regular methods with a carat.
@@ -1148,7 +1148,7 @@ perl6 example.p6 --length=abc
 Note that Perl 6 auto-generates a full usage message on error in
 command-line parsing.
 
-=head1 RubyGems, External Libraries
+=head1 RubyGems, external libraries
 
 See L<https://modules.perl6.org/>, where a growing number of Perl 6 libraries
 are available along with the tools to manage them.

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -105,9 +105,9 @@ C<\n>. So the text below match:
     say $text ~~ / .* /;
     # OUTPUT «｢Although I am a␤multi-line text,␤now can be matched␤with /.*/␤｣»
 
-=head1 Character Classes
+=head1 Character classes
 
-=head2 Backslashed Character Classes
+=head2 Backslashed character classes
 
 There are predefined character classes of the form C<\w>. Its negation is
 written with an upper-case letter, C<\W>.
@@ -212,7 +212,7 @@ Examples of word characters:
     0409 Љ CYRILLIC CAPITAL LETTER LJE
     =end code
 
-=head2 Predefined Character Classes
+=head2 Predefined character classes
 
 =begin table
 
@@ -789,7 +789,7 @@ These are both zero-width regex elements.
 
 
 X<<<|regex, <<; regex, >>; regex, «; regex, »>>>
-=head2 Left and Right Word Boundary
+=head2 Left and right word boundary
 
 C«<<» matches a left word boundary. It matches positions where there is a
 non-word character at the left, or the start of the string, and a word
@@ -824,7 +824,7 @@ To see the difference between C«<|w>» and C<«>, C<»>:
     say "stuff here!!!".subst(:g, /<</, '|');   # OUTPUT: «|stuff |here!!!␤»
     say "stuff here!!!".subst(:g, /<|w>/, '|'); # OUTPUT: «|stuff| |here|!!!␤»
 
-=head2 Summary of Anchors
+=head2 Summary of anchors
 
 Anchors are zero-width regex elements. Hence they do not use up a character of
 the input string, that is, they do not advance the current position at which
@@ -849,7 +849,7 @@ character of an input string.
 
 =end table
 
-=head1 Zero-Width Assertions
+=head1 Zero-width assertions
 
 Zero-Width Assertions can help you implement your own anchor.
 
@@ -946,7 +946,7 @@ where we capture the first 3 of the 5 characters before bar, but only if C<bar> 
 
 
 
-=head1 Grouping and Capturing
+=head1 Grouping and capturing
 
 In regular (non-regex) Perl 6, you can use parentheses to group things
 together, usually to override operator precedence:
@@ -1228,7 +1228,7 @@ a number in the middle of a string:
 Of course, you can use any of the C<+>, C<*> and C<?> modifiers, and they'll
 behave just as they would in the C<m//> operator's context.
 
-=head2 Capturing Groups
+=head2 Capturing groups
 
 Just as in the match operator, capturing groups are allowed on the left-hand
 side, and the matched contents populate the C<$0>..C<$n> variables and the
@@ -1477,7 +1477,7 @@ as with ordinary C<|> interpolation, the longest match succeeds:
 
 The use of hash variables in regexes is preserved.
 
-=head2 Regex Boolean condition check
+=head2 Regex boolean condition check
 
 The special operator C«<?{}>» allows the evaluation of a boolean expression that
 can perform a semantic evaluation of the match before the regular expression
@@ -1883,7 +1883,7 @@ abracadabra
        abra
 =end code
 
-=head2 Substitution Adverbs
+=head2 Substitution adverbs
 
 You can apply matching adverbs (such as C<:global>, C<:pos> etc.) to
 substitutions. In addition, there are adverbs that only make sense for
@@ -2061,7 +2061,7 @@ which might not be a good idea.  A compromise would be
 and then, in the post-processing, strip leading and trailing spaces and tabs
 from the section header.
 
-=head2 Matching Whitespace
+=head2 Matching whitespace
 
 The C<:sigspace> adverb (or using the C<rule> declarator instead of C<token>
 or C<regex>) is very handy for implicitly parsing whitespace that can appear

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -71,7 +71,7 @@ associated weights are the 'values':
     Bag / BagHash     a positive integer          0
     Mix / MixHash     a non-zero real number      0
 
-=head1 Set/Bag Operators
+=head1 Set/Bag operators
 
 =comment TODO: Update this after ab5tract's set/bag/mix operator redesign.
 

--- a/doc/Language/tables.pod6
+++ b/doc/Language/tables.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Pod 6 tables
 
-=SUBTITLE The Good, the Bad and the Ugly
+=SUBTITLE The good, the bad and the ugly
 
 The official specification for Perl 6 POD tables is located in the
 Documentation specification here:
@@ -44,7 +44,7 @@ HINT: During development, use of the environment variable C<RAKUDO_POD6_TABLE_DE
 will show you how Rakudo interprets your pod tables before they are passed
 to renderers such as B<Pod::To::HTML>, B<Pod::To::Text>, and B<Pod::To::Markdown>.
 
-=head1 Best Practices
+=head1 Best practices
 
 HINT: Not adhering to the following best practices may require more table
 processing due to additional looping over table rows.
@@ -139,7 +139,7 @@ method is now considered to be deprecated. The practice will generate a
 warning in the upcoming version C<6.d>, and it will raise an exception in
 version C<6.e>.
 
-=head1 Good Tables
+=head1 Good tables
 
 Following are examples of valid (Good) tables (taken from the current
 L<Specification Tests|https://github.com/perl6/roast>).
@@ -237,7 +237,7 @@ bar
 =end table
 =end code
 
-=head1 Bad Tables
+=head1 Bad tables
 
 Following are examples of invalid (Bad) tables, and they should
 trigger an unhandled exception during parsing.
@@ -270,7 +270,7 @@ r1c0 |  r1c1
 =end table
 =end code
 
-=head1 Ugly Tables
+=head1 Ugly tables
 
 Following are examples of valid tables that are probably intended to
 be two columns, but the columns are not aligned well so each

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Terms
 
-=SUBTITLE Perl 6 Terms
+=SUBTITLE Perl 6 terms
 
 Most syntactic constructs in Perl 6 can be categorized in I<terms> and
 L<operators|/language/operators>.

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -145,7 +145,7 @@ many tests we I<plan> to run (such that the testing framework can tell us if
 more or fewer tests were run than we expected) and when finished with the
 tests, we use I<done-testing> to tell the framework we are done.
 
-=head2 Thread Safety
+=head2 Thread safety
 
 Note that routines in C<Test> module are I<not> thread-safe. This means you
 should not attempt to use the testing routines in multiple threads simultaneously,
@@ -367,7 +367,7 @@ if it's larger, use relative tolerance of C<1e-6>.
     is-approx $value, $expected, :$abs-tol, :$rel-tol;
     is-approx $value, $expected, :$abs-tol, :$rel-tol, 'test description';
 
-=head3 Absolute Tolerance
+=head3 Absolute tolerance
 
 When an absolute tolerance is set, it's used as the actual maximum value by
 which the C<$value> and C<$expected> can differ. For example:
@@ -382,7 +382,7 @@ which the C<$value> and C<$expected> can differ. For example:
 Regardless of values given, the difference between them cannot be more
 than C<2>.
 
-=head3 Relative Tolerance
+=head3 Relative tolerance
 
 When a relative tolerance is set, the test checks the relative difference between
 values. Given the same tolerance, the larger the numbers given, the larger the
@@ -408,7 +408,7 @@ to calculate the difference is:
 
 and the test will fail if C<rel-diff> is higher than C<$rel-tol>.
 
-=head3 Both Absolute and Relative Tolerance Specified
+=head3 Both absolute and relative tolerance specified
 
 =for code :skip-test
 is-approx $value, $expected, :rel-tol<.5>, :abs-tol<10>;

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -18,9 +18,9 @@ them where they would rarely be seen.  Because of this, Perl 6's warts are
 in different places than you may expect them to be when coming from another
 language.
 
-=head1 Variables and Constants
+=head1 Variables and constants
 
-=head2 Constants are Computed at Compile Time
+=head2 Constants are computed at compile time
 
 Constants are computed at compile time, so if you use them in modules keep in mind
 that their values will be frozen due to pre-compilation of the module itself:
@@ -277,7 +277,7 @@ parent objects, it is required to use C<callsame> inside C<BUILDALL>, but not in
 
 =head1 Whitespace
 
-=head2 Whitespace in Regexes does not match literally
+=head2 Whitespace in regexes does not match literally
 
 =for code
 say 'a b' ~~ /a b/; # OUTPUT: «False␤»
@@ -296,7 +296,7 @@ Ways to match whitespace:
 =item with C<m:s/a b/> or C<m:sigspace/a b/>, the blank in the regexes
       matches arbitrary whitespace
 
-=head2 Ambiguities in Parsing
+=head2 Ambiguities in parsing
 
 While some languages will let you get away with removing as much whitespace
 between tokens as possible, Perl 6 is less forgiving. The overarching
@@ -347,7 +347,7 @@ say 3 < 5 > 4
 
 =head1 Captures
 
-=head2 Containers versus values in a Capture
+=head2 Containers versus values in a capture
 
 Beginners might expect a variable in a C<Capture> to supply its current
 value when that C<Capture> is later used.  For example:
@@ -520,7 +520,7 @@ my @array = qw{victor alice bob charlie eve};
 say @array.tail;      # OUTPUT: «eve␤»
 say @array.tail(2);   # OUTPUT: «(charlie eve)␤»
 
-=head2 Typed Array parameters
+=head2 Typed array parameters
 
 Quite often new users will happen to write something like:
 
@@ -635,7 +635,7 @@ encode the string as UTF8 and then get the number of bytes.
 
 For more information on how strings work in Perl 6, see the L<Unicode page|/language/unicode>.
 
-=head2 All Text is Normalized By Default
+=head2 All text is normalized by default
 
 Perl 6 normalizes all text into Unicode NFC form (Normalization Form Canonical).
 Filenames are the only text not normalized by default. If you are expecting
@@ -643,7 +643,7 @@ your strings to maintain a byte for byte representation as the original,
 you need to use L«C<UTF8-C8>|/language/unicode#UTF8-C8» when reading or writing
 to any filehandles.
 
-=head2 Allomorphs Generally Follow Numeric Semantics
+=head2 Allomorphs generally follow numeric semantics
 
 L<Str> C<"0"> is C<True>, while L<Numeric> is C<False>. So what's the L<Bool> value of
 L<allomorph|/language/glossary#index-entry-Allomorph> C«<0>»?
@@ -762,7 +762,7 @@ The C<^>, C<|>, and C<&> are I<not> bitwise operators, they create
 L<Junctions|/type/Junction>. The corresponding bitwise operators in Perl 6 are:
 C<+^>, C<+|>, C<+&> for integers and C<?^>, C<?|>, C<?&> for booleans.
 
-=head2 Exclusive Sequence Operator
+=head2 Exclusive sequence operator
 
 Lavish use of whitespace helps readability, but keep in mind infix operators
 cannot have any whitespace in them. One such operator is the sequence operator
@@ -778,7 +778,7 @@ it's no longer a single infix operator, but an infix inclusive sequence operator
 are valid endpoints for the sequence operator, so the result you'll get might
 not be what you expected.
 
-=head2 String Ranges/Sequences
+=head2 String ranges/Sequences
 
 In some languages, using strings as range end points, considers the entire
 string when figuring out what the next string should be; loosely treating the
@@ -811,7 +811,7 @@ sequence operator that calls C<.succ> method on the starting string:
 say join ", ", ("az", *.succ ... "bc");
 # OUTPUT: «az, ba, bb, bc␤»
 
-=head2 Topicalizing Operators
+=head2 Topicalizing operators
 
 The smartmatch operator C<~~> and C<andthen> set the topic C<$_> to their
 left-hand-side. In conjunction with implicit method calls on the topic this can
@@ -835,7 +835,7 @@ say .&method;
 say .&method ~~ 'topic';
 # OUTPUT: «object␤False␤»
 
-=head2 Fat Arrow and Constants
+=head2 Fat arrow and constants
 
 The fat arrow operator C«=>» will turn words on its left-hand side to C<Str>
 without checking the scope for constants or C<\>-sigiled variables. Use
@@ -1001,9 +1001,9 @@ To achieve the desired result, use global matching, capturing parentheses or a l
     for 'x' ~~ /(.)/  { say 'yes' }  # OUTPUT: «yes␤»
     for ('x' ~~ /./,) { say 'yes' }  # OUTPUT: «yes␤»
 
-=head1 Common Precedence Mistakes
+=head1 Common precedence mistakes
 
-=head2 Adverbs and Precedence
+=head2 Adverbs and precedence
 
 Adverbs do have a precedence that may not follow the order of operators that is displayed on your screen. If two operators of equal precedence are followed by an adverb it will pick the first operator it finds in the abstract syntax tree. Use parentheses to help Perl 6 understand what you mean or use operators with looser precedence.
 
@@ -1015,7 +1015,7 @@ say !(%x<b>:exists);          # works too
 say not %x<b>:exists;         # works as well
 say True unless %x<b>:exists; # avoid negation altogether
 
-=head2 Ranges and Precedence
+=head2 Ranges and precedence
 
 The loose precedence of C<..> can lead to some errors.  It is usually best to parenthesize ranges when you want to operate on the entire range.
 
@@ -1037,7 +1037,7 @@ sub f {
 }
 say f; # OUTPUT: «True␤»
 
-=head2 Exponentiation Operator and Prefix Minus
+=head2 Exponentiation operator and prefix minus
 
 =for code
 say -1²;   # OUTPUT: «-1␤»
@@ -1105,7 +1105,7 @@ Finally, note that, currently, when declaring the functions whitespace
 may be used between a function or method name and the parentheses
 surrounding the parameter list without problems.
 
-=head2 Named Parameters
+=head2 Named parameters
 
 Many built-in subroutines and method calls accept named parameters and your own
 code may accept them as well, but be sure the arguments you pass when calling
@@ -1159,7 +1159,7 @@ The nice thing about the distinction here is that it gives the developer the
 option of passing pairs as either named or positional arguments, which can be
 handy in various instances.
 
-=head2 Argument Count Limit
+=head2 Argument count limit
 
 While it is typically unnoticeable, there is a backend-dependent
 argument count limit. Any code that does flattening of arbitrarily
@@ -1220,9 +1220,9 @@ sub explicitly-return-ret () {
 =end code
 
 
-=head1 Input and Output
+=head1 Input and output
 
-=head2 Closing Open Filehandles and Pipes
+=head2 Closing open filehandles and pipes
 
 Unlike some other languages, Perl 6 does not use reference counting,
 and so B<the filehandles are NOT closed when they go out of scope>. You
@@ -1237,7 +1237,7 @@ with routines L<run> and L<shell>.
 The caveat applies to L<IO::CatHandle> type as well, though not as severely.
 See L«C<IO::CatHandle.close>|/type/IO::CatHandle#method_close» for details.
 
-=head2 IO::Path Stringification
+=head2 IO::Path stringification
 
 Partly for historical reasons and partly by design, an L<IO::Path> object
 L<stringifies|/type/IO::Path#method_Str> without considering its
@@ -1273,7 +1273,7 @@ consider rewriting it in a way that does not involve changing the
 current directory. For example, you can pass C<cwd> named argument to
 L<run> without having to use C<chdir> around it.
 
-=head2 Splitting the Input Data Into Lines
+=head2 Splitting the input data into lines
 
 There is a difference between using C<.lines> on
 L«C<IO::Handle>|/type/IO::Handle#routine_lines» and on a
@@ -1426,7 +1426,7 @@ If you want to work with lines, then use C<$proc.stdout.lines>. If
 you're after the whole output, then something like this should do the
 trick: C<whenever $proc.stdout { $out ~= $_ }>.
 
-=head1 Exception Handling
+=head1 Exception handling
 
 =head2 Sunk C<Proc>
 
@@ -1457,7 +1457,7 @@ say "still alive";
 # OUTPUT: «still alive␤»
 
 
-=head1 Using Shortcuts
+=head1 Using shortcuts
 
 =head2 The ^ twigil
 
@@ -1796,7 +1796,7 @@ L<single argument rule|/language/functions#Slurpy_Conventions>, and
 there are other cases when this kind of a generalization may not work.
 
 
-=head2 Using [~] for concatenating a list of Blobs
+=head2 Using [~] for concatenating a list of blobs
 
 The L<C<~> infix operator|/routine/~#(Operators)_infix_~> can be used
 to concatenate L<Str>s I<or> L<Blob>s. However, an empty list will

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -179,7 +179,7 @@ for L<Metamodel::ClassHOW|/type/Metamodel::ClassHOW>.
     say C.HOW ~~ Metamodel::ClassHOW;
     # OUTPUT: «True␤»
 
-=head3 Private Attributes
+=head3 Private attributes
 
 Private L<attribute|/type/Attribute>s are addressed with any of the twigils
 C<$!>, C<@!> and C<%!>. They do not have public accessor methods generated
@@ -222,7 +222,7 @@ A normal method in a subclass does not compete with multis of a parent class.
     # OUTPUT: «B::Int␤»
 
 X«|only method»
-=head4 Only Method
+=head4 Only method
 
 To explicitly state that a method is not a multi method use the C<only method> declarator.
 

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -92,7 +92,7 @@ Reading with this type of encoding and encoding them back to UTF8-C8 will give y
 
 Please note that this encoding so far is not supported in the JVM implementation of Rakudo.
 
-=head1 Entering Unicode Codepoints and Codepoint Sequences
+=head1 Entering unicode codepoints and codepoint sequences
 
 You can enter Unicode codepoints by number (decimal as well as hexadecimal). For example, the character named
 "latin capital letter ae with macron" has decimal codepoint 482 and hexadecimal codepoint 0x1E2:
@@ -123,7 +123,7 @@ the L<uniparse>:
     say "DIGIT ONE".uniparse;  # OUTPUT: «1␤»
     say uniparse("DIGIT ONE"); # OUTPUT: «1␤»
 
-=head2 Name Aliases
+=head2 Name aliases
 
 By name alias. Name Aliases are used mainly for codepoints without an official
 name, for abbreviations, or for corrections (Unicode names never change).
@@ -147,7 +147,7 @@ Abbreviations:
     say "\c[ZWJ]".uniname;  # OUTPUT: «ZERO WIDTH JOINER␤»
     say "\c[NBSP]".uniname; # OUTPUT: «NO-BREAK SPACE␤»
 
-=head2 Named Sequences
+=head2 Named sequences
 
 You can also use any of the L<Named Sequences|http://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
 these are not single codepoints, but sequences of them. [Starting in 2017.02]
@@ -155,7 +155,7 @@ these are not single codepoints, but sequences of them. [Starting in 2017.02]
     say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]";      # OUTPUT: «É̩␤»
     say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]".ords; # OUTPUT: «(201 809)␤»
 
-=head3 Emoji Sequences
+=head3 Emoji sequences
 
 Rakudo has support for Emoji 4.0 (the latest non-draft release) sequences.
 For all of them see:

--- a/doc/Language/unicode_ascii.pod6
+++ b/doc/Language/unicode_ascii.pod6
@@ -14,7 +14,7 @@ Reference is made below to various properties of unicode codepoints.
 The definitive list can be found here:
 L<http://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
 
-=head1 Alphabetic Characters
+=head1 Alphabetic characters
 
 Any codepoint that has the C<Ll> (Letter, lowercase), C<Lu> (Letter,
 uppercase), C<Lt> (Letter, titlecase), C<Lm> (Letter, modifier), or
@@ -109,7 +109,7 @@ X<|«>X<|»>X<|×>X<|÷>X<|≤>X<|≥>X<|≠>X<|−>X<|∘>X<|≅>X<|π>X<|τ>X<
   ⊍      |  U+228D   | (.)        |
   ⊎      |  U+228E   | (+)        |
 
-=head2 Atomic Operators
+=head2 Atomic operators
 
 The atomic operators have C<U+269B ⚛ ATOM SYMBOL> incorporated into them. Their
 ASCII equivalents are ordinary subroutines, not operators:

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -32,7 +32,7 @@ hardcoded list, but it is possible to restore I<XCompose> by setting
 C<GTK_IM_MODULE=xim> in your environment. It might be necessary to install
 a xim bridge as well, such as C<uim-xim>.
 
-=head2 Getting Compose working in all Programs
+=head2 Getting compose working in all programs
 
 You may have issues using the compose key in all programs. In that case you can
 try C<ibus>.


### PR DESCRIPTION
Changes a number of different heading types into sentence case in the Language documents.

Only worked on strings and not on generated strings.

## The problem
Use sentence case throughout titles and headings
https://github.com/perl6/doc/issues/2223

## Solution provided

I have changed a number of headings within Language documents to have sentence cased headlines 


