### PR TITLE
Rewrite of Syntax-Identifier section

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -225,13 +225,12 @@ say 'code again';
 
 Identifiers are grammatical building blocks that may be used to give a name
 to entities/objects such as constants, variables (e.g. Scalars) and routines
-(e.g. Subs and Methods). In a variable name, an identifier is normally preceded
-by a sigil; i.e. the sigil is not part of the identifier, only of the variable
-name.
+(e.g. Subs and Methods). In a L<variable name|/language/variables>, any sigil
+(and twigil) precedes the identifier and does not form a part thereof.
 
-    constant c = 299792458;         # Identifier "c" names an Int
-    my $a = 123;                    # Identifier "a" in the name "$a" of a Scalar
-    sub hello { say "Hello!" };     # Identifier "hello" names a Sub
+    constant c = 299792458;         # identifier "c" names an Int
+    my $a = 123;                    # identifier "a" in the name "$a" of a Scalar
+    sub hello { say "Hello!" };     # identifier "hello" names a Sub
 
 Identifiers come in different forms: ordinary identifiers, extended
 identifiers, and compound identifiers.
@@ -239,20 +238,21 @@ identifiers, and compound identifiers.
 =head3 Ordinary identifiers
 
 An ordinary identifier is composed of a leading alphabetic character
-that may be followed by one or more alphanumeric characters. It may also
+which may be followed by one or more alphanumeric characters. It may also
 contain isolated, embedded apostrophes C<'> and/or hyphens C<->, provided
 that the next character is each time alphabetic.
 
 The definitions of "alphabetic" and "alphanumeric" include appropriate Unicode
 characters. Which characters are "appropriate" depends on the implementation.
 In the Rakudo/MoarVM Perl 6 implementation alphabetic characters include
-Unicode characters in the character category I<Letter>, and the underscore
-C<_>. Alphanumeric characters additionally include Unicode characters in the
-general category I<Number, Decimal Digit> (Nd).
+characters with the Unicode General Category value I<Letter> (L), and the
+underscore C<_>. Alphanumeric characters additionally include characters with
+the Unicode General Category value I<Number, Decimal Digit> (Nd).
 
 =begin code :skip-test
 # valid ordinary identifiers:
 x
+_snake_oil
 something-longer
 with-numbers1234
 don't-do-that
@@ -265,17 +265,8 @@ piece_of_π
 42                    # Identifier does not start with alphabetic character
 with-numbers1234-5    # Embedded hyphen not followed by alphabetic character
 is-prime?             # Question mark is not alphanumeric
-x²                    # Superscript 2 has Unicode general category No
+x²                    # Superscript 2 is not alphanumeric (in the sense explained above)
 =end code
-
-In the C<x²> example above, since the Unicode superscript numeral C<²> is not
-alphanumeric, it cannot be a part of an ordinary identifier. Still, it may form
-part of a valid expression as an operator. The expression C<$x²>, for instance,
-produces the square of variable C<$x>. This should be somewhat surprising at this
-point, since operators are L<Subs|/type/Sub>, and, as mentioned above, Subs are
-named using identifiers. So how does the superscript numeral get accepted as
-(part of) an identifier? The key to this riddle lies in the concept of I<extended
-identifiers>, which is elaborated upon in the next section.
 
 =head3 Extended identifiers
 
@@ -298,26 +289,26 @@ my Dog $spot .= new("woof");        # this.
 =end code
 
 Similarly, sets of operators work together in various syntactic categories with names
-like C<prefix>, C<infix>, C<postfix>, etc. The long, official names of these operators,
-however, often contain characters that are excluded from ordinary identifiers:
+like C<prefix>, C<infix>, C<postfix>, etc. The long, official names of these operators
+often contain characters that are excluded from ordinary identifiers:
 
     infix:<+>                       # the official name of the operator in $a + $b
     infix:<*>                       # the official name of the operator in $a * $b
     infix:«<=»                      # the official name of the operator in $a <= $b
 
-For all such uses, you can append one or more subscript-like adverbial forms or "colon
-pairs" to an ordinary identifier to create a so-called I<extended identifier>. When
-appended to an identifier (that is, in postfix position), the adverbial syntax
-generates unique variants of that identifier.
+For all such uses, you can append one or more "colon pairs" to an ordinary identifier
+to create a so-called I<extended identifier>. When appended to an identifier (that is,
+in postfix position), the colon pair generates unique variants of that identifier.
 
