### PR TITLE
Changes routine headlines

### DIFF
--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -283,7 +283,7 @@ radians.
     say atan2(3);               # OUTPUT: «1.24904577239825␤»
     say 3.atan2;                # OUTPUT: «1.24904577239825␤»
 
-=head2 method sec
+=head2 routine sec
 
 Defined as:
 
@@ -563,7 +563,7 @@ of 10. Returns C<NaN> for negative arguments and C<-Inf> for C<0>.
 
     say log10(1001);            # OUTPUT: «3.00043407747932␤»
 
-=head2 method exp
+=head2 routine exp
 
 Defined as:
 
@@ -909,7 +909,7 @@ C<$pattern> is applied to the remaining characters of C<$string>.
     say "perL 6".samecase("A__a__"); # OUTPUT: «Perl 6␤»
     say "pERL 6".samecase("Ab");     # OUTPUT: «Perl 6␤»
 
-=head2 method uniprop
+=head2 routine uniprop
 
 Defined as:
 
@@ -928,7 +928,7 @@ Returns a Bool for Boolean properties.
     say 'a'.uniprop('Alphabetic'); # OUTPUT: «True␤»
     say '1'.uniprop('Alphabetic'); # OUTPUT: «False␤»
 
-=head2 method uniprops
+=head2 sub uniprops
 
 Defined as:
 
@@ -941,7 +941,7 @@ L<General Category|https://en.wikipedia.org/wiki/Unicode_character_property#Gene
 Returns a Bool for Boolean properties. Similar to L<uniprop|/routine/uniprop>
 
 
-=head2 method uniname
+=head2 routine uniname
 
 Defined as:
 
@@ -963,7 +963,7 @@ codepoints, and L<uniparse> for the opposite direction.
     say (0..0x1FFFF).sort(*.uniname.chars)[*-1].chr.uniname;
     # OUTPUT: ««ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA INITIAL FORM␤»␤»
 
-=head2 method uninames
+=head2 routine uninames
 
 Defined as:
 
@@ -983,7 +983,7 @@ codepoints in that character.
 
 See L<uniparse> for the opposite direction.
 
-=head2 method unimatch
+=head2 routine unimatch
 
 Defined as:
 
@@ -1252,7 +1252,7 @@ Returns an undefined value if C<$needle> wasn't found.
 
 See L<the documentation in type Str|/type/Str#routine_rindex> for examples.
 
-=head2 routine match
+=head2 method match
 
 Defined as:
 
@@ -1393,7 +1393,7 @@ C<EVAL> is also a gateway for executing code in other languages:
 =for code
 EVAL "use v5.20; say 'Hello from perl5!'", :lang<Perl5>;
 
-=head2 routine EVALFILE
+=head2 sub EVALFILE
 
 Defined as:
 


### PR DESCRIPTION
If a routine is only defined as sub, change to 'sub name', if only by
method to 'method name', and if by both to 'routine name' - where this was
not already the case.

## The problem
Methods, routines, subs misnamed on Cool page #2308

## Solution provided
Made changes

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
