### PR TITLE
Fix #2359 Add link to arguments in Objects

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -530,7 +530,7 @@ Objects are generally created through method calls, either on the type
 object or on another object of the same type.
 
 Class L<Mu> provides a constructor method called L<new>, which takes named
-arguments and uses them to initialize public attributes.
+L<arguments|/laanguage/functions#Arguments> and uses them to initialize public attributes.
 
     class Point {
         has $.x;
@@ -544,7 +544,7 @@ arguments and uses them to initialize public attributes.
     # OUTPUT: «y: 2␤»
 
 C<Mu.new> calls method L<bless> on its invocant, passing all the named
-arguments. C<bless> creates the new object and then calls method C<BUILDALL>
+L<arguments|/language/functions#Arguments>. C<bless> creates the new object and then calls method C<BUILDALL>
 on it. C<BUILDALL> walks all subclasses in reverse method resolution order
 (i.e. from L<Mu> to most derived classes) and in each class checks for the
 existence of a method named C<BUILD>. If the method exists, the method is

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -530,7 +530,7 @@ Objects are generally created through method calls, either on the type
 object or on another object of the same type.
 
 Class L<Mu> provides a constructor method called L<new>, which takes named
-L<arguments|/laanguage/functions#Arguments> and uses them to initialize public attributes.
+L<arguments|/language/functions#Arguments> and uses them to initialize public attributes.
 
     class Point {
         has $.x;


### PR DESCRIPTION
This PR adds a link to  https://docs.perl6.org/language/functions#Arguments from the object construction phase, as the issue #2359 suggests.