### PR TITLE
Clarifies capturing properties of square brackets in regex

### DIFF
--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1008,7 +1008,7 @@ The parentheses in regexes perform a double role: they group the regex
 elements inside and they capture what is matched by the sub-regex inside.
 
 To get only the grouping behavior, you can use square brackets C<[ ... ]>
-instead.
+which, by default, don't capture.
 
     if 'abc' ~~ / [a||b] (c) / {
         say ~$0;                # OUTPUT: «c␤»
@@ -1103,8 +1103,15 @@ and slightly verbose, way of naming captures is like this:
         say ~$<myname>      # OUTPUT: «abc␤»
     }
 
+The square brackets in the above example, which don't usually capture, will now capture its grouping
+with the given name.
+
 The access to the named capture, C«$<myname>», is a shorthand for indexing
 the match object as a hash, in other words: C<$/{ 'myname' }> or C«$/<myname>».
+
+We can also use round brackets in the above example, but they will work exactly the same as square brackets.
+The captured group will only be accessible by its name as a key from the match object and not from
+its position in the list with C<$/[0]> or C<$0>.
 
 Named captures can also be nested using regular capture group syntax:
 
@@ -1129,7 +1136,7 @@ all named captures:
         }
     }
 
-A more convenient way to get named captures is discussed in
+A more convenient way to get named captures is by using named regex as discussed in
 the L<Subrules|#Subrules> section.
 
 =head2 X«Capture markers: C«<( )>»|regex,<( )>»


### PR DESCRIPTION
Also clarifies how round brackets work in name capture.

Also take the mystery out of what we are going to see in subrules.

## The problem
named capture using non-capturing group confusion #1634

Also looked like a little further clarity could be added to the way brackets work for capturing.

## Solution provided
Refer to 'default' of square brackets not capturing and then highlight that it is a change to default behaviour that they capture when named. Didn't want to use round brackets in the example as think it's advisable myself (though not imperative) to use square brackets in named groupings. Highlighted that you can use round brackets in the example though.

Added a line mentioning named regexes as this is what the subrules link goes on to talk about, but no harm mentioning it here. 

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
