### PR TITLE
Fix typo and link in Glossary

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -1005,7 +1005,7 @@ deferred to other classes.
         method bark { ... }          # the ... indicates a stub
     }
 
-Classes with stubs are L<Abstract classes>.
+Classes with stubs are L<Abstract classes|#Abstract class>.
 
 =head1 Symbol
 X<|Symbol>

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -148,7 +148,7 @@ X<|Apocalypse>
 
 A document originally written by L<#TimToady>, in which he processed the
 initial barrage of RFCs that came out of the Perl community.  Now only kept
-as an historical document for reference.  See also L<#Exegesis> and
+as a historical document for reference.  See also L<#Exegesis> and
 L<#Synopsis>.
 
 X<|Arity>


### PR DESCRIPTION
This fixes a typo and an incorrect link on the Glossary page.

From what I read, it seems like "an historical" is not up to taste. It's "a" unless the "h" is silent, which it isn't in "historical", unless you're French :-)