### PR TITLE
Fixes missed and doubtful sentence cases on Language docs

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -533,7 +533,7 @@ Unchanged:
 =item C«== != < > <= >=»   Numeric comparisons
 =item C<eq ne lt gt le ge>  String comparisons
 
-=head2 C<,> (Comma) List Separator
+=head2 C<,> (Comma) List separator
 
 Unchanged, but note that in order to flatten an array variable to a list (in
 order to append or prefix more items) one should use the C<|> operator
@@ -568,8 +568,8 @@ depend on the types of both arguments, and those rules are far from
 identical in Perl 5 and Perl 6. See L<~~|/routine/~~> and
 L<the smartmatch operator|/language/operators#index-entry-smartmatch_operator>
 
-=head2 C<& | ^> String Bitwise ops
-=head2 C<& | ^> Numeric Bitwise ops
+=head2 C<& | ^> String bitwise ops
+=head2 C<& | ^> Numeric bitwise ops
 =head2 C<& | ^> Boolean ops
 
 In Perl 5, C<& | ^> were invoked according to the contents of their
@@ -665,7 +665,7 @@ my $result = $score > 60 ?  'Pass' :  'Fail'; # Perl 5
 =for code :preamble<my $score>
 my $result = $score > 60 ?? 'Pass' !! 'Fail'; # Perl 6
 
-=head2 C<.> (Dot) String Concatenation
+=head2 C<.> (Dot) String concatenation
 
 Replaced by the tilde.
 
@@ -676,7 +676,7 @@ $food = 'grape' . 'fruit'; # Perl 5
 =for code :preamble<no strict;>
 $food = 'grape' ~ 'fruit'; # Perl 6
 
-=head2 C<x> List Repetition or String Repetition operator
+=head2 C<x> List repetition or string repetition operator
 
 In Perl 5, C<x> is the Repetition operator, which behaves differently in
 scalar or list contexts:
@@ -702,7 +702,7 @@ Mnemonic: C<x> is short and C<xx> is long, so C<xx> is the one used for lists.
     @ones = 5 xx @ones;         # Parentheses no longer needed
 
 
-=head2 C<..> C<...> Two Dots or Three Dots, Range op or Flipflop op
+=head2 C<..> C<...> Two dots or three dots, range op or flipflop op
 
 In Perl 5, C<..> was one of two completely different operators, depending
 on context.
@@ -719,7 +719,7 @@ In Perl 5, C<"${foo}s"> deliminates a variable name from regular text next to
 it. In Perl 6, simply extend the curly braces to include the sigil too:
 C<"{$foo}s">. This is in fact a very simple case of interpolating an expression.
 
-=head1 Compound Statements
+=head1 Compound statements
 
 These statements include conditionals and loops.
 
@@ -907,7 +907,7 @@ while (my ($k, $v) = each(%hash)) { ... } # Perl 5
 =for code :preamble<no strict;>
 for %hash.kv -> $k, $v { ... } # Perl 6
 
-=head2 Flow Control statements
+=head2 Flow control statements
 
 Unchanged:
 
@@ -1005,7 +1005,7 @@ say "element exists" if exists $array[$i];  # Perl 5
 =for code :preamble<no strict;>
 say "element exists" if @array[$i]:exists;  # Perl 6 - use :exists adverb
 
-=head1 Regular Expressions ( Regex / Regexp )
+=head1 Regular expressions ( regex / regexp )
 
 =head2 Change C<=~> and C<!~> to C<~~> and C<!~~> .
 


### PR DESCRIPTION
These are sentence cases I was less sure of as wasn't sure whether to consider things like "List Separator" as proper noun. Hopefully digestible enough for someone to consider in this separate commit.

Also a couple that I noticed I missed whilst looking at those.

## The problem
This is just a small tail end to the closed bug:

Use sentence case throughout titles and headings
https://github.com/perl6/doc/issues/2223

## Solution provided

Small list of final changes of sweep through to sentence case titles in language documents.
