### PR TITLE
Modify case in link to Finding_modules

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -81,7 +81,7 @@ C<MyModule::Class> will be defined when C<MyModule> is loaded.
 
 C<use> loads and then imports from a compunit at compile time. It will look for
 files that end in C<.pm6> (C<.pm> is also supported). See
-L<here|/language/modules#Finding_Modules>
+L<here|/language/modules#Finding_modules>
 for where the runtime will look for modules.
 
 =for code :skip-test

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -112,7 +112,7 @@ construct, allowing the code to actually be executed.
 
 =item X<B<lib>|lib> This pragma adds subdirectories to the library search
 path so that the interpreter can
-L<find the modules|/language/modules#Finding_Modules>.
+L<find the modules|/language/modules#Finding_modules>.
 
 =for code :skip-test<Just a pragma>
 use lib <lib /opt/lib /usr/local/lib>;


### PR DESCRIPTION
Previous link does not jump to paragraph: https://docs.perl6.org/language/modules#Finding_Modules

Adjusted case: https://docs.perl6.org/language/modules#Finding_modules