### PR TITLE
Document typing of returns in signature

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -846,6 +846,13 @@ will be checked against the given code object.
     CATCH { default { put .^name,': ', .Str } }
     # OUTPUT: «X::TypeCheck::Assignment: Type check failed in assignment to $i; expected Positive but got Int (-42)␤»
 
+Subsets can be used in signatures, e.g. by typing the output:
+    subset Foo of List where (Int,Str);
+    sub a($a, $b, --> Foo) { $a, $b }
+    # Only a List with the first element beint an Int and the second a Str will pass the type check.
+    a(1,"foo");  # passes
+    a("foo", 1); # fails
+
 Subsets can be anonymous, allowing inline placements where a subset is required
 but a name is neither needed nor desirable.
 


### PR DESCRIPTION
## The problem
As discussed on #perl6 document the typing of return in signatures.

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
