### PR TITLE
Remove extra =end item

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -587,7 +587,7 @@ lib
 =item If you have any additional files (such as templates or a dynamic
     library) that you wish to have installed so you can access them at
     runtime, they should be placed in a C<resources> sub-directory of your project, eg.:
-    
+
 =begin code :lang<text>
 resources
 └── templates
@@ -596,7 +596,6 @@ resources
     The additional file can then be accessed inside module code via a relative path, eg.,
     C<'resources/templates/mytemplate.mustache'.IO.slurp>. The module installer will provide the correct
     absolute reference.
-=end item
 
 =item The C<README.md> file is a L<markdown-formatted|https://help.github.com/articles/markdown-basics/>
     text file, which will later be automatically rendered as HTML by GitHub/GitLab for modules kept


### PR DESCRIPTION
## The problem
Syntax error on modules.pod6 causing tests to fail

## Solution provided
Remove extra =end item
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
