### PR TITLE
Supply fix

### DIFF
--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -14,7 +14,6 @@ It is a thread-safe implementation of the
 L<Observer Pattern|https://en.wikipedia.org/wiki/Observer_pattern>,
 and central to supporting reactive programming in Perl 6.
 
-
 There are two types of Supplies: C<live> and C<on demand>. When tapping into a
 C<live> supply, the tap will only see values that are flowing through the
 supply B<after> the tap has been created. Such supplies are normally infinite
@@ -29,7 +28,7 @@ time it is tapped. If the tap is closed, the timer simply stops emitting values
 to that tap.
 
 A C<live> C<Supply> is obtained from the L<Supplier|/type/Supplier>
-factory method C<Supply>.  New values are emitted by calling C<emit> on
+factory method C<Supply>. New values are emitted by calling C<emit> on
 the C<Supplier> object.
 
     my $supplier = Supplier.new;
@@ -60,13 +59,9 @@ Creates a new tap (a kind of subscription if you will), in addition to all
 existing taps. The first positional argument is a piece of code that will be
 called when a new value becomes available through the C<emit> call.
 
-The C<&done> callback is called when the C<done> method on the supply is
-called, indicating the end of life of the channel. For a C<live> supply the
-C<done> routine will be called on the parent C<Supplier>.
+The C<&done> callback can be called in a number of cases: if a supply block is being tapped, when a C<done> routine is reached; if a supply block is being tapped, it will be automatically triggered if the supply block reaches the end; if the C<&done> method is called on the parent C<Supplier> (in the case of a supply block, if there are multiple Suppliers referenced by C<whenever>, they must all have their C<done> method invoked for this to trigger the C<&done> callback of the tap).
 
-The C<&quit> callback is called when the C<quit> method on the supply is
-called, indicating an erroneous termination of the supply. For a C<live>
-supply the C<quit> routine will be called on the parent C<Supplier>
+The C<&quit> callback is called if the tap is on a supply block which exits with an error. It is also called if the C<quit> method is invoked on the parent C<Supplier> (in the case of a supply block any one C<Supplier> quitting with an uncaught exception will call the C<&quit> callback as the block will exit with an error).
 
 Method C<tap> returns an object of type L<Tap|/type/Tap>, on which you can
 call the C<close> method to cancel the subscription.

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -59,7 +59,7 @@ Creates a new tap (a kind of subscription if you will), in addition to all
 existing taps. The first positional argument is a piece of code that will be
 called when a new value becomes available through the C<emit> call.
 
-The C<&done> callback can be called in a number of cases: if a supply block is being tapped, when a C<done> routine is reached; if a supply block is being tapped, it will be automatically triggered if the supply block reaches the end; if the C<&done> method is called on the parent C<Supplier> (in the case of a supply block, if there are multiple Suppliers referenced by C<whenever>, they must all have their C<done> method invoked for this to trigger the C<&done> callback of the tap).
+The C<&done> callback can be called in a number of cases: if a supply block is being tapped, when a C<done> routine is reached; if a supply block is being tapped, it will be automatically triggered if the supply block reaches the end; if the C<done> method is called on the parent C<Supplier> (in the case of a supply block, if there are multiple Suppliers referenced by C<whenever>, they must all have their C<done> method invoked for this to trigger the C<&done> callback of the tap as the block will then reach its end).
 
 The C<&quit> callback is called if the tap is on a supply block which exits with an error. It is also called if the C<quit> method is invoked on the parent C<Supplier> (in the case of a supply block any one C<Supplier> quitting with an uncaught exception will call the C<&quit> callback as the block will exit with an error).
 

--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -59,9 +59,17 @@ Creates a new tap (a kind of subscription if you will), in addition to all
 existing taps. The first positional argument is a piece of code that will be
 called when a new value becomes available through the C<emit> call.
 
-The C<&done> callback can be called in a number of cases: if a supply block is being tapped, when a C<done> routine is reached; if a supply block is being tapped, it will be automatically triggered if the supply block reaches the end; if the C<done> method is called on the parent C<Supplier> (in the case of a supply block, if there are multiple Suppliers referenced by C<whenever>, they must all have their C<done> method invoked for this to trigger the C<&done> callback of the tap as the block will then reach its end).
+The C<&done> callback can be called in a number of cases: if a supply block is being tapped, when a C<done> routine is reached;
+if a supply block is being tapped, it will be automatically triggered if the supply block reaches the end;
+if the C<done> method is called on the parent C<Supplier>
+(in the case of a supply block, if there are multiple Suppliers referenced by C<whenever>, they must
+all have their C<done> method invoked for this to trigger the C<&done> callback of the tap as the
+block will then reach its end).
 
-The C<&quit> callback is called if the tap is on a supply block which exits with an error. It is also called if the C<quit> method is invoked on the parent C<Supplier> (in the case of a supply block any one C<Supplier> quitting with an uncaught exception will call the C<&quit> callback as the block will exit with an error).
+The C<&quit> callback is called if the tap is on a supply block which exits with an error. It is also
+called if the C<quit> method is invoked on the parent C<Supplier> (in the case of a supply block any
+one C<Supplier> quitting with an uncaught exception will call the C<&quit> callback as the block will
+exit with an error).
 
 Method C<tap> returns an object of type L<Tap|/type/Tap>, on which you can
 call the C<close> method to cancel the subscription.


### PR DESCRIPTION
## The problem
Supply doc is wrong about `done` #2161

## Solution provided
Clarifies when &done and &quit are called
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
