### PR TITLE
Fix 2412

### DIFF
--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -35,15 +35,19 @@ $fruits<apple kiwi> = False, True;
 say $fruits.keys.sort;  # OUTPUT: «kiwi orange peach␤»
 =end code
 
-Here is a convenient shorthand idiom for adding an element to a SetHash:
+Here is a convenient shorthand idiom for adding and removing SetHash elements:
 
 =begin code
 my SetHash $fruits .= new;
 say $fruits<cherry>;      # OUTPUT: «False␤»
 $fruits<cherry>++;
 say $fruits<cherry>;      # OUTPUT: «True␤»
-
 $fruits<apple banana kiwi>»++; # Add multiple elements
+
+$fruits<cherry>--;
+say $fruits<cherry>;      # OUTPUT: «False␤»
+$fruits<banana kiwi>»-- # Remove multiple elements
+
 =end code
 
 =head1 Creating C<SetHash> objects

--- a/doc/Type/SetHash.pod6
+++ b/doc/Type/SetHash.pod6
@@ -46,7 +46,7 @@ $fruits<apple banana kiwi>»++; # Add multiple elements
 
 $fruits<cherry>--;
 say $fruits<cherry>;      # OUTPUT: «False␤»
-$fruits<banana kiwi>»-- # Remove multiple elements
+$fruits<banana kiwi>»--; # Remove multiple elements
 
 =end code
 


### PR DESCRIPTION
## The problem
In SetHash section "a convenient shorthand idiom for adding an element to a SetHash" ($fruits<cherry>++) is explained. But corresponding convenient idiom $fruits<cherry>-- for removing items from SetHash is not mentioned despite the fact that it is officially in spec: https://github.com/perl6/roast/blob/master/S02-types/sethash.t#L67

## Solution provided
This PR adds examples for removing SetHash items 
