### PR TITLE
Add WAT to Glossary

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -454,6 +454,7 @@ inside an L<EVAL> is also considered a compunit.
 X<|DWIM>
 
 I<Do What I Mean>.  A programming language designer motto.
+The opposite of a DWIM is a L<#WAT>.
 
 =head2 flap
 X<|flap>
@@ -1205,6 +1206,13 @@ A virtual machine is the Perl compiler entity that executes the
 L<bytecode|#bytecode>.  It can optimize the bytecode or generate machine code
 Just in Time.  Examples are L<#MoarVM>, L<#Parrot> (who are intended to run
 Perl 6) and more generic virtual machines such as JVM and Javascript.
+
+=head2 WAT
+X<|WAT>
+
+The opposite of a L<#DWIM>; counter-intuitive behavior. It is said
+that to every DWIM there is a corresponding WAT.
+See also L<https://www.destroyallsoftware.com/talks/wat>.
 
 =head1 whitespace
 X<|whitespace>


### PR DESCRIPTION
Synopsis 99 has an entry for WAT. It still appears in chat and issues,
e.g. in the doc repo, often as the backside of a DWIM [1]. The formulation
in this commit differs a bit from S99 to highlight that perceived duality.

I haven't seen any issue about it nor any mention of WAT in the history
of the doc repository, so it doesn't seem like it has been removed for
any reason -- and it's still used.

[1] https://colabti.org/irclogger/irclogger_log_search/perl6?search=WAT&action=search