### PR TITLE
Replaces more http links with https in 'Language' docs

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -486,7 +486,7 @@ apply.
     say $subref->($foo, $bar);
 
 In relatively recent versions of Perl 5 (5.20 and later), a new feature allows
-the use of the arrow operator for dereferencing:  see L<Postfix Dereferencing|https://search.cpan.org/~shay/perl-5.20.1/pod/perl5200delta.pod#Experimental_Postfix_Dereferencing>.
+the use of the arrow operator for dereferencing:  see L<Postfix Dereferencing|https://metacpan.org/pod/release/SHAY/perl-5.20.1/pod/perl5200delta.pod#Experimental_Postfix_Dereferencing>.
 This can be used to create an array from a scalar. This operation is usually
 called I<decont>, as in decontainerization, and in Perl 6 methods such as
 C<.list> and C<.hash> are used:
@@ -1254,7 +1254,7 @@ No longer relevant: in Perl 6, source code is expected to be in utf8 encoding.
 
 =head3 C<vars>
 
-Discouraged in Perl 5. See L<http://perldoc.perl.org/vars.html>.
+Discouraged in Perl 5. See L<https://perldoc.perl.org/vars.html>.
 
 You should refactor your Perl 5 code to remove the need for C<use vars>,
 before translating into Perl 6.
@@ -1756,7 +1756,7 @@ This project is a suite of Perl cross-compilers, including Perl 5-to-6
 translation. It has a web front-end, and so can be used without
 installation. It only supports a subset of Perl 5 syntax so far.
 
-L<http://fglock.github.io/Perlito/perlito/perlito5.html>
+L<https://fglock.github.io/Perlito/perlito/perlito5.html>
 
 =head2 Perl-ToPerl6
 

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -578,7 +578,7 @@ Real Soon Now
 =head2 RT
 X<|RT>
 
-Request Tracker (L<http://rt.perl.org/>).  The place where all the bugs
+Request Tracker (L<https://rt.perl.org/>).  The place where all the bugs
 related to L<#Rakudo> live.
 
 =head2 TIMTOWTDI

--- a/doc/Language/haskell-to-p6.pod6
+++ b/doc/Language/haskell-to-p6.pod6
@@ -420,7 +420,7 @@ And in Perl6:
     =end code
 
 See this design document for more information on what kinds of list comprehensions are possible
-in Perl6: L<http://design.perl6.org/S04.html#The_do-once_loop>.
+in Perl6: L<https://design.perl6.org/S04.html#The_do-once_loop>.
 
 As you can see, when you get into some more advanced Haskell list comprehensions, Perl6
 does not translate exactly the same, but it's possible to do the same things, nonetheless.

--- a/doc/Language/unicode_ascii.pod6
+++ b/doc/Language/unicode_ascii.pod6
@@ -12,7 +12,7 @@ bigger.
 
 Reference is made below to various properties of unicode codepoints.
 The definitive list can be found here:
-L<http://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
+L<https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt>.
 
 =head1 Alphabetic characters
 


### PR DESCRIPTION
Finding links that match  L\<url\> and replacing http links with https where appropriate (ie where they work)

## The problem
Use HTTPS URLs, where available #2246

## Solution provided

Further work on this issue, using a different pattern to find the links 

