### PR TITLE
Makes http links https if applicable in 'Types' documents

### DIFF
--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -733,7 +733,7 @@ order to see how it is going to behave:
     say ‘👨‍👩‍👧‍👦🏿’.uniprops(‘Grapheme_Cluster_Break’); # OUTPUT: «(E_Base_GAZ ZWJ E_Base_GAZ ZWJ E_Base_GAZ ZWJ E_Base_GAZ E_Modifier)␤»
 
 You can read more about graphemes in the
-L<Unicode Standard|http://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries>,
+L<Unicode Standard|https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries>,
 which Perl 6 tightly follows, using a method called L<NFG, normal form graphemes|/language/glossary#NFG> for efficiently representing them.
 
 =head2 routine codes

--- a/doc/Type/IO.pod6
+++ b/doc/Type/IO.pod6
@@ -378,7 +378,7 @@ quote variables:
 
 Note that C<--> is required for many programs to disambiguate between
 command-line arguments and
-L<filenames that begin with hyphens|http://mywiki.wooledge.org/BashPitfalls#Filenames_with_leading_dashes>.
+L<filenames that begin with hyphens|https://mywiki.wooledge.org/BashPitfalls#Filenames_with_leading_dashes>.
 
 A sunk L<Proc> object for a process that L<exited|/routine/exitcode>
 unsuccessfully will throw. If you wish to ignore such failures, simply

--- a/doc/Type/Int.pod6
+++ b/doc/Type/Int.pod6
@@ -135,7 +135,7 @@ this code that implements it:
     say @pieces; # OUTPUT: «[5 4 3 2]␤»
 
 For a more detailed discussion, see
-L<this blog post|http://perl6.party/post/Perl6-.polymod-break-up-a-number-into-denominations>
+L<this blog post|https://perl6.party/post/Perl6-.polymod-break-up-a-number-into-denominations>
 
 =head2 routine is-prime
 

--- a/doc/Type/Junction.pod6
+++ b/doc/Type/Junction.pod6
@@ -250,7 +250,7 @@ On the other hand, the version of "~" that uses strings as a prefix or postfix w
 
 =head1 See Also
 
-=item L<http://perlgeek.de/blog-en/perl-5-to-6/08-junctions.html>
+=item L<https://perlgeek.de/blog-en/perl-5-to-6/08-junctions.html>
 =item L<http://perl6maven.com/perl6-is-a-value-in-a-given-list-of-values>
 =item L<https://perl6advent.wordpress.com/2009/12/13/day-13-junctions/>
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1093,7 +1093,7 @@ Combining multiple cycles and C<:partial> also works:
     say ('a'..'h').rotor(1 => 1, 3 => -1, :partial).join('|');
     # OUTPUT: «a|c d e|e|g h␤»
 
-See L<this blog post for more elaboration on rotor|http://perl6.party/post/Perl-6-.rotor-The-King-of-List-Manipulation>.
+See L<this blog post for more elaboration on rotor|https://perl6.party/post/Perl-6-.rotor-The-King-of-List-Manipulation>.
 
 =head2 method batch
 

--- a/doc/Type/NFC.pod6
+++ b/doc/Type/NFC.pod6
@@ -8,7 +8,7 @@
 
 A Codepoint string in Unicode Normalization Form C. It is created by Canonical Decomposition,
 followed by Canonical Composition. For more information on what this means, see
-L<Unicode TR15|http://www.unicode.org/reports/tr15/>.
+L<Unicode TR15|https://www.unicode.org/reports/tr15/>.
 
 =end pod
 

--- a/doc/Type/NFD.pod6
+++ b/doc/Type/NFD.pod6
@@ -6,7 +6,7 @@
 
     class NFD is Uni {}
 
-A Codepoint string in the "D" L<Unicode Normalization Form|http://www.unicode.org/reports/tr15/>
+A Codepoint string in the "D" L<Unicode Normalization Form|https://www.unicode.org/reports/tr15/>
 
 =end pod
 

--- a/doc/Type/NFKC.pod6
+++ b/doc/Type/NFKC.pod6
@@ -8,7 +8,7 @@
 
 A Codepoint string in Unicode Normalization Form KC. It is created by Compatibility Decomposition,
 followed by Canonical Composition. For more information on what this means, see
-L<Unicode TR15|http://www.unicode.org/reports/tr15/>.
+L<Unicode TR15|https://www.unicode.org/reports/tr15/>.
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6

--- a/doc/Type/NFKD.pod6
+++ b/doc/Type/NFKD.pod6
@@ -7,7 +7,7 @@
     class NFKD is Uni {}
 
 A Codepoint string in Unicode Normalization Form KD. It is created by Compatibility Decomposition.
-For more information on what this means, see L<Unicode TR15|http://www.unicode.org/reports/tr15/>.
+For more information on what this means, see L<Unicode TR15|https://www.unicode.org/reports/tr15/>.
 
 =end pod
 

--- a/doc/Type/Uni.pod6
+++ b/doc/Type/Uni.pod6
@@ -13,7 +13,7 @@ characters are separate elements of a C<Uni> instance.
 C<Uni> presents itself with a list-like interface of integer Codepoints.
 
 Typical usage of C<Uni> is through one of its subclasses, C<NFC>, C<NFD>,
-C<NFKD> and C<NFKC>, which represent strings in one of the L<Unicode Normalization Forms|http://www.unicode.org/reports/tr15/> of the same name.
+C<NFKD> and C<NFKC>, which represent strings in one of the L<Unicode Normalization Forms|https://www.unicode.org/reports/tr15/> of the same name.
 
 =head1 Methods
 


### PR DESCRIPTION
## The problem
Use HTTPS URLs, where available #2246

## Solution provided
Gone through the 'Type' documents and changed http to https where it works in links matching L\<name\> or L\<name|url\>

