### PR TITLE
Add a missing comma

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -650,7 +650,7 @@ Make your X<C<META6.json>|META6.json> file look something like this:
         "resources" : [ ],
         "tags": [
           "Vortex", "Total", "Perspective"
-        ]
+        ],
         "source-url" : "git://github.com/R<you>/Vortex-TotalPerspective.git"
     }
 =end code


### PR DESCRIPTION
## The problem
A missing comma in a META6.json example

## Solution provided
The comma was added, validating the JSON
