### PR TITLE
Revert "Make pod-tables scroll horizontally on smaller views"

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -74,12 +74,6 @@ svg {
     height: auto;
 }
 
-table.pod-table {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
-}
-
 table.pod-table tr:nth-child(odd) {
     background-color: rgba(0, 0, 0, 0.031373);
 }


### PR DESCRIPTION
Reverts perl6/doc#2258

Scrolling worked, but layout affected. Back to the drawing board