-The generic colon pair notation acceptable in identifiers is C<:key<value>> : it starts
-with a single colon C<:>, followed by an ordinary identifier C<key>, in turn followed
-by some quoting bracketing construct, such as C«< >», C<« »> or C<[' ']>, which quotes
-one or more arbitrary characters C<value>:
+The generic colon pair syntax acceptable in identifiers is C<:key<value>>, wherein
+C<key> I<or> C<value> is optional. A colon pair thus starts with a single colon C<:>,
+followed by an ordinary identifier C<key> and/or a quoting bracketing construct
+such as C«< >», C<« »> or C<[' ']> which quotes one or more arbitrary characters
+C<value>:
 
 =begin code :skip-test
 # exemplary valid extended identifiers:
-postfix:<²>                         # The official long name of the operator in $x²
+postfix:<²>                         # the official long name of the operator in $x²
 WOW:That'sAwesome
 WOW:That's<<🆒>>
 party:sweet<16>
@@ -326,13 +317,10 @@ party:sweet<16>
 party:16<sweet>                     # 16 is not an ordinary identifier
 party:16sweet
 party:!a                            # ...and neither is !a
-party:$a                            # ...or $a
+party:$a                            # ...nor $a
 =end code
-N<As the examples illustrate, the C<key> I<or> the quoted C<value> is optional.
-Colon pairs with a null key are normally used for naming operators, as
-in the first two examples above. Starting with Perl 6 language version 6.d, colon
-pairs with C<sym> as the C<key> (e.g. C«:sym<foo>») are reserved for possible
-future use.>
+N<Starting with Perl 6 language version 6.d, colon pairs with C<sym> as the
+C<key> (e.g. C«:sym<foo>») are reserved for possible future use.>
 
 In an extended identifier, the colon pair is considered an integral part of the name,
 so C<infix:<+>> and C<infix:<->> are two different operators. The bracketing
@@ -384,19 +372,15 @@ names.
     constant $what = 'are';
     my @we:<are>= <the champions>;
     say @we:«$what»;                # OUTPUT: «[the champions]␤»
-    say @we:[$what];                # OUTPUT: «[the champions]␤»
     say @we:<$what>;                # Compilation error: Variable '@we:<$what>' is not declared
 
 =head3 Compound identifiers
 
 A compound identifier is an identifier that is composed of two or more
 ordinary and/or extended identifiers that are separated from one another by a
-double colon C<::>. Note that the C<::> is referred to as a I<double colon>,
-and not as a I<colon pair>. The latter term refers to the adverbial syntax
-C<:key<value>> that may be used to create a Pair, or, as described above, to
-create an extended identifier.
+double colon C<::>.
 
-The double colon C<::> is also known as the I<namespace separator> or the
+The double colon C<::> is known as the I<namespace separator> or the
 I<package delimiter>, which clarifies its semantic function in a name: to force
 the preceding portion of the name to be considered a
 L<package|/language/packages>/namespace through which the subsequent portion of

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -292,9 +292,11 @@ Similarly, sets of operators work together in various syntactic categories with 
 like C<prefix>, C<infix>, C<postfix>, etc. The long, official names of these operators
 often contain characters that are excluded from ordinary identifiers:
 
+=begin code :skip-test
     infix:<+>                       # the official name of the operator in $a + $b
     infix:<*>                       # the official name of the operator in $a * $b
     infix:«<=»                      # the official name of the operator in $a <= $b
