### PR TITLE
Adjust heading links

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -12,7 +12,7 @@ features and idioms are not).
 Hence this should not be mistaken for a beginner tutorial or a promotional
 overview of Perl 6; it is intended as a technical reference for Perl 6
 learners with a strong Perl 5 background and for anyone porting Perl 5 code
-to Perl 6 (though note that L<#Automated translation> might be more
+to Perl 6 (though note that L<#Automated_translation> might be more
 convenient).
 
 A note on semantics; when we say "now" in this document, we mostly just

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -12,7 +12,7 @@ features and idioms are not).
 Hence this should not be mistaken for a beginner tutorial or a promotional
 overview of Perl 6; it is intended as a technical reference for Perl 6
 learners with a strong Perl 5 background and for anyone porting Perl 5 code
-to Perl 6 (though note that L<#Automated_translation> might be more
+to Perl 6 (though note that L<#Automated translation> might be more
 convenient).
 
 A note on semantics; when we say "now" in this document, we mostly just

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -466,7 +466,7 @@ Since C<BUILD> runs in the context of the newly created C<Task> object, it
 is allowed to manipulate those private attributes. The trick here is that
 the private attributes (C<&!callback> and C<@!dependencies>) are being used
 as the bind targets for C<BUILD>'s parameters. Zero-boilerplate
-initialization! See L<objects|/language/objects#Object_Construction> for
+initialization! See L<objects|/language/objects#Object_construction> for
 more information.
 
 The C<BUILD> method is responsible for initializing all attributes and must also
@@ -484,7 +484,7 @@ handle default values:
         ) { }
     =end code
 
-See L<Object Construction|/language/objects#Object_Construction> for more
+See L<Object Construction|/language/objects#Object_construction> for more
 options to influence object construction and attribute initialization.
 
 =head1 Consuming our class

--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -105,7 +105,7 @@ say ~@array; # OUTPUT: «1 2 3 4 5 6␤»
 =end code
 
 This will happen also in a
-L<I<reduction>|https://docs.perl6.org/language/operators#Reduction_Operators>
+L<I<reduction>|https://docs.perl6.org/language/operators#Reduction_operators>
 context, when C<[~]> is applied to a list
 
      say [~] [ 3, 5+6i, Set(<a b c>), [1,2,3] ]; # OUTPUT: «35+6ic a b1 2 3␤»

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -348,7 +348,7 @@ L<DEFINITE|/language/classtut#index-entry-.DEFINITE> and L<defined>
 routines. Several other constructs exist that test for definiteness, such as
 L«C<with>, C<orwith>, and C<without>|/syntax/with%20orwith%20without»
 statements, L«C<//>|/routine/$SOLIDUS$SOLIDUS», L<andthen>, L<notandthen>, and
-L<orelse> operators, as well as L<type constraint smileys|/type/Signature#Constraining_Defined_and_Undefined_Values>.
+L<orelse> operators, as well as L<type constraint smileys|/type/Signature#Constraining_defined_and_undefined_values>.
 
 =head2 What is C<so>?
 
@@ -398,7 +398,7 @@ To explicitly allow either type objects or instances, you can use C<:_>.
 
 =head2 What is the C«-->» thing in the signature?
 
-L«-->|/type/Signature#Constraining_Return_Types» is a return constraint, either
+L«-->|/type/Signature#Constraining_return_types» is a return constraint, either
 a type or a definite value.
 
 Example of a type constraint:
@@ -586,7 +586,7 @@ initializes them:
     B.new(x => 5).show-x;
 
 C<BUILD> is called by the default constructor (indirectly, see
-L<Object Construction|/language/objects#Object_Construction>
+L<Object Construction|/language/objects#Object_construction>
 for more details) with all the named arguments that the user passes to the
 constructor. C<:$!x> is a named parameter with name C<x>, and when called
 with a named argument of name C<x>, its value is bound to the attribute C<$!x>.

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1142,7 +1142,7 @@ to L<exit|https://docs.perl6.org/routine/exit> has to be performed.
     }
 
 This C<MAIN> is defining two kind of aliases, as explained in
-L<Signatures|/type/Signature#Positional_vs._Named>: C<:file($data)> aliases the
+L<Signatures|/type/Signature#Positional_vs._named_arguments>: C<:file($data)> aliases the
 content passed to the command-line parameter C<--file=> to the variable
 C<$data>; C<:v(:$verbose)> not only aliases C<v> to C<verbose>, but also creates
 a new command line parameter C<verbose> thanks to the specification of the C<:>.

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -835,7 +835,7 @@ subroutine/method/callable block.
 =head1 Parrot
 X<|Parrot>
 
-A L<virtual machine|#Virtual machine> designed to run Perl 6 and other
+A L<virtual machine|#Virtual_machine> designed to run Perl 6 and other
 dynamic languages.  No longer actively maintained.
 
 =head1 PAST
@@ -963,7 +963,7 @@ X<|role>
 Roles, mix-ins or traits define interfaces and/or implementation of
 those interfaces as well as instance variables using them, and are
 mixed-in when declaring classes that follow that interface. L<Abstract
