### PR TITLE
Mention phasers a bit more explicitly in the Control page

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -85,6 +85,12 @@ You have to watch out for this in most languages anyway to prevent things
 from getting accidentally commented out.  Many of the examples below may
 have unnecessary semicolons for clarity.
 
+=head1 X<Phasers|control flow,Phasers>
+
+Blocks may have phasers: special labeled blocks that break their execution
+into phases that run in particular phases. See the page
+L<phasers|/language/phasers> for the details.
+
 =head1 X<do|control flow,do>
 
 The simplest way to run a block where it cannot be a stand-alone statement
@@ -912,6 +918,24 @@ for @x -> $x {
 
 prints "1245".
 
+If the C<NEXT> L<phaser|/language/phasers> is present, it runs before the next iteration:
+
+=begin code
+my Int $i = 0;
+while ($i < 10) {
+  if ($i % 2 == 0) {
+    next;
+  }
+
+  say "$i is odd.";
+
+  NEXT {
+    $i++;
+  }
+}
+# OUTPUT: «1 is odd.␤3 is odd.␤5 is odd.␤7 is odd.␤9 is odd.␤»
+=end code
+
 =head1 X<last|control flow, last>
 
 The C<last> command immediately exits the loop in question.
@@ -926,6 +950,25 @@ for @x -> $x {
 =end code
 
 prints "12".
+
+If the C<LAST> L<phaser|/language/phasers> is present, it runs:
+
+=begin code
+my Int $i = 1;
+while ($i < 10) {
+  if ($i % 5 == 0) {
+    last;
+  }
+
+  LAST {
+    say "The last number was $i.";
+  }
+  NEXT {
+    $i++;
+  }
+}
+# OUTPUT: «The last number was 5.␤»
+=end code
 
 =head1 X<redo|control flow, redo>
 


### PR DESCRIPTION
## The problem
The Phasers were mentioned only in passing, and NEXT and LAST weren't mentioned at all.

## Solution provided
This patch mentioned the concept of phasers explicitly immediately after discussing blocks, and mentions the two common phasers NEXT and LAST when discussing the relevant tokens.

I think that it's my first pull request here, please be gentle :)