+=end code
 
 For all such uses, you can append one or more "colon pairs" to an ordinary identifier
 to create a so-called I<extended identifier>. When appended to an identifier (that is,
@@ -327,41 +329,51 @@ so C<infix:<+>> and C<infix:<->> are two different operators. The bracketing
 characters used, however, do not count as part of the name; only the quoted data
 matters. So these are all the same name:
 
+=begin code :skip-test
     infix:<+>
     infix:<<+>>
     infix:«+»
     infix:['+']
     infix:('+')
+=end code
 
 Similarly, all of this works:
 
+=begin code :skip-test
     my $foo:bar<baz> = 'quux';
     say $foo:bar«baz»;                                  # OUTPUT: «quux␤»
     my $take-me:<home> = 'When the glory has no end';
     say $take-me:['home'];                              # OUTPUT: «When the glory has no end␤»
     my $foo:bar<2> = 5;
     say $foo:bar(1+1);                                  # OUTPUT: «5␤»
+=end code
 
 Where an extended identifier comprises two or more colon pairs, their order
 is generally significant:
 
+=begin code :skip-test
     my $a:b<c>:d<e> = 100;
     my $a:d<e>:b<c> = 200;
     say $a:b<c>:d<e>;               # OUTPUT: «100␤», NOT: «200␤»
+=end code
 
 An exception to this rule is I<module versioning>; so these identifiers
 effectively name the same module:
 
+=begin code :skip-test
     use ThatModule:auth<Somebody>:ver<2.7.18.28.18>
     use ThatModule:ver<2.7.18.28.18>:auth<Somebody>
+=end code
 
 Furthermore, the adverbial form in extended identifiers supports
 compile-time interpolation, which mandates the use of
 L<constants|/language/terms#Constants> for the interpolation values:
 
+=begin code :skip-test
     constant $c = 42;               # Constant binds to Int; $-sigil enables interpolation
     my $a:foo<42> = "answer";
     say $a:foo«$c»;                 # OUTPUT: «answer␤»
+=end code
 
 Although quoting bracketing constructs are generally interchangeable
 in the context of identifiers, they are not identical. In particular,
@@ -369,10 +381,12 @@ angle brackets C«< >» (which mimic single quote interpolation
 characteristics) cannot be used for the interpolation of constant
 names.
 
+=begin code :skip-test
     constant $what = 'are';
     my @we:<are>= <the champions>;
     say @we:«$what»;                # OUTPUT: «[the champions]␤»
     say @we:<$what>;                # Compilation error: Variable '@we:<$what>' is not declared
+=end code
 
 =head3 Compound identifiers
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -268,52 +268,73 @@ is-prime?             # Question mark is not alphanumeric
 x²                    # Superscript 2 has Unicode general category No
 =end code
 
-In the C<x²> example above, the Unicode superscript numeral C<²> is not, and
-cannot be, a part of an ordinary identifier. Still, it may form part of a valid
-expression as an operator. The expression C<$x²>, for instance, produces the
-square of variable C<$x>. This should be somewhat surprising at this point,
-since operators are L<Subs|/type/Sub>, and, as mentioned above, Subs are named using
-identifiers. So how does the superscript numeral get accepted as (part of) an
-identifier? The key to this riddle lies in the concept of I<extended
+In the C<x²> example above, since the Unicode superscript numeral C<²> is not
+alphanumeric, it cannot be a part of an ordinary identifier. Still, it may form
+part of a valid expression as an operator. The expression C<$x²>, for instance,
+produces the square of variable C<$x>. This should be somewhat surprising at this
+point, since operators are L<Subs|/type/Sub>, and, as mentioned above, Subs are
+named using identifiers. So how does the superscript numeral get accepted as
+(part of) an identifier? The key to this riddle lies in the concept of I<extended
 identifiers>, which is elaborated upon in the next section.
 
 =head3 Extended identifiers
 
-It is often convenient to have names that contain arbitrary characters.
-Use cases include situations where a set of entities shares a common "short"
-name, but still needs for each of its elements to be identifiable individually.
-For example, you might use a module whose short name is C<ThatModule>, but the
-complete long name of a module includes its version, naming authority, and
-perhaps even its source language. Similarly, sets of operators work together in
-various syntactic categories with names like C<prefix>, C<infix>, C<postfix>,
-etc. The (long) names of these operators, however, often contain characters that
-are excluded from ordinary identifiers.
-
-For all such uses, you can append one or more
-L<adverbial pairs|/language/syntax#Adverbial_pairs_(colon_pairs)> to an ordinary
-identifier to create a so-called I<extended identifier>. When appended
-to an identifier (that is, in postfix position), the adverbial pair syntax
-generates unique variants of that identifier.
-
-The generic form of an adverbial pair or "colon pair" is C<:key<value>> :
-it starts with a single colon C<:>, followed by an ordinary identifier C<key>,
-in turn followed by some quoting bracketing construct, such as C«< >», C<« »> or
-C<[' ']>, which quotes one or more arbitrary characters C<value>:
+It is often convenient to have names that contain characters that are not allowed
+in ordinary identifiers. Use cases include situations where a set of entities shares
+a common "short" name, but still needs for each of its elements to be identifiable
+individually. For example, you might use a module whose short name is C<Dog>, while
+its long name includes its naming authority and version:
 
 =begin code :skip-test
-# exemplary extended identifiers:
-infix:<+>                           # The official long name of the operator in $a + $b
-postfix:<²>                         # The official long name of the operator in $x²
-WOW:That's<<🆒>>
-ThatModule:auth<Somebody>:ver<2.7.18>
+Dog:auth<Somebody>:ver<1.0>         # Long module names including author and version
+Dog:auth<Somebody>:ver<2.0>
+
+------------------------------------
+
+use Dog:auth<Somebody>:ver<2.0>;    # Selection of second module causes its full name
+                                    # to be aliased to the short name for the rest of
+                                    # the lexical scope, allowing a declaration like
+my Dog $spot .= new("woof");        # this.
 =end code
 
-The C<key> I<or> the quoted C<value> is optional. Colon pairs with a null key
-C<key> are normally used for naming operators, as in the first two examples
-above. Starting with Perl 6 language version 6.d, colon pairs with C<sym> as
-the C<key> (e.g. C«:sym<foo>») are reserved for possible future use.
+Similarly, sets of operators work together in various syntactic categories with names
+like C<prefix>, C<infix>, C<postfix>, etc. The long, official names of these operators,
+however, often contain characters that are excluded from ordinary identifiers:
 
-In an extended identifier, the adverb is considered an integral part of the name,
+    infix:<+>                       # the official name of the operator in $a + $b
+    infix:<*>                       # the official name of the operator in $a * $b
+    infix:«<=»                      # the official name of the operator in $a <= $b
+
+For all such uses, you can append one or more subscript-like adverbial forms or "colon
+pairs" to an ordinary identifier to create a so-called I<extended identifier>. When
+appended to an identifier (that is, in postfix position), the adverbial syntax
+generates unique variants of that identifier.
+
+The generic colon pair notation acceptable in identifiers is C<:key<value>> : it starts
+with a single colon C<:>, followed by an ordinary identifier C<key>, in turn followed
+by some quoting bracketing construct, such as C«< >», C<« »> or C<[' ']>, which quotes
+one or more arbitrary characters C<value>:
+
+=begin code :skip-test
+# exemplary valid extended identifiers:
+postfix:<²>                         # The official long name of the operator in $x²
+WOW:That'sAwesome
+WOW:That's<<🆒>>
+party:sweet<16>
+
+# exemplary invalid extended identifiers:
+party:16<sweet>                     # 16 is not an ordinary identifier
+party:16sweet
+party:!a                            # ...and neither is !a
+party:$a                            # ...or $a
+=end code
+N<As the examples illustrate, the C<key> I<or> the quoted C<value> is optional.
+Colon pairs with a null key are normally used for naming operators, as
+in the first two examples above. Starting with Perl 6 language version 6.d, colon
+pairs with C<sym> as the C<key> (e.g. C«:sym<foo>») are reserved for possible
+future use.>
+
+In an extended identifier, the colon pair is considered an integral part of the name,
 so C<infix:<+>> and C<infix:<->> are two different operators. The bracketing
 characters used, however, do not count as part of the name; only the quoted data
 matters. So these are all the same name:
@@ -346,7 +367,7 @@ effectively name the same module:
     use ThatModule:auth<Somebody>:ver<2.7.18.28.18>
     use ThatModule:ver<2.7.18.28.18>:auth<Somebody>
 
-Furthermore, the adverbial pair syntax in extended identifiers supports
+Furthermore, the adverbial form in extended identifiers supports
 compile-time interpolation, which mandates the use of
 L<constants|/language/terms#Constants> for the interpolation values:
 
@@ -371,7 +392,7 @@ names.
 A compound identifier is an identifier that is composed of two or more
 ordinary and/or extended identifiers that are separated from one another by a
 double colon C<::>. Note that the C<::> is referred to as a I<double colon>,
-and not as a I<colon pair>. The latter term refers to the adverbial pair syntax
+and not as a I<colon pair>. The latter term refers to the adverbial syntax
 C<:key<value>> that may be used to create a Pair, or, as described above, to
 create an extended identifier.
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -249,7 +249,7 @@ characters with the Unicode General Category value I<Letter> (L), and the
 underscore C<_>. Alphanumeric characters additionally include characters with
 the Unicode General Category value I<Number, Decimal Digit> (Nd).
 
-=begin code :skip-test
+=begin code
 # valid ordinary identifiers:
 x
 _snake_oil
@@ -260,12 +260,12 @@ piece_of_π
 駱駝道                 # "Rakuda-dō", Japanese for "Way of the camel"
 =end code
 
-=begin code :skip-test
+=begin code
 # invalid ordinary identifiers:
-42                    # Identifier does not start with alphabetic character
-with-numbers1234-5    # Embedded hyphen not followed by alphabetic character
-is-prime?             # Question mark is not alphanumeric
-x²                    # Superscript 2 is not alphanumeric (in the sense explained above)
+42                    # identifier does not start with alphabetic character
+with-numbers1234-5    # embedded hyphen not followed by alphabetic character
+is-prime?             # question mark is not alphanumeric
+x²                    # superscript 2 is not alphanumeric (in the sense explained above)
 =end code
 
 =head3 Extended identifiers
@@ -276,8 +276,8 @@ a common "short" name, but still needs for each of its elements to be identifiab
 individually. For example, you might use a module whose short name is C<Dog>, while
 its long name includes its naming authority and version:
 
-=begin code :skip-test
-Dog:auth<Somebody>:ver<1.0>         # Long module names including author and version
+=begin code
+Dog:auth<Somebody>:ver<1.0>         # long module names including author and version
 Dog:auth<Somebody>:ver<2.0>
 
 ------------------------------------
@@ -292,7 +292,7 @@ Similarly, sets of operators work together in various syntactic categories with 
 like C<prefix>, C<infix>, C<postfix>, etc. The long, official names of these operators
 often contain characters that are excluded from ordinary identifiers:
 
-=begin code :skip-test
+=begin code
     infix:<+>                       # the official name of the operator in $a + $b
     infix:<*>                       # the official name of the operator in $a * $b
     infix:«<=»                      # the official name of the operator in $a <= $b
@@ -308,7 +308,7 @@ followed by an ordinary identifier C<key> and/or a quoting bracketing construct
 such as C«< >», C<« »> or C<[' ']> which quotes one or more arbitrary characters
 C<value>:
 
-=begin code :skip-test
+=begin code
 # exemplary valid extended identifiers:
 postfix:<²>                         # the official long name of the operator in $x²
 WOW:That'sAwesome
@@ -329,7 +329,7 @@ so C<infix:<+>> and C<infix:<->> are two different operators. The bracketing
 characters used, however, do not count as part of the name; only the quoted data
 matters. So these are all the same name:
 
-=begin code :skip-test
+=begin code
     infix:<+>
     infix:<<+>>
     infix:«+»
@@ -339,7 +339,7 @@ matters. So these are all the same name:
 
 Similarly, all of this works:
 
-=begin code :skip-test
+=begin code
     my $foo:bar<baz> = 'quux';
     say $foo:bar«baz»;                                  # OUTPUT: «quux␤»
     my $take-me:<home> = 'When the glory has no end';
@@ -351,7 +351,7 @@ Similarly, all of this works:
 Where an extended identifier comprises two or more colon pairs, their order
 is generally significant:
 
-=begin code :skip-test
+=begin code
     my $a:b<c>:d<e> = 100;
     my $a:d<e>:b<c> = 200;
     say $a:b<c>:d<e>;               # OUTPUT: «100␤», NOT: «200␤»
@@ -360,16 +360,16 @@ is generally significant:
 An exception to this rule is I<module versioning>; so these identifiers
 effectively name the same module:
 
-=begin code :skip-test
+=begin code
     use ThatModule:auth<Somebody>:ver<2.7.18.28.18>
     use ThatModule:ver<2.7.18.28.18>:auth<Somebody>
 =end code
 
-Furthermore, the adverbial form in extended identifiers supports
-compile-time interpolation, which mandates the use of
+Furthermore, colon pairs in extended identifiers support
+compile-time interpolation; this requires the use of
 L<constants|/language/terms#Constants> for the interpolation values:
 
-=begin code :skip-test
+=begin code
     constant $c = 42;               # Constant binds to Int; $-sigil enables interpolation
     my $a:foo<42> = "answer";
     say $a:foo«$c»;                 # OUTPUT: «answer␤»
@@ -381,7 +381,7 @@ angle brackets C«< >» (which mimic single quote interpolation
 characteristics) cannot be used for the interpolation of constant
 names.
 
-=begin code :skip-test
+=begin code
     constant $what = 'are';
     my @we:<are>= <the champions>;
     say @we:«$what»;                # OUTPUT: «[the champions]␤»

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -223,109 +223,193 @@ say 'code again';
 
 =head2 X<Identifiers|identifier,identifiers>
 
-Identifiers are grammatical building blocks that occur in several kind
-of statements, giving a name to objects, data structures and blocks of
-code. These names must start with an alphabetic character (or an
-underscore), followed by zero or more word characters (alphabetic,
-underscore or number). You can also embed dashes C<-> or single quotes
-C<'> in the middle, but not two in a row, and only if followed
-immediately by an alphabetic character.
+Identifiers are grammatical building blocks that may be used to give a name
+to entities/objects such as constants, variables (e.g. Scalars) and routines
+(e.g. Subs and Methods). In a variable name, an identifier is normally preceded
+by a sigil; i.e. the sigil is not part of the identifier, only of the variable
+name.
+
+    constant c = 299792458;         # Identifier "c" names an Int
+    my $a = 123;                    # Identifier "a" in the name "$a" of a Scalar
+    sub hello { say "Hello!" };     # Identifier "hello" names a Sub
+
+Identifiers come in different forms: ordinary identifiers, extended
+identifiers, and compound identifiers.
+
+=head3 Ordinary identifiers
+
+An ordinary identifier is composed of a leading alphabetic character
+that may be followed by one or more alphanumeric characters. It may also
+contain isolated, embedded apostrophes C<'> and/or hyphens C<->, provided
+that the next character is each time alphabetic.
+
+The definitions of "alphabetic" and "alphanumeric" include appropriate Unicode
+characters. Which characters are "appropriate" depends on the implementation.
+In the Rakudo/MoarVM Perl 6 implementation alphabetic characters include
+Unicode characters in the character category I<Letter>, and the underscore
+C<_>. Alphanumeric characters additionally include Unicode characters in the
+general category I<Number, Decimal Digit> (Nd).
 
 =begin code :skip-test
-# valid identifiers:
+# valid ordinary identifiers:
 x
 something-longer
 with-numbers1234
-don't
-fish-food
-π
+don't-do-that
+piece_of_π
+駱駝道                 # "Rakuda-dō", Japanese for "Way of the camel"
 =end code
 
 =begin code :skip-test
-# not valid identifiers:
-with-numbers1234-5
-42
-is-prime?
-fish--food
+# invalid ordinary identifiers:
+42                    # Identifier does not start with alphabetic character
+with-numbers1234-5    # Embedded hyphen not followed by alphabetic character
+is-prime?             # Question mark is not alphanumeric
+x²                    # Superscript 2 has Unicode general category No
 =end code
 
-You use identifiers to name of constants, types (including classes and
-modules) and routines (subs and methods); they also appear in variable
-names usually proceeded by a sigil; see L<variables|/language/variables>
-for more details.
+In the C<x²> example above, the Unicode superscript numeral C<²> is not, and
+cannot be, a part of an ordinary identifier. Still, it may form part of a valid
+expression as an operator. The expression C<$x²>, for instance, produces the
+square of variable C<$x>. This should be somewhat surprising at this point,
+since operators are L<Subs|/type/Sub>, and, as mentioned above, Subs are named using
+identifiers. So how does the superscript numeral get accepted as (part of) an
+identifier? The key to this riddle lies in the concept of I<extended
+identifiers>, which is elaborated upon in the next section.
 
-Namespaces are provided by L<packages|/language/packages>. By separating
-identifiers with double colons, the right most name is inserted into
-existing or automatically created packages.
+=head3 Extended identifiers
 
-    my Int $Foo::Bar::buzz = 42;
-    say $Foo::Bar::buzz; # OUTPUT: «42␤»
+It is often convenient to have names that contain arbitrary characters.
+Use cases include situations where a set of entities shares a common "short"
+name, but still needs for each of its elements to be identifiable individually.
+For example, you might use a module whose short name is C<ThatModule>, but the
+complete long name of a module includes its version, naming authority, and
+perhaps even its source language. Similarly, sets of operators work together in
+various syntactic categories with names like C<prefix>, C<infix>, C<postfix>,
+etc. The (long) names of these operators, however, often contain characters that
+are excluded from ordinary identifiers.
 
-Identifiers can contain colon pairs. The entire colon pair becomes part
-of the name of the identifier.
+For all such uses, you can append one or more
+L<adverbial pairs|/language/syntax#Adverbial_pairs_(colon_pairs)> to an ordinary
+identifier to create a so-called I<extended identifier>. When appended
+to an identifier (that is, in postfix position), the adverbial pair syntax
+generates unique variants of that identifier.
 
-    my $foo::bar = 1;
-    say MY::.keys;
-    # OUTPUT: «($=pod !UNIT_MARKER EXPORT $_ $! ::?PACKAGE
-    #          GLOBALish $¢ $=finish $/ $foo:bar $foo:bar<2>
-    #          $?PACKAGE)␤»
-    say OUR::.key; # OUTPUT: «foo␤»
+The generic form of an adverbial pair or "colon pair" is C<:key<value>> :
+it starts with a single colon C<:>, followed by an ordinary identifier C<key>,
+in turn followed by some quoting bracketing construct, such as C«< >», C<« »> or
+C<[' ']>, which quotes one or more arbitrary characters C<value>:
 
-The last sentence shows how the C<foo> package has been created
-automatically, as a deposit for variables in that namespace.
+=begin code :skip-test
+# exemplary extended identifiers:
+infix:<+>                           # The official long name of the operator in $a + $b
+postfix:<²>                         # The official long name of the operator in $x²
+WOW:That's<<🆒>>
+ThatModule:auth<Somebody>:ver<2.7.18>
+=end code
 
-Identifiers can also contain single colons, and in that case they can
-add I<symbols> within angle brackets. This is a mechanism that supports
-interpolation; which is also supported by colonpairs if the interpolated
-variable is inserted in parentheses. Please note that resolution of
-names often happens at compile time, so interpolation values must be
-known at compile time.
+The C<key> I<or> the quoted C<value> is optional. Colon pairs with a null key
+C<key> are normally used for naming operators, as in the first two examples
+above. Starting with Perl 6 language version 6.d, colon pairs with C<sym> as
+the C<key> (e.g. C«:sym<foo>») are reserved for possible future use.
 
-    my $foo:bar<2> = 2;
-    constant $c = 42;
-    my $a:foo<42> = "answer";
-    say $a:foo«$c»;    # OUTPUT: «answer␤»
-    my $buz = "qux";
-    my $bur::quux = 7;
-    say $bur::($buz);  # OUTPUT: «7␤»
+In an extended identifier, the adverb is considered an integral part of the name,
+so C<infix:<+>> and C<infix:<->> are two different operators. The bracketing
+characters used, however, do not count as part of the name; only the quoted data
+matters. So these are all the same name:
 
-The first statement is an example of I<X<extended identifiers>>. Extended
-identifiers are used extensively in the definition of the language, for
-instance, to define L<terms|language/syntax#Term_term:%3C%3E>. They include a
-colon C<:> in their name, and might include a bracketing-quoting construct such
-as C<«»>, C«<>» or C<['']>. These bracketing constructs are interchangeable. For
-instance
+    infix:<+>
+    infix:<<+>>
+    infix:«+»
+    infix:['+']
+    infix:('+')
+
+Similarly, all of this works:
 
     my $foo:bar<baz> = 'quux';
-    say $foo:bar«baz»; # OUTPUT: «quux␤»
+    say $foo:bar«baz»;                                  # OUTPUT: «quux␤»
     my $take-me:<home> = 'When the glory has no end';
-    say $take-me:['home'];# OUTPUT: «When the glory has no end␤»
+    say $take-me:['home'];                              # OUTPUT: «When the glory has no end␤»
+    my $foo:bar<2> = 5;
+    say $foo:bar(1+1);                                  # OUTPUT: «5␤»
 
-This extended syntax is used, for intance, for module versions and
-authors in the shape:
-C«HTTP::UserAgent:ver<1.1.16>:auth<github:sergot>».
+Where an extended identifier comprises two or more colon pairs, their order
+is generally significant:
 
-Colonpairs with empty key (e.g. C«:<foo>») aer reserved in subroutine
-names, as they're used to introduce
-L<a new custom operator|/language/functions#Defining_operators> into
-a particular category. Starting with 6.d language, colonpairs with
-C<sym> key (e.g. C«:sym<foo>») are reserved for possible future use.
+    my $a:b<c>:d<e> = 100;
+    my $a:d<e>:b<c> = 200;
+    say $a:b<c>:d<e>;               # OUTPUT: «100␤», NOT: «200␤»
 
-There are slight differences between the three constructs: C«<>» cannot be used
-for interpolation of constant names.
+An exception to this rule is I<module versioning>; so these identifiers
+effectively name the same module:
 
-    constant $what= 'are';
+    use ThatModule:auth<Somebody>:ver<2.7.18.28.18>
+    use ThatModule:ver<2.7.18.28.18>:auth<Somebody>
+
+Furthermore, the adverbial pair syntax in extended identifiers supports
+compile-time interpolation, which mandates the use of
+L<constants|/language/terms#Constants> for the interpolation values:
+
+    constant $c = 42;               # Constant binds to Int; $-sigil enables interpolation
+    my $a:foo<42> = "answer";
+    say $a:foo«$c»;                 # OUTPUT: «answer␤»
+
+Although quoting bracketing constructs are generally interchangeable
+in the context of identifiers, they are not identical. In particular,
+angle brackets C«< >» (which mimic single quote interpolation
+characteristics) cannot be used for the interpolation of constant
+names.
+
+    constant $what = 'are';
     my @we:<are>= <the champions>;
-    say @we:«$what»; # «[the champions]␤»
+    say @we:«$what»;                # OUTPUT: «[the champions]␤»
+    say @we:[$what];                # OUTPUT: «[the champions]␤»
+    say @we:<$what>;                # Compilation error: Variable '@we:<$what>' is not declared
 
-This example, similar to the one used above, shows how constants can be
-interpolated into a variable name. Only constants can be used for this;
-using C«@we:<$what>» instead would yield an error; using C«@we:[$what]»,
-however, would be no problem.
+=head3 Compound identifiers
 
-Unicode superscript numerals are exponents and not part of an
-identifier; e.g. C<$x²> does the square of variable C<$x>.  Subscript
-numerals are TBD.
+A compound identifier is an identifier that is composed of two or more
+ordinary and/or extended identifiers that are separated from one another by a
+double colon C<::>. Note that the C<::> is referred to as a I<double colon>,
+and not as a I<colon pair>. The latter term refers to the adverbial pair syntax
+C<:key<value>> that may be used to create a Pair, or, as described above, to
+create an extended identifier.
+
+The double colon C<::> is also known as the I<namespace separator> or the
+I<package delimiter>, which clarifies its semantic function in a name: to force
+the preceding portion of the name to be considered a
+L<package|/language/packages>/namespace through which the subsequent portion of
+the name is to be located:
+
+    module MyModule {               # declare a module package
+        our $var = "Hello";         # declare package-scoped variable
+    }
+    say $MyModule::var              # OUTPUT: «Hello␤»
+
+In the example above, C<MyModule::var> is a compound identifier, composed
+of the package name identifier C<MyModule> and the identifier part of the
+variable name C<var>. Altogether C<$MyModule::var> is often referred
+to as a L<package-qualified name|/language/packages#Package-qualified_names>.
+
+Separating identifiers with double colons causes the rightmost name to be
+inserted into existing (see above example) I<or automatically created>
+packages:
+
+    my $foo::bar = 1;
+    say OUR::.keys;                 # OUTPUT: «(foo)␤»
+    say foo.HOW                     # OUTPUT: «Perl6::Metamodel::PackageHOW.new␤»
+
+The last lines shows how the C<foo> package was created automatically, as a
+deposit for variables in that namespace.
+
+The double colon syntax enables runtime
+L<interpolation|/language/packages#Interpolating_into_names> of a string into a
+package or variable name using C<::($expr)> where you'd ordinarily put a package
+or variable name:
+
+    my $buz = "quux";
+    my $bur::quux = 7;
+    say $bur::($buz);               # OUTPUT: «7␤»
 
 =head2 Term term:<>
 


### PR DESCRIPTION
## The problem
Identifier-section was perceived as a bit messy.

## Solution provided
Restructured section along the lines of the different types of identifiers: 