-classes|#Abstract class> are particular examples of Roles where the
+classes|#Abstract_class> are particular examples of Roles where the
 actual implementation is deferred to the class that uses that Role.
 
 Roles are part of Perl 6's L<object system|/language/objects>, and are
@@ -1003,7 +1003,7 @@ In Perl, the sigil is the first character of a variable name.  It must
 be either $, @, %, or & respectively for a L<scalar|/type/Scalar>,
 L<array|/type/Array>, L<hash|/type/Hash>, or L<code|/type/Code>
 variable.  See also Twigil and role. Also sigiled variables allow short
-conventions for L<variable interpolation|#Variable interpolation> in a
+conventions for L<variable interpolation|#Variable_interpolation> in a
 double quoted string, or even postcircumfix expressions starting with
 such a variable.
 
@@ -1048,7 +1048,7 @@ X<|Symbol>
 
 Fancy alternative way to denote a name. Generally used in the context of
 L<module|/language/modules>s linking, be it in the OS level, or at the
-Perl 6 L<#Virtual machine> level for modules generated from languages
+Perl 6 L<#Virtual_machine> level for modules generated from languages
 targeting these VMs.  The set of imported or exported symbols is called
 the symbol table.
 

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -402,7 +402,7 @@ pairs can be accessed in the same way as with plain C<.kv>:
     }
 
 You can also loop over a C<Hash> using
-L<destructuring|/type/Signature#Destructuring_Parameters>.
+L<destructuring|/type/Signature#Destructuring_arguments>.
 
 =head2 In place editing of values
 

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -787,7 +787,7 @@ a less specific type to a more specific one.
 As a special case, if a L<Signature|/type/Signature> is supplied as C<$target-type> then
 a C<subroutine> will be returned which will call the native function pointed to by C<$source>
 in the same way as a subroutine declared with the C<native> trait.  This is described in
-L<Function Pointers|/langauge/nativecall#Function_Pointers>.
+L<Function Pointers|/language/nativecall#Function_pointers>.
 
 =head2 sub cglobal
 

--- a/doc/Language/nativetypes.pod6
+++ b/doc/Language/nativetypes.pod6
@@ -7,7 +7,7 @@
 Perl 6 offers a set of I<native> types with a fixed, and known,
 representation in memory. This page shows which ones exist and how they
 can be used. Please check also the page on
-L<native numerics|/language/numerics#Native_Numerics>
+L<native numerics|/language/numerics#Native_numerics>
 for more information on them.
 
 X<|int>X<|uint>X<|num>X<|str>

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -478,7 +478,7 @@ C<BUILD> on each class in an L<inheritance|#Inheritance> chain:
     # OUTPUT: «InvertiblePoint2D.new(x => 1, y => 2)␤»
     =end code
 
-See also: L<#Object Construction>.
+See also: L<#Object_construction>.
 
 =head2 Inheritance
 
@@ -523,7 +523,7 @@ declared type:
     # OUTPUT: «the child's somewhat more fancy frob is called␤»
     =end code
 
-=head2 X<Object Construction|BUILDALL (method)>
+=head2 X<Object construction|BUILDALL (method)>
 
 Objects are generally created through method calls, either on the type
 object or on another object of the same type.

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -945,12 +945,12 @@ L<Hash> into an argument list.
     slurpee( <a b c d>, { e => 3 }, 'e' => 'f' => 33 )
     # OUTPUT: «\(("a", "b", "c", "d"), {:e(3)}, :e(:f(33)))␤»
 
-Please see the L<C<Signature> page, specially the section on Captures|/type/Signature#Capture_Parameters>
+Please see the L<C<Signature> page, specially the section on Captures|/type/Signature#Capture_parameters>
 for more information on the subject.
 
 Outside of argument lists, it returns a L<Slip|/type/Slip>, which makes
 it flatten into the outer list. Inside L<argument
-list|/language/list#Argument_List_(Capture)_Context>
+list|/language/list#Argument_list_(Capture)_context>
 L<C<Positional>s|/type/Positional> are turned into positional arguments
 and L<C<Associative>s|/type/Associative> are turned into named
 arguments.

--- a/doc/Language/performance.pod6
+++ b/doc/Language/performance.pod6
@@ -169,7 +169,7 @@ more efficient for that case.
 
 =head2 Speed up type-checks and call resolution
 
-Most L<C<where> clauses|/type/Signature#Type_Constraints> – and thus most
+Most L<C<where> clauses|/type/Signature#Type_constraints> – and thus most
 L<subsets|https://design.perl6.org/S12.html#Types_and_Subtypes> – force dynamic
 (runtime) type checking and call resolution for any call it I<might> match.
 This is slower, or at least later, than compile-time.

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -210,9 +210,9 @@ character or a list of characters.
     say $s;
     # OUTPUT: «I really ♡♥❤💕 Perl 6!␤»
 
