### PR TITLE
describe .pick(*) as shuffling

### DIFF
--- a/doc/Type/Baggy.pod6
+++ b/doc/Type/Baggy.pod6
@@ -38,7 +38,7 @@ by the values corresponding to each key. Unlike C<pick>, it works only on mutabl
 structures, e.g. L<BagHash|/type/BagHash>. Use of C<grab> on an immutable structure results in an
 C<X::Immutable> exception. If C<*> is passed as C<$count>, or C<$count> is greater than
 or equal to the L<total|#method total> of the invocant, then C<total> elements from the
-invocant are returned in a random sequence.
+invocant are returned in a random sequence; i.e. they are returned shuffled.
 
 Grabbing decrements the grabbed key's weight by one (deleting the key
 when it reaches 0). By definition, the C<total> of the invocant also decreases by one, so the

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -617,7 +617,8 @@ Defined as:
 If C<$count> is supplied: Returns C<$count> elements chosen at random
 and without repetition from the invocant. If C<*> is passed as C<$count>,
 or C<$count> is greater than or equal to the size of the list, then all
-elements from the invocant list are returned in a random sequence.
+elements from the invocant list are returned in a random sequence; i.e. they
+are returned shuffled.
 
 In I<method> form, if C<$count> is omitted: Returns a single random item from
 the list, or Nil if the list is empty

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -77,7 +77,7 @@ are 'picked' without replacement.
 
 If C<*> is passed as C<$count>, or C<$count> is greater than or equal to the number
 of L<elements|#method elems> of the invocant, then all element/C<True> C<Pair>s from
-the invocant are returned in a random sequence.
+the invocant are returned in a random sequence; i.e. they are returned shuffleed;
 
 Note that each C<pickpairs> invocation maintains its own private state and has
 no effect on subsequent C<pickpairs> invocations.

--- a/doc/Type/Setty.pod6
+++ b/doc/Type/Setty.pod6
@@ -61,7 +61,7 @@ exception.
 Returns C<$count> elements chosen at random (without repetition) from the set.
 
 If C<*> is passed as C<$count>, or C<$count> is greater than or equal to the
-size of the set, then all its elements are returned in random order.
+size of the set, then all its elements are returned in random order (shuffled).
 
 =head2 method pickpairs
 
@@ -77,7 +77,7 @@ are 'picked' without replacement.
 
 If C<*> is passed as C<$count>, or C<$count> is greater than or equal to the number
 of L<elements|#method elems> of the invocant, then all element/C<True> C<Pair>s from
-the invocant are returned in a random sequence; i.e. they are returned shuffleed;
+the invocant are returned in a random sequence; i.e. they are returned shuffled;
 
 Note that each C<pickpairs> invocation maintains its own private state and has
 no effect on subsequent C<pickpairs> invocations.


### PR DESCRIPTION
## The problem

Not clear that you use `pick(*)` to shuffle a list.

## Solution provided

Describe `pick(*)` as shuffling.