### PR TITLE
Add Pod::Defn & Pod::FormattingCode

### DIFF
--- a/doc/Type/Pod/Block.pod6
+++ b/doc/Type/Pod/Block.pod6
@@ -25,6 +25,8 @@ Useful subclasses:
                                   tabular data
     Pod::Heading              =head1 etc. headings
     Pod::Item                 list items
+    Pod::Defn                 definition lists
+    Pod::FormattingCode       formatting codes
 
 =end table
 

--- a/doc/Type/Pod/Defn.pod6
+++ b/doc/Type/Pod/Defn.pod6
@@ -1,0 +1,19 @@
+=begin pod
+
+=TITLE class Pod::Defn
+
+=SUBTITLE Pod Definition List
+
+    class Pod::Defn is Pod::Block { }
+
+Class for definition lists in a Pod document.
+
+=head1 Methods
+
+=head2 method term
+
+    method term(--> Mu)
+
+=end pod
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/doc/Type/Pod/FormattingCode.pod6
+++ b/doc/Type/Pod/FormattingCode.pod6
@@ -1,0 +1,23 @@
+=begin pod
+
+=TITLE class Pod::FormattingCode
+
+=SUBTITLE Pod Formatting Code
+
+    class Pod::FormattingCode is Pod::Block { }
+
+Class for formatting codes in a Pod document.
+
+=head1 Methods
+
+=head2 method type
+
+    method type(--> Mu)
+
+=head2 method meta
+
+    method meta(--> Positional)
+
+=end pod
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
## The problem
Missing type doc for `Pod::Defn` & `Pod::FormattingCode`
Related issues: #2238 & #2302 

## Solution provided
Add type docs
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
