### PR TITLE
Example use of whenever should use a react block

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -144,6 +144,10 @@ N: Juan Julián Merelo Guervós
 E: jjmerelo@gmail.com
 U: JJ
 
+N: Joelle Maslak
+E: jmaslak@antelope.net
+U: jmaslak
+
 N: John Gabriele
 E: jgabriele@fastmail.fm
 

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -163,8 +163,12 @@ Or when using C<whenever>:
 =begin code
 my $listener = IO::Socket::Async.listen('127.0.0.1', 5000);
 my $big-finish = Promise.new;
-my $tap = do whenever $listener -> $conn { ... }
-await $big-finish;
+my $tap;
+react {
+    $tap = do whenever $listener -> $conn { ... }
+}
+
+# When you want to close the listener, you can still use:
 $tap.close;
 =end code
 

--- a/doc/Type/IO/Socket/Async.pod6
+++ b/doc/Type/IO/Socket/Async.pod6
@@ -162,7 +162,6 @@ Or when using C<whenever>:
 
 =begin code
 my $listener = IO::Socket::Async.listen('127.0.0.1', 5000);
-my $big-finish = Promise.new;
 my $tap;
 react {
     $tap = do whenever $listener -> $conn { ... }


### PR DESCRIPTION
## The problem

whenever needs to be in a react block (looks like a 6.d feature).

## Solution provided

Wrapped the usage of whenever in a react block within the example for listen().

Also added myself to CREDITS.