### PR TITLE
Fix example for Pod::Block::Named. Fixes #2425

### DIFF
--- a/doc/Type/Pod/Block/Named.pod6
+++ b/doc/Type/Pod/Block/Named.pod6
@@ -7,11 +7,11 @@
     class Pod::Block::Named is Pod::Block { }
 
 Class for a named Pod block. For example
-
-    =begin MySection
-    ...
-    =end MySection
-
+=begin code :skip-test
+=begin MySection
+...
+=end MySection
+=end code
 creates a C<Pod::Block::Named> with name C<MySection>.
 
 =head1 Methods


### PR DESCRIPTION
## The problem
Looking at [https://docs.perl6.org/type/Pod::Block::Named](https://docs.perl6.org/type/Pod::Block::Named), you can see that example does not demonstrate its real code, rather it is rendered as pod heading, not a code piece.

## Solution provided
Wrap the example in:
```
=begin code :skip-test
=end code
```

