### PR TITLE
Makes some http links across 'Language' documents https

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -486,7 +486,7 @@ apply.
     say $subref->($foo, $bar);
 
 In relatively recent versions of Perl 5 (5.20 and later), a new feature allows
-the use of the arrow operator for dereferencing:  see L<Postfix Dereferencing|http://search.cpan.org/~shay/perl-5.20.1/pod/perl5200delta.pod#Experimental_Postfix_Dereferencing>.
+the use of the arrow operator for dereferencing:  see L<Postfix Dereferencing|https://search.cpan.org/~shay/perl-5.20.1/pod/perl5200delta.pod#Experimental_Postfix_Dereferencing>.
 This can be used to create an array from a scalar. This operation is usually
 called I<decont>, as in decontainerization, and in Perl 6 methods such as
 C<.list> and C<.hash> are used:

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -35,7 +35,7 @@ To generate HTML from the Pod files, you'll need:
 =item The Perl 6 modules Pod::To::HTML, Pod::To::BigPage, and URI::Escape
 (can be installed via L<zef|https://github.com/ugexe/zef>).
 
-=item B<Optional>: L<GraphViz|http://graphviz.org>, for creating graphs
+=item B<Optional>: L<GraphViz|https://www.graphviz.org>, for creating graphs
 of the relationships between Perl 6 types
 
 =item B<Optional>: L<Atom Highlights|https://github.com/atom/highlights> and L<language-perl6|https://atom.io/packages/language-perl6>, for syntax

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -893,7 +893,7 @@ means "Paradise."
 X<|Reify>
 =head1 Reify
 
-In the English language, L<reify means|http://www.dictionary.com/browse/reify>
+In the English language, L<reify means|https://www.dictionary.com/browse/reify>
 "to convert into or regard as a concrete thing." Its meaning in Perl 6 is very
 similar, in that conceptual things, like "elements of an infinite list", get
 I<reified> when you try to operate on some of them.
@@ -1148,7 +1148,7 @@ A character or group of blank characters, used to separate words. An example is 
 =head1 6model
 X<|6model>
 
-6model is used in the L<MoarVM>, and provides primitives used to create an object system. It is described in L<this presentation by Jonathan Worthington|http://jnthn.net/papers/2013-yapceu-moarvm.pdf> and implemented L<here in MoarVM|https://github.com/MoarVM/MoarVM/tree/master/src/6model>.
+6model is used in the L<MoarVM>, and provides primitives used to create an object system. It is described in L<this presentation by Jonathan Worthington|https://jnthn.net/papers/2013-yapceu-moarvm.pdf> and implemented L<here in MoarVM|https://github.com/MoarVM/MoarVM/tree/master/src/6model>.
 
 =end pod
 

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -83,7 +83,7 @@ a C<Cannot modify an immutable Str (value)> exception thrown.
 
 Making classes associative provides a very convenient way of using and working
 with them using hashes; an example can be seen in
-L<Cro|http://cro.services/docs/reference/cro-http-client#Setting_the_request_body>,
+L<Cro|https://cro.services/docs/reference/cro-http-client#Setting_the_request_body>,
 which uses it extensively for the convenience of using hashes to define
 structured requests and express its response.
 

--- a/doc/Language/modules-extra.pod6
+++ b/doc/Language/modules-extra.pod6
@@ -14,7 +14,7 @@ more fun.
 Some modules and tools to help you with generating files that are part
 of a module distribution.
 
-=item L<App::Assixt|http://modules.perl6.org/dist/App::Assixt> The module developer's assistant
+=item L<App::Assixt|https://modules.perl6.org/dist/App::Assixt> The module developer's assistant
 =item L<App::Mi6|https://modules.perl6.org/dist/App::Mi6>     Minimal authoring tool for Perl 6
 =item L<META6|https://modules.perl6.org/dist/META6>        Do things with Perl 6 META files
 =item L<Module::Skeleton|https://bitbucket.org/rightfold/module-skeleton>        Generate a skeleton module

--- a/doc/Language/mop.pod6
+++ b/doc/Language/mop.pod6
@@ -115,7 +115,7 @@ The presence of a C<Scalar> object indicates that the object is "itemized".
 =head1 Structure of the meta object system
 
 B<Note:> this documentation largely reflects the meta object system as
-implemented by the L<Rakudo Perl 6 compiler|http://rakudo.org/>, since the
+implemented by the L<Rakudo Perl 6 compiler|https://rakudo.org/>, since the
 L<design documents|https://design.perl6.org/> are very light on details.
 
 For each type declarator keyword, such as C<class>, C<role>, C<enum>,

--- a/doc/Language/newline.pod6
+++ b/doc/Language/newline.pod6
@@ -48,7 +48,7 @@ will get those characters at the end of the line, as shown.
 
 In regular expressions,
 L<C<\n>|/language/regexes#index-entry-regex_\n-regex_\N-\n_and_\N> is defined in
-terms of the L<Unicode definition of logical newline|http://unicode.org/reports/tr18/#Line_Boundaries>. It will match C<.>
+terms of the L<Unicode definition of logical newline|https://unicode.org/reports/tr18/#Line_Boundaries>. It will match C<.>
 and also C<\v>, as well as any class that includes whitespace.
 
 =end pod

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -33,8 +33,8 @@ phase|/language/phasers#INIT>.
 
 =head2 Profile locally
 
-When using the L<MoarVM|http://moarvm.org> backend, the
-L<Rakudo|http://rakudo.org> compiler's C<--profile> command line option writes
+When using the L<MoarVM|https://moarvm.org> backend, the
+L<Rakudo|https://rakudo.org> compiler's C<--profile> command line option writes
 the profile data to an HTML file.
 
 This file will open to the "Overview" section, which gives some overall data
@@ -203,7 +203,7 @@ general topic, read the wikipedia page on L<algorithmic efficiency|https://en.wi
 This is another very important class of algorithmic improvement.
 
 See the slides for
-L<Parallelism, Concurrency, and Asynchrony in Perl 6|http://jnthn.net/papers/2015-yapcasia-concurrency.pdf#page=17>
+L<Parallelism, Concurrency, and Asynchrony in Perl 6|https://jnthn.net/papers/2015-yapcasia-concurrency.pdf#page=17>
 and/or L<the matching video|https://www.youtube.com/watch?v=JpqnNCx7wVY&list=PLRuESFRW2Fa77XObvk7-BYVFwobZHdXdK&index=8>.
 
 =head2 Use existing high performance code
@@ -212,7 +212,7 @@ There are plenty of high performance C libraries that you can use within Perl 6
 L<NativeCall|/language/nativecall> makes it easy to create wrappers for them. There's
 experimental support for C++ libraries, too.
 
-If you want to L<use Perl 5 modules in Perl 6|http://stackoverflow.com/a/27206428/1077672>,
+If you want to L<use Perl 5 modules in Perl 6|https://stackoverflow.com/a/27206428/1077672>,
 mix in Perl 6 types and the L<Meta-Object Protocol|/language/mop>.
 
 More generally, Perl 6 is designed to smoothly interoperate with other languages and
@@ -235,10 +235,10 @@ L<NQP|https://github.com/perl6/nqp> that's basically a subset of Perl 6. If you
 can write Perl 6, you can fairly easily learn to use and improve the mid-level
 NQP code too, at least from a pure language point of view. To dig into NQP and
 Rakudo's guts, start with
-L<NQP and internals course|http://edumentab.github.io/rakudo-and-nqp-internals-course/>.
+L<NQP and internals course|https://edumentab.github.io/rakudo-and-nqp-internals-course/>.
 
 =item If low-level C hacking is your idea of fun, checkout
-L<MoarVM|http://moarvm.org> and visit the freenode IRC channel #moarvm
+L<MoarVM|https://moarvm.org> and visit the freenode IRC channel #moarvm
 (L<logs|https://irclog.perlgeek.de/moarvm/>).
 
 =head2 Still need more ideas?

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -12,7 +12,7 @@ code works as expected.
 In Perl 6, the L<Test|https://github.com/rakudo/rakudo/blob/master/lib/Test.pm6>
 module provides a testing framework. Perl 6's official spectest suite uses C<Test>.
 
-The testing functions emit output conforming to the L<Test Anything Protocol|http://testanything.org>. In general, they are used in sink context:
+The testing functions emit output conforming to the L<Test Anything Protocol|https://testanything.org>. In general, they are used in sink context:
 
 =for code :preamble<my ($meta,$relaxed-name); sub check-name($meta,:$relaxed-name){}>
 ok check-name($meta, :$relaxed-name), "name has a hyphen rather than '::'"
@@ -165,7 +165,7 @@ command line:
 =for code :lang<shell>
 $ perl6 t/test-filename.t
 
-Or via the L<prove|http://perldoc.perl.org/prove.html> command from Perl 5,
+Or via the L<prove|https://perldoc.perl.org/prove.html> command from Perl 5,
 where C<perl6> is specified as the executable that runs the tests:
 
 =for code :lang<shell>

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -1044,7 +1044,7 @@ say -1²;   # OUTPUT: «-1␤»
 say -1**2; # OUTPUT: «-1␤»
 
 When performing a
-L<regular mathematical calculation|http://www.wolframalpha.com/input/?i=-1%C2%B2>,
+L<regular mathematical calculation|https://www.wolframalpha.com/input/?i=-1%C2%B2>,
 the power takes precedence over the minus; so C<-1²> can be written as C<-(1²)>.
 Perl 6 matches these rules of mathematics and the precedence of C<**> operator is
 tighter than that of the prefix C<->. If you wish to raise a negative number
@@ -1528,7 +1528,7 @@ differences.
 
 Keep in mind that C<« »> performs word splitting similarly to how
 shells do it, so
-L<many shell pitfalls|http://mywiki.wooledge.org/BashPitfalls> apply
+L<many shell pitfalls|https://mywiki.wooledge.org/BashPitfalls> apply
 here as well (especially when using in combination with C<run>):
 
     my $file = ‘--my arbitrary filename’;
@@ -1542,7 +1542,7 @@ here as well (especially when using in combination with C<run>):
 
 Note that C<--> is required for many programs to disambiguate between
 command-line arguments and
-L<filenames that begin with hyphens|http://mywiki.wooledge.org/BashPitfalls#Filenames_with_leading_dashes>.
+L<filenames that begin with hyphens|https://mywiki.wooledge.org/BashPitfalls#Filenames_with_leading_dashes>.
 
 =head1 Scope
 

--- a/doc/Language/unicode.pod6
+++ b/doc/Language/unicode.pod6
@@ -127,7 +127,7 @@ the L<uniparse>:
 
 By name alias. Name Aliases are used mainly for codepoints without an official
 name, for abbreviations, or for corrections (Unicode names never change).
-For full list of them see L<here|http://www.unicode.org/Public/UCD/latest/ucd/NameAliases.txt>.
+For full list of them see L<here|https://www.unicode.org/Public/UCD/latest/ucd/NameAliases.txt>.
 
 Control codes without any official name:
 
@@ -149,7 +149,7 @@ Abbreviations:
 
 =head2 Named sequences
 
-You can also use any of the L<Named Sequences|http://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
+You can also use any of the L<Named Sequences|https://www.unicode.org/Public/UCD/latest/ucd/NamedSequences.txt>,
 these are not single codepoints, but sequences of them. [Starting in 2017.02]
 
     say "\c[LATIN CAPITAL LETTER E WITH VERTICAL LINE BELOW AND ACUTE]";      # OUTPUT: «É̩␤»
@@ -159,8 +159,8 @@ these are not single codepoints, but sequences of them. [Starting in 2017.02]
 
 Rakudo has support for Emoji 4.0 (the latest non-draft release) sequences.
 For all of them see:
-L<Emoji ZWJ Sequences|http://www.unicode.org/Public/emoji/4.0/emoji-zwj-sequences.txt>
-and L<Emoji Sequences|http://www.unicode.org/Public/emoji/4.0/emoji-sequences.txt>.
+L<Emoji ZWJ Sequences|https://www.unicode.org/Public/emoji/4.0/emoji-zwj-sequences.txt>
+and L<Emoji Sequences|https://www.unicode.org/Public/emoji/4.0/emoji-sequences.txt>.
 Note that any names with commas should have their commas removed, since Perl 6 uses
 commas to separate different codepoints/sequences inside the same C<\c> sequence.
 

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -94,7 +94,7 @@ C<.XCompose> in C<%USERPROFILE%>, or editing user-defined sequences in the optio
 
 =head2 Vim
 
-In L<Vim|http://www.vim.org/>, unicode characters are entered (in
+In L<Vim|https://www.vim.org/>, unicode characters are entered (in
 insert-mode) by pressing first C<Ctrl-V> (also denoted C<^V>), then C<u> and
 then the hexadecimal value of the unicode character to be entered.  For
 example, the Greek letter λ (lambda) is entered via the key combination:
@@ -126,7 +126,7 @@ them.
 
 =head2 Emacs
 
-In L<Emacs|http://www.gnu.org/software/emacs/>, unicode characters are
+In L<Emacs|https://www.gnu.org/software/emacs/>, unicode characters are
 entered by first entering the chord C<C-x 8 RET> at which point the
 text C<Unicode (name or hex):> appears in the minibuffer.  One then enters
 the unicode code point hexadecimal number followed by the enter key.  The


### PR DESCRIPTION
For format L<name|url> in 'Language' docs, changes http to https where appropriate.

## The problem
This is a start on the following:
Use HTTPS URLs, where available #2246

## Solution provided
I've switched http to https in the 'Language' docs where the format is L<name|url>

https://vimdoc.sourceforge.net/htmldoc/digraph.html is not correctly configured for https so left as http

https://vim.wikia.com/wiki/Entering_special_characters redirects to a non-secure version so have left as http