-You can also use L«unicode names|/language/unicode#Entering_Unicode_Codepoints_and_Codepoint_Sequences»
+You can also use L«unicode names|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences»
 , L<named sequences|/language/unicode#Named_sequences>
-and L<name aliases|/language/unicode#Name_aliases> with L«\c[]|/language/unicode#Entering_Unicode_Codepoints_and_Codepoint_Sequences».
+and L<name aliases|/language/unicode#Name_aliases> with L«\c[]|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences».
 
     my $s = "Camelia \c[BROKEN HEART] my \c[HEAVY BLACK HEART]!";
     say $s;

--- a/doc/Language/structures.pod6
+++ b/doc/Language/structures.pod6
@@ -293,7 +293,7 @@ this particular role is mixed in; in this case it will contain the hash it is
 mixed in with; it will contain something else (and possibly work some other way)
 in other case. This role will provide the C<last> method to any variable it's
 mixed with, providing new, attachable, functionalities to I<regular> variables.
-Roles can even be L<added to existing variables using the C<does> keyword|/language/objects#Mixins_of_Roles>.
+Roles can even be L<added to existing variables using the C<does> keyword|/language/objects#Mixins_of_roles>.
 
 L<Subsets|/language/typesystem#subset> can also be used to constrain the
 possible values a variable might hold; they are Perl 6 attempt at

--- a/doc/Language/system.pod6
+++ b/doc/Language/system.pod6
@@ -9,7 +9,7 @@
 The simplest way is to use the
 L<C<@*ARGS>|/language/variables#index-entry-%24%2AARGS> variable to obtain
 arguments from the command line; this array will contain the strings that follow
-the program name. L<C<%*ENV>|/language/variables#Runtime_Environment> will
+the program name. L<C<%*ENV>|/language/variables#Runtime_environment> will
 contain the environment variables, so that if you use:
 
 =begin code :lang<shell>

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -273,7 +273,7 @@ Remember that C<BUILDALL> is a method, not a submethod. That's because by
 default, there is only one such method per class hierarchy, whereas C<BUILD>
 is explicitly called per class. That is the reason why, in order to properly initialize
 parent objects, it is required to use C<callsame> inside C<BUILDALL>, but not inside C<BUILD>
-(for more on the subject see L<object creation|/language/objects#Object_Construction>).
+(for more on the subject see L<object creation|/language/objects#Object_construction>).
 
 =head1 Whitespace
 
@@ -1736,7 +1736,7 @@ For instance, C<CREATE>, C<take> and C<defined> (which are defined in L<Mu>). In
 general, multi methods and simple methods will not have any problem, but it
 might not be a good practice to use them as rule names.
 
-Also avoid L<phasers|/language/objects#Object_Construction> for rule/token/regex
+Also avoid L<phasers|/language/objects#Object_construction> for rule/token/regex
 names: C<TWEAK>, C<BUILD>, C<BUILD-ALL> will throw another kind of exception if
 you do that: C<Cannot find method 'match': no method cache and no
 .^find_method>, once again only slightly related to what is actually going on.

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -263,7 +263,7 @@ X<|FALLBACK (method)>
 A method with the special name C<FALLBACK> will be called when other means to
 resolve the name produce no result. The first argument holds the name and all
 following arguments are forwarded from the original call. Multi methods and
-L«sub-signatures|/type/Signature#Destructuring_Parameters» are supported.
+L«sub-signatures|/type/Signature#Destructuring_arguments» are supported.
 
     class Magic {
         method FALLBACK ($name, |c(Int, Str)) {

--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -6,7 +6,7 @@
 
 Perl 6 allows the use of unicode characters as variable names.  Many
 operators are defined with unicode symbols (in particular the L<set/bag
-operators|/language/setbagmix#Set%2FBag_Operators>) as well as some quoting
+operators|/language/setbagmix#Set%2FBag_operators>) as well as some quoting
 constructs.  Hence it is good to know how to enter these symbols into editors,
 the Perl 6 shell and the command line, especially if the symbols aren't
 available as actual characters on a keyboard.
@@ -255,7 +255,7 @@ Thus constructs such as these are now possible:
 
 =head2 Set/bag operators
 
-The L<set/bag operators|/language/setbagmix#Set%2FBag_Operators> all
+The L<set/bag operators|/language/setbagmix#Set%2FBag_operators> all
 have set-theory-related symbols, the unicode code points and their ascii
 equivalents are listed below.  To compose such a character, it is merely
 necessary to enter the character composition chord (e.g. C<Ctrl-V u> in Vim;

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -73,7 +73,7 @@ The container type can be set with C<is> in a declaration.
     # OUTPUT: «X::OutOfRange: Hash key out of range. Is: cherry, should be in (oranges bananas)»
 
 For information on variables without sigils, see
-L<sigilless variables|#Sigilless variables>.
+L<sigilless variables|#Sigilless_variables>.
 
 =head2 Item and list assignment
 


### PR DESCRIPTION
Adjust links to headings according to latest adaptation of headings
from #Links_Of_This_Form to #Links_of_this_form.

refs: https://github.com/perl6/doc/issues/1838

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
