### PR TITLE
Changes as requested by AlexDaniel

### DIFF
--- a/doc/Language/00-POD6-CONTROL
+++ b/doc/Language/00-POD6-CONTROL
@@ -3,12 +3,12 @@
 #
 # DO NOT REMOVE OR MODIFY THE FILE NAME AT THE END OF EACH LINE
 
-section: AT THE BEGINNING
+section: At the beginning
 
 Brief Introduction FILE: intro
 Perl 6 Example P6-101 FILE: 101-basics
 
-section: MIGRATION GUIDES
+section: Migration guides
 
 Perl 5 to Perl 6 guide - In a Nutshell FILE: 5to6-nutshell
 Perl 5 to Perl 6 guide - Overview FILE: 5to6-overview
@@ -21,7 +21,7 @@ Javascript (Node) to Perl 6 - Nutshell FILE: js-nutshell
 Python to Perl 6 - Nutshell FILE: py-nutshell
 Ruby to Perl 6 - Nutshell FILE: rb-nutshell
 
-section: TUTORIALS
+section: Tutorials
 
 Classes and objects FILE: classtut
 Concurrency FILE: concurrency
@@ -36,7 +36,7 @@ Module development utilities FILE: modules-extra
 Module packages FILE: module-packages
 Modules FILE: modules
 
-section: GENERAL REFERENCE
+section: General reference
 
 About the docs FILE: about
 Community FILE: community
@@ -48,7 +48,7 @@ Terms FILE: terms
 Testing FILE: testing
 Traps to avoid FILE: traps
 
-section: PERL 6 FUNDAMENTAL TOPICS
+section: Fundamental topics
 
 Containers FILE: containers
 Contexts and contextualizers FILE: contexts
@@ -86,6 +86,6 @@ Unicode FILE: unicode
 Unicode versus ASCII symbols FILE: unicode_ascii
 Variables FILE: variables
 
-section: PERL 6 ADVANCED TOPICS
+section: Advanced topics
 
 Experimental Features FILE: experimental

--- a/doc/Language/intro.pod6
+++ b/doc/Language/intro.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Brief Introduction
 
-=SUBTITLE Using the Perl 6 Documentation
+=SUBTITLE Using this documentation
 
 Documenting a large language like Perl 6 has to balance several contradictory
 goals, such as being brief whilst being comprehensive, catering to professional

--- a/util/manage-page-order.p6
+++ b/util/manage-page-order.p6
@@ -58,7 +58,7 @@ given $mode {
             do-update()
         } else {
             copy-dir-tree :fromdir('doc'), :todir('build')
-        };
+        }
     }
     default {
         EXIT("\$mode '$mode' is unknown");
@@ -450,7 +450,7 @@ sub help {
         -n      - create  (for mode 'control')
         -h      - extended help
         -d      - debug
-        -m    - manage (include the categories)
+        -m      - manage (include the categories)
 
     Note: The modes are selected by entering either the first letter
           of the mode name or its complete name.


### PR DESCRIPTION
## The problem
Change to Sentence case for sections
typos in code
Remove Perl6
Also, changed some section titles (eg removed Perl 6 from Advanced topics).

