### PR TITLE
Mention value types in eqv documentation

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1822,6 +1822,29 @@ implement an appropriate infix C<eqv> operator:
     multi infix:<eqv>(A $l, A $r) { $l.a eqv $r.a }
     say A.new(a => 5) eqv A.new(a => 5);            # OUTPUT: «True␤»
 
+
+Note that C<eqv> does not work recursively on every kind of container type,
+e.g. C<Set>:
+
+    my class A {
+        has $.a;
+    }
+    say Set(A.new(a => 5)) eqv Set(A.new(a => 5));  # OUTPUT: «False␤»
+
+Even though the contents of the two sets are C<eqv>, the sets are not.
+The reason is that C<eqv> delegates the equality check to the C<Set> object
+which relies on element-wise C«===» comparison. Turning the class C<A>
+into a L<value type|/type/ValueObjAt> by giving it a C<WHICH> method
+produces the expected behavior:
+
+    my class A {
+        has $.a;
+        method WHICH {
+            ValueObjAt.new: "A|$!a.WHICH()"
+        }
+    }
+    say Set(A.new(a => 5)) eqv Set(A.new(a => 5));  # OUTPUT: «True␤»
+
 =head2 infix C«===»
 
     sub infix:<===>(Any, Any)


### PR DESCRIPTION
## The problem
The `eqv` documentation demonstrates that two arbitrary (from user-defined
classes) objects are equivalent when their types agree and, recursively, their
properties are equivalent. But if you put these two equivalent objects each into
a `Set`, the sets do not compare `True` when using `eqv`. This is a WAT to me.

## Solution provided
`eqv` on Sets works differently than I had imagined. It doesn't unpack the Sets,
but delegates the check to Set.ACCEPTS, which in turn uses `===` to perform
the element-wise comparisons. To get the expected behaviour, as timotimo [explained](https://colabti.org/irclogger/irclogger_log/perl6?date=2018-12-04#l49),
the class must act like a value type.

Since I had never once heard of value types before, I think it is a good idea
to show the problem and link to an explanation of "value type" to increase its
page rank, which this commit does.

I'm open to suggestions. For example, I don't know if the "**Trap:**" tag should
be removed from my additions. One could also consider rewriting the previous
paragraphs, so that the impression doesn't even arise that `eqv` is really recursively
applied to anything "container-y", as that clearly isn't the case for Sets.