### PR TITLE
Make pod-tables scroll horizontally on smaller views

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -74,9 +74,15 @@ svg {
     height: auto;
 }
 
+table.pod-table {
+    display: block;
+    overflow-x: auto;
+}
+
 table.pod-table tr:nth-child(odd) {
     background-color: rgba(0, 0, 0, 0.031373);
 }
+
 table.pod-table tr:nth-child(even) {
     background-color: transparent;
 }


### PR DESCRIPTION
If a table is too wide for a page a horizontal scroll bar will be added to the bottom.

If the page is focused, the right key will scroll right and left to come back.

I'm presuming this will work on mobile with finger dragging, but no testing set up for that at the moment.

Reverted a previous commit doing this, and this should now work. 'nowrap' was causing the problem which is not in this commit.

## The Problem

Squished table cells on mobile #650

Table columns that are outside the viewport are not viewable. Problem on mobile. This occurs in the bug report and is also in the 'Routines' page, directly linkable from the front page of the site making the bug quite prominent.

## The Solution

Add css via sass generator following advice from someone's question on stackoverflow (https://stackoverflow.com/questions/5533636/add-horizontal-scrollbar-to-html-table) on best way for creating scrollable table.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
