### PR TITLE
Replace broken link with a new link

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -1774,7 +1774,7 @@ live on GitHub. An online converter may become available at some point.
 =item L<https://perlgeek.de/en/article/5-to-6>
 =item L<https://github.com/Util/Blue_Tiger/>
 =item L<https://perl6advent.wordpress.com/2011/12/23/day-23-idiomatic-perl-6/>
-=item L<http://www.perlfoundation.org/perl6/index.cgi?perl_6_delta_tablet>
+=item L<https://docs.perl6.org/language/5to6-overview>
 
 =end pod
 


### PR DESCRIPTION
Replace http://www.perlfoundation.org/perl6/index.cgi?perl_6_delta_tablet with https://docs.perl6.org/language/5to6-overview for tips on translating Perl 5 to Perl 6

## The problem
404 on link on https://docs.perl6.org/language/5to6-nutshell #2250

## Solution provided
I've replaced the link with the one to the 5to6-overview, which seems best to me.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
