### PR TITLE
Add examples of passing arguments to grammars

### DIFF
--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -439,16 +439,16 @@ Once the arguments are passed in, they can be used in a call to a named regex in
 =begin code
     grammar demonstrate-arguments-again
         rule TOP ($word) {
-	   <phrase-stem><added-word($word)>
+        <phrase-stem><added-word($word)>
         }
 
         rule phrase-stem {
-	   "I like"
-	}
+           "I like"
+        }
 
         rule added-word($passed-word) {
            $passed-word
-	}
+        }
      }
 
      say demonstrate-arguments-again.parse("I like vegetables", :args(("vegetables",)));
@@ -463,13 +463,13 @@ Alternatively, you can initialise dynamic variables and use any arguments that w
      grammar demonstrate-arguments-dynamic {
          rule TOP ($*word, $*extra) {
             <phrase-stem><added-words>
-	  }
+         }
          rule phrase-stem {
-	    "I like"
-	 }
+            "I like"
+         }
          rule added-words {
-	    $*word $*extra
-	 }
+            $*word $*extra
+         }
       }
 
      say demonstrate-arguments-dynamic.parse("I like everything else", :args(("everything", "else")));

--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -419,6 +419,65 @@ attributes can be accessed in the match returned after parsing if made public:
     # OUTPUT: [(Bool) True]
 =end code
 
+=head2 Passing arguments into grammars
+
+To pass arguments into a grammar, you can use the named argument of C<:args> on any of the parsing methods of grammar. The arguments passed should be in a C<list>.
+
+=begin code
+    grammar demonstrate-arguments {
+        rule TOP ($word) {
+        "I like" $word
+        }
+    }
+
+    # Notice the comma after "sweets" when passed to :args to coerce it to a list
+    say demonstrate-arguments.parse("I like sweets", :args(("sweets",))); # OUTPUT: «｢I like sweets｣␤»    
+=end code
+
+Once the arguments are passed in, they can be used in a call to a named regex inside the grammar.
+
+=begin code
+    grammar demonstrate-arguments-again
+        rule TOP ($word) {
+	   <phrase-stem><added-word($word)>
+        }
+
+        rule phrase-stem {
+	   "I like"
+	}
+
+        rule added-word($passed-word) {
+           $passed-word
+	}
+     }
+
+     say demonstrate-arguments-again.parse("I like vegetables", :args(("vegetables",)));
+     # OUTPUT: ｢I like vegetables｣␤»
+     # OUTPUT:  «phrase-stem => ｢I like ｣␤»
+     # OUTPUT:  «added-word => ｢vegetables｣␤»
+=end code
+
+Alternatively, you can initialise dynamic variables and use any arguments that way within the grammar.
+
+=begin code
+     grammar demonstrate-arguments-dynamic {
+         rule TOP ($*word, $*extra) {
+            <phrase-stem><added-words>
+	  }
+         rule phrase-stem {
+	    "I like"
+	 }
+         rule added-words {
+	    $*word $*extra
+	 }
+      }
+
+     say demonstrate-arguments-dynamic.parse("I like everything else", :args(("everything", "else")));
+     # OUTPUT: «｢I like everything else｣␤»
+     # OUTPUT:  «phrase-stem => ｢I like ｣␤»
+     # OUTPUT:  «added-words => ｢everything else｣␤»
+=end code
+
 X<|Actions>
 =head1 Action objects
 


### PR DESCRIPTION
Demonstrate passing arguments to grammars

## The problem
Passing arguments to tokens in Grammars is undocumented #2102

## Solution provided
Adds some examples of using arguments with classes and rules
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
