### PR TITLE
Corrects some imprecisions in the "Doing math with Perl 6" article

### DIFF
--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -84,7 +84,7 @@ mathematical notation.
 Perl 6 can do arithmetic using different data types. L<Num>, L<Rat> and
 L<Complex> can all operate as a L<field under the operations of addition, subtraction, multiplication and division|https://en.wikipedia.org/wiki/Field_(mathematics)>
 (technically, it should be noted that data types dealing with floating point number representations are not a field in the mathematical sense due to the inherent
-imprecissions of their arithmetic. However, they constitute an approximate enough, computer friendly version of such mathematical objects for most of the cases).
+imprecisions of their arithmetic. However, they constitute an approximate enough, computer friendly version of such mathematical objects for most of the cases).
 The equivalent mathematical fields are:
 
 =begin table

--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -82,7 +82,9 @@ mathematical notation.
 =head1 Arithmetic
 
 Perl 6 can do arithmetic using different data types. L<Num>, L<Rat> and
-L<Complex> can all operate as a L<field under the operations of addition, subtraction, multiplication and division|https://en.wikipedia.org/wiki/Field_(mathematics)>.
+L<Complex> can all operate as a L<field under the operations of addition, subtraction, multiplication and division|https://en.wikipedia.org/wiki/Field_(mathematics)>
+(technically, it should be noted that data types dealing with floating point number representations are not a field in the mathematical sense due to the inherent
+imprecissions of their arithmetic. However, they constitute an approximate enough, computer friendly version of such mathematical objects for most of the cases).
 The equivalent mathematical fields are:
 
 =begin table
@@ -93,12 +95,10 @@ Num              ℝ
 Complex          ℂ
 =end table
 
-The C<Int>s, although technically corresponding to Z, is not really a
-mathematical field since they are not closed under the four arithmetical
-operations, and integers do not satisfy the
-L<identity axiom|https://math.stackexchange.com/questions/2192317/set-of-integers-not-a-field/2192330>.
-However, if the integer division C<div> is used, their operations will always
-yield other integers; if C</> is used, however, in general the result will be a
+The C<Int>s or ℤ, as they're usually called in mathematics, are not a
+mathematical field but rather a ring, since they are not closed under
+multiplicative inverses. However, if the integer division C<div> is used, their operations will always
+yield other integers; if C</> is used, on the other hand, in general the result will be a
 L<Rat>.
 
 Besides, C<Int> can do infinite-precision arithmetic (or at least infinite as
@@ -120,10 +120,10 @@ mathematically:
 basic operations for L<vectors|https://en.wikipedia.org/wiki/Coordinate_vector>.
 
 =item L<C<Math::Matrix>|https://github.com/pierre-vigier/Perl6-Math-Matrix>
-operates on the L<matrix field|https://en.wikipedia.org/wiki/Matrix_field>.
+operates on L<matrices rings over numeric rings|https://en.wikipedia.org/wiki/Matrix_(mathematics)>.
 
 =item L<C<Math::Quaternion>|https://github.com/Util/Perl6-Math-Quaternion>
-operates on the L<quaternion field|https://en.wikipedia.org/wiki/Quaternion>,
+operates on the L<quaternion algebra, ℍ|https://en.wikipedia.org/wiki/Quaternion>,
 which are a generalization of complex numbers.
 
 =item L<C<Math::Polynomial>|https://github.com/colomon/Math-Polynomial> works
@@ -195,7 +195,7 @@ We can, in fact, compute the approximation to the L<golden ratio|https://en.wiki
 The L<Math::Sequences|https://github.com/ajs/perl6-Math-Sequences> module
 includes many mathematical sequences, already defined for you. It defines many
 L<sequences from the encyclopedia|https://oeis.org/>, some of them with their
-original name, such as ℤ or ℝ.
+original name, such as ℤ.
 
 Some set operators also operate on sequences, and they can be used to find out if an object is part of it:
 
@@ -208,7 +208,7 @@ generators. And we can use set inclusion operators too:
     say (55,89).Set ⊂ (1,1, * + * … * > 200); # OUTPUT: «True␤»
 
 although it does not take into account if it is effectively a subsequence, just
-the presence of the two elements here; Sets have no order, and even if you don't
+the presence of the two elements here. Sets have no order, and even if you don't
 explicitly cast the subsequence into a Set or explicitly cast it into a C<Seq>
 it will be coerced into such for the application of the inclusion operator.
 


### PR DESCRIPTION
## The problem

The cited article contains a few mathematical imprecisions which ought to be addressed. One of them, about sequences and the real numbers, is particularly troublesome since there seemingly is no justification for this claim and doesn't really add much value to the rest of the article. 

## Solution provided

* Disclaimer about the purported mathematical field nature of Rat, Num
  and Complex
* Rephrases the Int section to be more consistent
* Matrices are not, in general, a field but a ring
* Hamilton's quaternions are not a field, but an algebra over the real
  numbers
* Claiming that ℝ is a sequence makes very little sense from a
  mathematical standpoint. Lacking further explanation/justification,
  the reference should be dropped until it can be given some meaning.