### PR TITLE
Update link to Perl 6 Pod documentation in Modules

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -628,7 +628,7 @@ C<Test>.
 
 =begin item
 
-To document your modules, use L<Perl 6 Pod |https://design.perl6.org/S26.html>
+To document your modules, use L<Perl 6 Pod |https://docs.perl6.org/language/pod>
 markup inside your modules. Module documentation is most appreciated and will be
 especially important once  the Perl 6 module directory (or some other site)
 begins rendering Pod docs as HTML for easy browsing. If you have extra docs (in


### PR DESCRIPTION
The link was pointing to https://design.perl6.org/S26.html and probably is better to use the Perl 6 Pod documentation from docs.perl6.org

