### PR TITLE
remove PREVIEW from examples

### DIFF
--- a/doc/Type/Promise.pod6
+++ b/doc/Type/Promise.pod6
@@ -79,7 +79,7 @@ thrown without any C<start> statement prefixes involved.
     =end code
 
     =begin code :solo
-    use v6.d.PREVIEW;
+    use v6.d;
     start { die }; sleep ⅓; say "hello";
     # OUTPUT:
     # Unhandled exception in code scheduled on thread 4

--- a/doc/Type/Signature.pod6
+++ b/doc/Type/Signature.pod6
@@ -388,7 +388,7 @@ thus you cannot use the C<.=> operator, for example.
 In 6.d language, the default default is the type object without the smiley constraint:
 
 =for code :solo
-    use v6.d.PREVIEW;
+    use v6.d;
     my Int:D $x .= new: 42; # OUTPUT: «42␤»
 
 A closing remark on terminology: this section is about the use of the type


### PR DESCRIPTION
Once 6.d is shipped in a compiler, apply this to remove the PREVIEW from these examples