### PR TITLE
Any list clarity

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -472,7 +472,7 @@ Defined as:
 
     method Supply(--> Supply:D) is nodal
 
-Coerces the invocant first to L<List> by applying its
+Coerces the invocant first to a C<list> by applying its
 L«C<.list>|/routine/list» method, and then to L<Supply>.
 
 =head2 method min
@@ -567,7 +567,7 @@ Defined as:
 
     method flatmap(Any:U: &code --> Seq)
 
-Coerces the invocant to L<List> by applying its
+Coerces the invocant to a C<list> by applying its
 L«C<.list>|/routine/list» method and uses
 L«C<List.flatmap>|/type/List#method_flatmap» on it.
 
@@ -580,7 +580,7 @@ Defined as:
     multi method roll(--> Any)
     multi method roll($n --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.roll>|/type/List#routine_roll» on it.
 
@@ -594,7 +594,7 @@ Defined as:
     multi method pick(--> Any)
     multi method pick($n --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.pick>|/type/List#routine_pick» on it.
 
@@ -659,7 +659,7 @@ Defined as:
 
     method first(Mu $matcher?, :$k, :$kv, :$p, :$end)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.first>|/type/List#routine_first» on it.
 
@@ -671,7 +671,7 @@ Defined as:
 
     method unique(:&as, :&with --> Seq:D)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.unique>|/type/List#routine_unique» on it.
 
@@ -683,7 +683,7 @@ Defined as:
 
     method repeated(:&as, :&with --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.repeated>|/type/List#routine_repeated» on it.
 
@@ -695,7 +695,7 @@ Defined as:
 
     method squish(:&as, :&with --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.squish>|/type/List#routine_squish» on it.
 
@@ -708,7 +708,7 @@ Defined as:
 
     method permutations(--> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.permutations>|/type/List#routine_permutations» on it.
 
@@ -720,7 +720,7 @@ Defined as:
 
     method categorize(&mapper --> Hash:D)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.categorize>|/type/List#routine_categorize» on it.
 
@@ -732,7 +732,7 @@ Defined as:
 
     method classify(&mapper -->Hash:D)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.classify>|/type/List#routine_classify» on it.
 
@@ -748,8 +748,7 @@ Defined as:
     multi method pairs(Any:U:  -->List)
     multi method pairs(Any:D:  -->List)
 
-Coerces the invocant to L<List> by applying its L«C<.list>|/routine/list» method
-and uses L<List.pairs|/type/List#routine_pairs> on it.
+Converts the invocant to a L<List> via the C<list> method and returns the result of L<List.pairs|/type/List#routine_pairs> on it.
 Returns an empty L<List> if the invocant is undefined:
 
 
@@ -767,8 +766,7 @@ Defined as:
     multi method antipairs(Any:U:  -->List)
     multi method antipairs(Any:D:  -->List)
 
-Coerces the invocant to L<List> by applying
-its L«C<.list>|/routine/list» method and uses
+Converts the invocant to a L<List> via the C<list> method and returns the result of
 L<List.antipairs|/type/List#routine_antipairs> on it.
 Returns an empty L<List> if the invocant is undefined:
 
@@ -785,9 +783,8 @@ Defined as:
     multi method kv(Any:U:  -->List)
     multi method kv(Any:D:  -->List)
 
-Coerces the invocant to L<List> by applying
-its L«C<.list>|/routine/list» method and uses
- L<List.kv|/type/List#routine_kv> on it.
+Invokes C<list> on the invocant and returns the result of
+L<List.kv|/type/List#routine_kv> on it.
 Returns an empty L<List> if the invocant is undefined:
 
     my $a;
@@ -941,7 +938,7 @@ Defined as:
 
     method combinations(--> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.combinations>|/type/List#routine_combinations» on it.
 
@@ -953,7 +950,7 @@ Defined as:
 
     method iterator(--> Iterator)
 
-Coerces the invocant to L<List> by applying its L«C<.list>|/routine/list» method and uses
+Coerces the invocant to a C<list> by applying its L«C<.list>|/routine/list» method and uses
 L«C<iterator>|/type/Iterable#method_iterator» on it.
 
     my $it = Any.iterator;
@@ -966,7 +963,7 @@ Defined as:
 
     method grep(Mu $matcher, :$k, :$kv, :$p, :$v --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.grep>|/type/List#routine_grep» on it.
 
@@ -1036,7 +1033,7 @@ Defined as:
     multi method batch(Int:D $batch --> Seq)
     multi method batch(Int:D :$elems --> Seq)
 
-Coerces the invocant to L<List> by applying
+Coerces the invocant to a C<list> by applying
 its L«C<.list>|/routine/list» method and uses
 L«C<List.batch>|/type/List#method_batch» on it.
 

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -336,7 +336,7 @@ Defined as:
 
     method Array(--> Array:D) is nodal
 
-Coerce the invocant to L<Array>.
+Coerces the invocant to L<Array>.
 
 =head2 method List
 
@@ -344,7 +344,7 @@ Defined as:
 
     method List(--> List:D) is nodal
 
-Coerce the invocant to L<List>, using the L<list> method.
+Coerces the invocant to L<List>, using the L<list> method.
 
 =head2 serial
 
@@ -367,7 +367,7 @@ Defined as:
     proto method Hash(|) is nodal
     multi method Hash( --> Hash:D)
 
-Coerce the invocant to L<Hash>.
+Coerces the invocant to L<Hash>.
 
 =head2 method hash
 
@@ -402,7 +402,7 @@ Defined as:
 
     method Slip(--> Slip:D) is nodal
 
-Coerce the invocant to L<Slip>.
+Coerces the invocant to L<Slip>.
 
 =head2 method Map
 
@@ -410,7 +410,7 @@ Defined as:
 
     method Map(--> Map:D) is nodal
 
-Coerce the invocant to L<Map>.
+Coerces the invocant to L<Map>.
 
 =head2 method Bag
 
@@ -418,7 +418,7 @@ Defined as:
 
     method Bag(--> Bag:D) is nodal
 
-Coerce the invocant to L<Bag>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<Bag>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method BagHash
@@ -427,7 +427,7 @@ Defined as:
 
     method BagHash(--> BagHash:D) is nodal
 
-Coerce the invocant to L<BagHash>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<BagHash>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method Set
@@ -436,7 +436,7 @@ Defined as:
 
     method Set(--> Set:D) is nodal
 
-Coerce the invocant to L<Set>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<Set>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method SetHash
@@ -445,7 +445,7 @@ Defined as:
 
     method SetHash(--> SetHash:D) is nodal
 
-Coerce the invocant to L<SetHash>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<SetHash>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method Mix
@@ -454,7 +454,7 @@ Defined as:
 
     method Mix(--> Mix:D) is nodal
 
-Coerce the invocant to L<Mix>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<Mix>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method MixHash
@@ -463,7 +463,7 @@ Defined as:
 
     method MixHash(--> MixHash:D) is nodal
 
-Coerce the invocant to L<MixHash>, whereby L<Positionals|/type/Positional>
+Coerces the invocant to L<MixHash>, whereby L<Positionals|/type/Positional>
 are treated as lists of values.
 
 =head2 method Supply
@@ -472,8 +472,8 @@ Defined as:
 
     method Supply(--> Supply:D) is nodal
 
-Coerce the invocant first to a C<list> by applying the invocant's
-L«C<.list>|/routine/list» method, and then to a L<Supply>.
+Coerces the invocant first to L<List> by applying its
+L«C<.list>|/routine/list» method, and then to L<Supply>.
 
 =head2 method min
 
@@ -482,7 +482,7 @@ Defined as:
     multi method min(--> Any:D)
     multi method min(&filter --> Any:D)
 
-Coerces to L<Iterable> and returns the numerically smallest element.
+Coerces the invocant to L<Iterable> and returns the numerically smallest element.
 
 If a L<Callable> positional argument is provided, each value is passed
 into the filter, and its return value is compared instead of the
@@ -498,7 +498,7 @@ Defined as:
     multi method max(--> Any:D)
     multi method max(&filter --> Any:D)
 
-Coerces to L<Iterable> and returns the numerically largest element.
+Coerces the invocant to L<Iterable> and returns the numerically largest element.
 
 If a L<Callable> positional argument is provided, each value is passed
 into the filter, and its return value is compared instead of the
@@ -567,13 +567,11 @@ Defined as:
 
     method flatmap(Any:U: &code --> Seq)
 
-Coerces the L<Any> to a C<list> by applying the
+Coerces the invocant to L<List> by applying its
 L«C<.list>|/routine/list» method and uses
 L«C<List.flatmap>|/type/List#method_flatmap» on it.
 
     say Any.flatmap({.reverse}); # OUTPUT: «((Any))␤»
-
-In the case of L<Any>, C<Any.list> returns a 1-item list, as is shown.
 
 =head2 method roll
 
@@ -582,8 +580,8 @@ Defined as:
     multi method roll(--> Any)
     multi method roll($n --> Seq)
 
-Coerces the invocant L<Any> to a C<list> by applying
-the L«C<.list>|/routine/list» method and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.roll>|/type/List#routine_roll» on it.
 
     say Any.roll;    # OUTPUT: «(Any)␤»
@@ -596,8 +594,8 @@ Defined as:
     multi method pick(--> Any)
     multi method pick($n --> Seq)
 
-Coerces the L<Any> to a C<list> by applying the
-L«C<.list>|/routine/list» method and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.pick>|/type/List#routine_pick» on it.
 
     say Any.pick;    # OUTPUT: «(Any)␤»
@@ -661,7 +659,8 @@ Defined as:
 
     method first(Mu $matcher?, :$k, :$kv, :$p, :$end)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.first>|/type/List#routine_first» on it.
 
     say Any.first; # OUTPUT: «(Any)␤»
@@ -672,7 +671,8 @@ Defined as:
 
     method unique(:&as, :&with --> Seq:D)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.unique>|/type/List#routine_unique» on it.
 
     say Any.unique; # OUTPUT: «((Any))␤»
@@ -683,7 +683,8 @@ Defined as:
 
     method repeated(:&as, :&with --> Seq)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.repeated>|/type/List#routine_repeated» on it.
 
     say Any.repeated; # OUTPUT: «()␤»
@@ -694,7 +695,8 @@ Defined as:
 
     method squish(:&as, :&with --> Seq)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.squish>|/type/List#routine_squish» on it.
 
     say Any.squish; # OUTPUT: «((Any))␤»
@@ -706,7 +708,8 @@ Defined as:
 
     method permutations(--> Seq)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.permutations>|/type/List#routine_permutations» on it.
 
     say Any.permutations; # OUTPUT: «(((Any)))␤»
@@ -717,7 +720,8 @@ Defined as:
 
     method categorize(&mapper --> Hash:D)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.categorize>|/type/List#routine_categorize» on it.
 
     say Any.categorize({ $_ }); # OUTPUT: «{(Any) => [(Any)]}␤»
@@ -728,7 +732,8 @@ Defined as:
 
     method classify(&mapper -->Hash:D)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.classify>|/type/List#routine_classify» on it.
 
     say Any.classify({ $_ }); # OUTPUT: «{(Any) => [(Any)]}␤»
@@ -743,9 +748,10 @@ Defined as:
     multi method pairs(Any:U:  -->List)
     multi method pairs(Any:D:  -->List)
 
-Returns an empty L<List> if the invocant is undefined, otherwise
-converts the invocant to a L<List> via the C<list> method
-and calls L<List.pairs|/type/List#routine_pairs> on it:
+Coerces the invocant to L<List> by applying its L«C<.list>|/routine/list» method
+and uses L<List.pairs|/type/List#routine_pairs> on it.
+Returns an empty L<List> if the invocant is undefined:
+
 
     say Any.pairs; # OUTPUT: «()␤»
     my $a;
@@ -761,9 +767,10 @@ Defined as:
     multi method antipairs(Any:U:  -->List)
     multi method antipairs(Any:D:  -->List)
 
-Applies the method L<List.antipairs|/type/List#routine_antipairs> to the invocant, if it is defined,
-after having invoked C<list> on it. If the invocant is not defined,
-it returns an empty L<List>:
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
+L<List.antipairs|/type/List#routine_antipairs> on it.
+Returns an empty L<List> if the invocant is undefined:
 
     my $a;
     say $a.antipairs;      # OUTPUT: «()»
@@ -778,9 +785,10 @@ Defined as:
     multi method kv(Any:U:  -->List)
     multi method kv(Any:D:  -->List)
 
-Returns an empty L<List> if the invocant is not defined, otherwise it
-does invoke C<list> on the invocant and then returns the result
-of L<List.kv|/type/List#routine_kv> on the latter:
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
+ L<List.kv|/type/List#routine_kv> on it.
+Returns an empty L<List> if the invocant is undefined:
 
     my $a;
     say $a.kv;      # OUTPUT: «()»
@@ -933,7 +941,8 @@ Defined as:
 
     method combinations(--> Seq)
 
-Treats the C<Any> as a 1-item list and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.combinations>|/type/List#routine_combinations» on it.
 
     say Any.combinations; # OUTPUT: «(() ((Any)))␤»
@@ -944,7 +953,7 @@ Defined as:
 
     method iterator(--> Iterator)
 
-Coerces the C<Any> to a C<list> by applying the C<.list> method and uses
+Coerces the invocant to L<List> by applying its L«C<.list>|/routine/list» method and uses
 L«C<iterator>|/type/Iterable#method_iterator» on it.
 
     my $it = Any.iterator;
@@ -957,7 +966,8 @@ Defined as:
 
     method grep(Mu $matcher, :$k, :$kv, :$p, :$v --> Seq)
 
-Coerces the C<Any> to a C<list> by applying the C<.list> method and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.grep>|/type/List#routine_grep» on it.
 
 Based on C<$matcher> value can be either C<((Any))> or empty List.
@@ -1026,7 +1036,8 @@ Defined as:
     multi method batch(Int:D $batch --> Seq)
     multi method batch(Int:D :$elems --> Seq)
 
-Coerces the object to a C<List> by applying the C<.list> method and uses
+Coerces the invocant to L<List> by applying
+its L«C<.list>|/routine/list» method and uses
 L«C<List.batch>|/type/List#method_batch» on it.
 
 =end pod


### PR DESCRIPTION
## The problem
The "1-item list" in Any docs is inaccurate #2176

## Solution provided

I have standardised the language based on other language in the document, though will need checking by someone with a greater understanding of what's actually being said.

Looking at the Cool type document, I have changed all descriptions which say 'coerce' to 'coerces' as there were both in the document.

I have added 'the invocant' in many places and hope this is correct to fit in with the language I was using in this update. Again, this was something used sporadically and I had to choose what to follow. It is now more consistent.

I have referred to C\<List\> meaning a class, rather than just 'a list'. Again, this seems more consistent to me with the rest of the document.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
