### PR TITLE
Take a small paragraph out of verbatim mode

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -563,8 +563,8 @@ Vortex-TotalPerspective/
 
 =end code
 
-    If your project contains other modules that help the main module do
-    its job, they should go in your lib directory like so:
+If your project contains other modules that help the main module do
+its job, they should go in your lib directory like so:
 
 =begin code :lang<text>
 lib


### PR DESCRIPTION
The paragraph between two code blocks is not itself a code block and should not be indented by four spaces.
