### PR TITLE
Change absolute urls to relative urls

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -364,7 +364,7 @@ associated with that key, and finally a newline.
 Let's see an example of this now.
 
 In this example, you will see some special syntax that makes it easier
-to make a list of strings. This is the C<< <...> >> L<quote-words|https://docs.perl6.org/language/operators#index-entry-qw-quote-words-quote-words> construct.
+to make a list of strings. This is the C<< <...> >> L<quote-words|/language/operators#index-entry-qw-quote-words-quote-words> construct.
 When you put words in between the < and > they are all assumed to be strings,
 so you do not need to wrap them each in double quotes C<< "..." >>.
 
@@ -433,7 +433,7 @@ B<2.> Instead of deleting the redundant C<@names> variable, you can also use it 
 player appears that wasn't mentioned in the first line, for example due to a
 typo. How would you modify your program to achieve that?
 
-Hint: Try using L<membership operators|https://docs.perl6.org/routine/(elem)>.
+Hint: Try using L<membership operators|/routine/(elem)>.
 
 B<Answer:> Change C<@names> to C<@valid-players>. When looping through the lines of
 the file, check to see that C<$p1> and C<$p2> are in C<@valid-players>. Note that

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -209,7 +209,7 @@ to add whitespace in Perl 6 code in places where it is otherwise not
 allowed.
 
 See also
-L<other lexical conventions in the syntax page|https://docs.perl6.org/language/syntax#Lexical_conventions>.
+L<other lexical conventions in the syntax page|/language/syntax#Lexical_conventions>.
 
 =head2 Sigils
 
@@ -1831,7 +1831,7 @@ live on GitHub. An online converter may become available at some point.
 =item L<https://perlgeek.de/en/article/5-to-6>
 =item L<https://github.com/Util/Blue_Tiger/>
 =item L<https://perl6advent.wordpress.com/2011/12/23/day-23-idiomatic-perl-6/>
-=item L<https://docs.perl6.org/language/5to6-overview>
+=item L</language/5to6-overview>
 
 =end pod
 

--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -1296,7 +1296,7 @@ as much as possible.
 =item printf
 
 Perl 6 version is similar; see
-L<sprintf|https://docs.perl6.org/type/Str#sub_sprintf> for details
+L<sprintf|/type/Str#sub_sprintf> for details
 on acceptable format directives. To print to a filehandle other than
 STDOUT, use the L«C<.printf>|/routine/printf» method on that filehandle.
 

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -268,7 +268,7 @@ exact running instance, for more information use <.^methods> to introspect all t
 =item %SIG
 
 No equivalent variable. To have your code executed on the reception of a
-signal, you can call the L<signal|https://docs.perl6.org/routine/signal#(Supply)_sub_signal>
+signal, you can call the L<signal|/routine/signal#(Supply)_sub_signal>
 subroutine, which returns a C<Supply> that can be tapped.
 
 =for code :lang<perl5>

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -58,7 +58,7 @@ perl app.pl daemon
 
 The documentation is written in Perl 6 Pod.
 
-For a quick introduction to Perl 6 Pod, see L<Perl 6 Pod|https://docs.perl6.org/language/pod>.
+For a quick introduction to Perl 6 Pod, see L<Perl 6 Pod|/language/pod>.
 
 For full details about the Perl 6 Pod specification, see L<Synopsis 26, Documentation|https://design.perl6.org/S26.html>.
 

--- a/doc/Language/contexts.pod6
+++ b/doc/Language/contexts.pod6
@@ -22,7 +22,7 @@ $sub; # OUTPUT: «WARNINGS:␤Useless use of $sub in sink context (line 1)␤»
 
 X<|sinking> You can force that sink context on L<Iterator>s, by using the
 L<C<sink-all>|/routine/sink-all> method. L<Proc>s can also be
-L<sunk via the C<sink> method|https://docs.perl6.org/type/Proc#method_sink>,
+L<sunk via the C<sink> method|/type/Proc#method_sink>,
 forcing them to raise an exception and not returning anything.
 
 In general, blocks will warn if evaluated in sink context; however,
@@ -105,7 +105,7 @@ say ~@array; # OUTPUT: «1 2 3 4 5 6␤»
 =end code
 
 This will happen also in a
-L<I<reduction>|https://docs.perl6.org/language/operators#Reduction_operators>
+L<I<reduction>|/language/operators#Reduction_operators>
 context, when C<[~]> is applied to a list
 
      say [~] [ 3, 5+6i, Set(<a b c>), [1,2,3] ]; # OUTPUT: «35+6ic a b1 2 3␤»
@@ -115,7 +115,7 @@ string:
 
     say [~] [] ; # OUTPUT: «␤»
 
-Since L<C<~> acts also as buffer concatenation operator|https://docs.perl6.org/routine/~#(Operators)_infix_~>,
+Since L<C<~> acts also as buffer concatenation operator|/routine/~#(Operators)_infix_~>,
 using it will
 have to check that every element is not empty, since a single empty buffer in
 string context will behave as a string, thus yielding an error.
@@ -135,7 +135,7 @@ say [~] $non-empty, $empty, $non-empty-also;
 =end code
 
 Since C<~> is putting in string context the second element of this list,
-L<C<~>|https://docs.perl6.org/routine/~#(Operators)_infix_~> is going to be
+L<C<~>|/routine/~#(Operators)_infix_~> is going to be
 using the second form that applies to strings, thus yielding the shown error.
 Simply making sure that everything you concatenate is a buffer will avoid this
 problem.

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -94,8 +94,8 @@ L<ecosystem|https://modules.perl6.org/>.
 
 =head2 Where can I find good documentation on Perl 6?
 
-See L<the official documentation website|https://docs.perl6.org/>
-(especially its L<"Language" section|https://docs.perl6.org/language.html>) as well as the
+See L<the official documentation website|/>
+(especially its L<"Language" section|/language.html>) as well as the
 L<Resources page|https://perl6.org/resources/>. You can also consult
 this L<great cheatsheet|https://htmlpreview.github.io/?https://github.com/perl6/mu/blob/master/docs/Perl6/Cheatsheet/cheatsheet.html>.
 
@@ -162,13 +162,13 @@ Yes, see L<glossary|/language/glossary>.
 =head2 I'm a Perl 5 programmer. Where is a list of differences between Perl 5
 and Perl 6?
 
-There are several I<Perl 5 to Perl 6> guides in the L<Language section of the documentation|https://docs.perl6.org/language.html>, most notable of which
+There are several I<Perl 5 to Perl 6> guides in the L<Language section of the documentation|/language.html>, most notable of which
 is the L<Overview|/language/5to6-nutshell>.
 
 X<|Ruby Quickstart (FAQ)>
 =head2 I'm a Ruby programmer looking for quickstart type docs?
 
-See the L<rb-nutshell|https://docs.perl6.org/language/rb-nutshell> guide.
+See the L<rb-nutshell|/language/rb-nutshell> guide.
 
 =head1 Modules
 
@@ -202,7 +202,7 @@ well with most Perl 5 modules. It can even run Perl 5 Catalyst and DBI.
 X<|C and C++ (FAQ)>
 =head2 Can I use C and C++ from Perl 6?
 
-L<Nativecall|https://docs.perl6.org/language/nativecall> makes this
+L<Nativecall|/language/nativecall> makes this
 particularly easy.
 
 =head2 Nativecall can't find libfoo.so and I only have libfoo.so.1.2!
@@ -225,7 +225,7 @@ X<|Core standard library (FAQ)> X<|Rakudo Star distribution and compiler-only re
 L<Rakudo Star distribution|https://rakudo.perl6.org/downloads/star/> does come
 with L<many useful modules|https://github.com/rakudo/star/tree/master/modules>.
 
-Rakudo compiler-only release includes L<only a couple of the most basic modules|https://docs.perl6.org/language/modules-core>.
+Rakudo compiler-only release includes L<only a couple of the most basic modules|/language/modules-core>.
 
 Many more modules can be found in the L<ecosystem|https://modules.perl6.org/>.
 
@@ -674,7 +674,7 @@ C<OpaquePointer> is deprecated and has been replaced with C<Pointer>.
 
 =head2 You can have colonpairs in identifiers. What's the justification?
 
-L<Identifiers can include colon pairs, which become part of their name|https://docs.perl6.org/language/syntax#Identifiers>. According to L<Larry Wall's answer to the issue|https://github.com/perl6/doc/issues/1753#issuecomment-362875676>, I<We already had the colon pair mechanism available, so it was a no-brainer to use that to extend any name that needs to be able to quote uniquefying but non-standard characters (or other information with a unique stringification to such characters)>.
+L<Identifiers can include colon pairs, which become part of their name|/language/syntax#Identifiers>. According to L<Larry Wall's answer to the issue|https://github.com/perl6/doc/issues/1753#issuecomment-362875676>, I<We already had the colon pair mechanism available, so it was a no-brainer to use that to extend any name that needs to be able to quote uniquefying but non-standard characters (or other information with a unique stringification to such characters)>.
 
 =head2 How do most people enter unicode characters?
 

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1117,7 +1117,7 @@ into a string context) in the C<for> loop that calls the function.
 
 Declaring a C<sub MAIN> is not compulsory in Perl 6 scripts, but you can
 provide one to create a
-L<command line interface|https://docs.perl6.org/language/create-cli>
+L<command line interface|/language/create-cli>
 for your script.
 
 =end pod

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -109,7 +109,7 @@ whitespace around angle brackets:
     say < 42+0i >.^name; # OUTPUT: «ComplexStr␤»
     say < 42/1 >.^name;  # OUTPUT: «RatStr␤»
 
-Please see L<the Numerics page|https://docs.perl6.org/language/numerics#Allomorphs>
+Please see L<the Numerics page|/language/numerics#Allomorphs>
 for a more complete description on how to work with these allomorphs.
 
 =head1 Anonymous
@@ -234,7 +234,7 @@ I<binder>.
 =head1 block
 X<|block>
 
-L<Blocks|https://docs.perl6.org/type/Block> are code object with its own lexical scope, which allows them to define variables without interfering with other in the containing block.
+L<Blocks|/type/Block> are code object with its own lexical scope, which allows them to define variables without interfering with other in the containing block.
 
 =head1 bytecode
 X<|bytecode>
@@ -1074,15 +1074,15 @@ X<|Tight>
 =head1 Tight and loose precedence
 
 In this context, tight or tighter refers to
-L<precedence rules|https://docs.perl6.org/language/functions#index-entry-is_tighter>
+L<precedence rules|/language/functions#index-entry-is_tighter>
 and is the opposite of C<looser>. Precedence rules for new terms are
 always expressed in relationship with other terms, so C<is tighter>
 implies that operands with that operator will be grouped before operands
 with the looser operator. Operators with
-L<tight precedence|https://docs.perl6.org/language/operators#Tight_AND_precedence>
+L<tight precedence|/language/operators#Tight_AND_precedence>
 are grouped with priority to others and are generally tighter than most
 others; loose
-L<exactly the opposite|https://docs.perl6.org/language/traps#Loose_boolean_operators>,
+L<exactly the opposite|/language/traps#Loose_boolean_operators>,
 so it is always convenient to be aware of the exact precedence of all
 operators used in an expression.
 
@@ -1115,7 +1115,7 @@ one simple string.>
 =head1 Type objects
 
 A
-L<type object|https://docs.perl6.org/language/classtut#index-entry-type_object>
+L<type object|/language/classtut#index-entry-type_object>
 is an object that is used to represent a type or a class. Since in
 object oriented programming everything is an object, classes are objects
 too, which inherit from the ur-class which, in our case, is L<Mu>.

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -706,7 +706,7 @@ a regex item.
 
 Hopefully this has helped introduce you to the grammars in Perl 6 and shown you
 how grammars and grammar action classes work together. For more information,
-check out the more advanced L<Perl Grammar Guide|https://docs.perl6.org/language/grammars>.
+check out the more advanced L<Perl Grammar Guide|/language/grammars>.
 
 For more grammar debugging, see
 L<Grammar::Debugger|https://github.com/jnthn/grammar-debugger>. This provides

--- a/doc/Language/iterating.pod6
+++ b/doc/Language/iterating.pod6
@@ -102,7 +102,7 @@ L<topic variable C<$_>|/language/variables#index-entry-topic_variable>, or
 capture them into the variables that are declared along with the block. These
 variables can be directly used inside the loop, without needing to declare them,
 by using the
-L<C<^> twigil|https://docs.perl6.org/syntax/$CIRCUMFLEX_ACCENT#(Traps_to_avoid)_twigil_^>.
+L<C<^> twigil|/syntax/$CIRCUMFLEX_ACCENT#(Traps_to_avoid)_twigil_^>.
 
 Implicit iteration occurs when using the L<sequence operator|/language/operators#index-entry-..._operators>.
 

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -166,7 +166,7 @@ above, the single argument rule I<... makes for behavior as the programmer would
 =head1 Testing for elements
 
 To test for elements in a C<List> or C<Array>, you can use the
-L<"is element of"|https://docs.perl6.org/language/setbagmix#infix_(elem)>
+L<"is element of"|/language/setbagmix#infix_(elem)>
 L<C<Set>|/type/Set> operator.
 
     my @a = <foo bar buzz>;

--- a/doc/Language/modules-core.pod6
+++ b/doc/Language/modules-core.pod6
@@ -18,7 +18,7 @@ to be used (at least until version 6.c) by the final user.
 
 =head2 C<NativeCall> modules
 
-=item L«C<NativeCall>|https://github.com/rakudo/rakudo/blob/master/lib/NativeCall.pm6»    Native Calling Interface (L<docs|https://docs.perl6.org/language/nativecall.html>)
+=item L«C<NativeCall>|https://github.com/rakudo/rakudo/blob/master/lib/NativeCall.pm6»    Native Calling Interface (L<docs|/language/nativecall.html>)
 =item L«C<NativeCall::Types>|https://github.com/rakudo/rakudo/blob/master/lib/NativeCall/Types.pm6»    Used by C<NativeCall>
 =item L«C<NativeCall::Compiler::GNU>|https://github.com/rakudo/rakudo/blob/master/lib/NativeCall/Compiler/GNU.pm6»    Used by C<NativeCall>
 =item L«C<NativeCall::Compiler::MSVC>|https://github.com/rakudo/rakudo/blob/master/lib/NativeCall/Compiler/MSVC.pm6»    Used by C<NativeCall>

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -647,7 +647,7 @@ C<Test>.
 
 =begin item
 
-To document your modules, use L<Perl 6 Pod |https://docs.perl6.org/language/pod>
+To document your modules, use L<Perl 6 Pod |/language/pod>
 markup inside your modules. Module documentation is most appreciated and will be
 especially important once  the Perl 6 module directory (or some other site)
 begins rendering Pod docs as HTML for easy browsing. If you have extra docs (in

--- a/doc/Language/numerics.pod6
+++ b/doc/Language/numerics.pod6
@@ -690,7 +690,7 @@ native type and converts it to a native.
 
 =head2 Atomic operations
 
-The language offers L<some operations|https://docs.perl6.org/type/atomicint>
+The language offers L<some operations|/type/atomicint>
 that are guaranteed to be performed atomically, i.e. safe to be executed
 by multiple threads without the need for locking with no risk of data races.
 

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -517,7 +517,7 @@ in list context. Check this:
 
 This array is itemized, in the sense that every element constitutes an item, as
 shown by the C<$> preceding the last element of the array, the
-L<(list) item contextualizer|https://docs.perl6.org/type/Any#index-entry-%24_%28item_contextualizer%29>.
+L<(list) item contextualizer|/type/Any#index-entry-%24_%28item_contextualizer%29>.
 
 The output will be (almost) the same if we attempt to flatten it using
 L<C<|> a. k. a. I<the flattener>|/routine/|>, which puts it in a list context:
@@ -729,7 +729,7 @@ X<Hyper method call operator>. Will call a method on all elements of a C<List> o
 Hyper method calls may appear to be the same as doing a L<map> call, however
 along with being a hint to the compiler that it can parallelize the call, the
 behaviour is also affected by
-L<nodality of the method|https://docs.perl6.org/routine/is%20nodal>
+L<nodality of the method|/routine/is%20nodal>
 being invoked, depending on
 which either L<nodemap> or L<deepmap> semantics are used to perform the call.
 

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -407,7 +407,7 @@ As you can see, folk wisdom is often of dubious value.
 
 =head2 Tables
 
-Check out this page for documentation related to L<Tables|https://docs.perl6.org/language/tables>
+Check out this page for documentation related to L<Tables|/language/tables>
 Z<Eventually copy everything from tables.pod6 and put it here>
 
 =head2 Pod comments

--- a/doc/Language/system.pod6
+++ b/doc/Language/system.pod6
@@ -70,7 +70,7 @@ other ways of interacting with the system through a low-level interface.
 
 The L<C<NativeCall>|/language/nativecall> API can be used to interact with
 system libraries, as well as any other accessible library. This
-L<short tutorial|https://docs.perl6.org/language/nativecall#Short_tutorial_on_calling_a_C_function>
+L<short tutorial|/language/nativecall#Short_tutorial_on_calling_a_C_function>
 explains, for instance, how to call system functions such as C<getaddrinfo>
 using that interface; some other functions like C<kill> can also be L<accessed
 that way, via declaration using the NativeCall

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -200,7 +200,7 @@ X<|constant (Terms)>
 
 Constants are similar to L<variables|/language/variables> without a
 L<container|/language/containers>, and thus cannot be rebound. However,
-their initializers are evaluated at L<BEGIN|https://docs.perl6.org/syntax/%20BEGIN> time:
+their initializers are evaluated at L<BEGIN|/syntax/%20BEGIN> time:
 
     constant speed-of-light = 299792458; # m/s
     constant @foo  = 1, 2, 3;

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -48,7 +48,7 @@ my $config-file := "config.txt".IO.slurp;
 =head2 Assigning to C<Nil> produces a different value, usually C<Any>
 
 Actually, assigning to C<Nil>
-L<reverts the variable to its default value|https://docs.perl6.org/type/Nil>. So:
+L<reverts the variable to its default value|/type/Nil>. So:
 
 =begin code
 my @a = 4, 8, 15, 16;
@@ -79,7 +79,7 @@ my $result2 = 'abcdef' ~~ / dex /;
 say "Result2 is { $result2.^name }"; # OUTPUT: «Result2 is Any␤»
 =end code
 
-A L<C<Match> will be C<Nil>|https://docs.perl6.org/language/regexes#Literals>
+A L<C<Match> will be C<Nil>|/language/regexes#Literals>
 if it finds nothing; however it assigning C<Nil> to C<$result2> above
 will result in its default value, which is C<Any> as shown.
 
@@ -857,7 +857,7 @@ in mind that C<+=> isn't defined as method on the left hand argument
 Here C<@a> is assigned the result of adding C<@a> (which has three elements)
 and C<10>; C<13> is therefore placed in C<@a>.
 
-Use the L<hyper form|https://docs.perl6.org/language/operators#Hyper_operators>
+Use the L<hyper form|/language/operators#Hyper_operators>
 of the assignment operators instead:
 
     my @a = 1, 2, 3;
@@ -1201,7 +1201,7 @@ say doesn't-return-ret;
 # BAD: outputs «Nil» and a warning «Useless use of constant string "ret" in sink context (line 13)»
 =end code
 
-Code for C<returns-ret> and C<doesn't-return-ret> might look exactly the same, since in principle it does not matter where the L<C<CATCH>|https://docs.perl6.org/language/phasers#index-entry-Phasers__CATCH-CATCH> block goes. However, a block is an object and the last object in a C<sub> will be returned, so the C<doesn't-return-ret> will return C<Nil>, and, besides, since "ret" will be now in sink context, it will issue a warning. In case you want to place phasers last for conventional reasons, use the explicit form of C<return>.
+Code for C<returns-ret> and C<doesn't-return-ret> might look exactly the same, since in principle it does not matter where the L<C<CATCH>|/language/phasers#index-entry-Phasers__CATCH-CATCH> block goes. However, a block is an object and the last object in a C<sub> will be returned, so the C<doesn't-return-ret> will return C<Nil>, and, besides, since "ret" will be now in sink context, it will issue a warning. In case you want to place phasers last for conventional reasons, use the explicit form of C<return>.
 
 =begin code
 sub explicitly-return-ret () {

--- a/doc/Type/Associative.pod6
+++ b/doc/Type/Associative.pod6
@@ -98,7 +98,7 @@ the object for the first time.  Should return the invocant.
 
 =head1 See also
 
-See L<Methods to implement for positional subscripting|https://docs.perl6.org/language/subscripts#Methods_to_implement_for_associative_subscripting> for information about additional methods that can be implemented for the C<Associative> role.
+See L<Methods to implement for positional subscripting|/language/subscripts#Methods_to_implement_for_associative_subscripting> for information about additional methods that can be implemented for the C<Associative> role.
 
 =end pod
 

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -546,7 +546,7 @@ Defined as:
 
 Formats a string based on the given format and arguments and C<.print>s the
 result into the filehandle. See
-L<sub sprintf|https://docs.perl6.org/type/Str#sub_sprintf> for details on
+L<sub sprintf|/type/Str#sub_sprintf> for details on
 acceptable format directives.
 
 Attempting to call this method when the handle is

--- a/doc/Type/Iterator.pod6
+++ b/doc/Type/Iterator.pod6
@@ -256,7 +256,7 @@ The Iterator role implements this method in terms of C<pull-one>. In
 general, it is also not intended to be called directly as in the example
 above. It can be implemented, if unhappy with this default
 implementation, by those using this role. See
-L<the documentation for C<push-exactly>|https://docs.perl6.org/type/Iterator#method_push-exactly>
+L<the documentation for C<push-exactly>|/type/Iterator#method_push-exactly>
 for an example implementation.
 
 =head2 method push-all

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -85,7 +85,7 @@ Returns C<True> if and only if the invocant conforms to type C<$type>.
     say $d.does(Any);                 # True    (Date is a subclass of Any)
     say $d.does(DateTime);            # False   (Date is not a subclass of DateTime)
 
-Unlike L<C<isa>|https://docs.perl6.org/routine/isa#(Mu)_routine_isa>, which
+Unlike L<C<isa>|/routine/isa#(Mu)_routine_isa>, which
 returns C<True> only for superclasses, C<does> includes both superclasses and
 roles.
 
@@ -422,7 +422,7 @@ stringifying non-C<Str> object using the C<.Str> method.
 
     multi method say(--> Bool:D)
 
-Will L<C<say>|https://docs.perl6.org/type/IO::Handle#method_say> to
+Will L<C<say>|/type/IO::Handle#method_say> to
 L<standard output|/language/variables#index-entry-%24*OUT>.
 To produce machine readable output use C<.put> instead.
 

--- a/doc/Type/Order.pod6
+++ b/doc/Type/Order.pod6
@@ -12,7 +12,7 @@
 
     multi sub infix:<cmp>(\a, \b --> Order:D)
 
-C<cmp> will first try to compare operands as strings (via coercion to L<Stringy>), and, failing that, will try to compare numerically via the C«<=>» operator or any other type-appropriate comparison operator. See also L<the documentation for the C<cmp> operator|https://docs.perl6.org/routine/cmp#(Operators)_infix_cmp>.
+C<cmp> will first try to compare operands as strings (via coercion to L<Stringy>), and, failing that, will try to compare numerically via the C«<=>» operator or any other type-appropriate comparison operator. See also L<the documentation for the C<cmp> operator|/routine/cmp#(Operators)_infix_cmp>.
 
 =head2 infix <=>
 

--- a/doc/Type/Positional.pod6
+++ b/doc/Type/Positional.pod6
@@ -57,7 +57,7 @@ the object for the first time.  Should return the invocant.
 
 =head1 See also
 
-See L<Methods to implement for positional subscripting|https://docs.perl6.org/language/subscripts#Methods_to_implement_for_positional_subscripting> for information about additional methods that can be implemented for the C<Positional> role.
+See L<Methods to implement for positional subscripting|/language/subscripts#Methods_to_implement_for_positional_subscripting> for information about additional methods that can be implemented for the C<Positional> role.
 
 =end pod
 

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -7,7 +7,7 @@
     class Str is Cool does Stringy { }
 
 Built-in class for strings. Objects of type C<Str> are immutable, but
-L<read the FAQ to understand precisely what this means|https://docs.perl6.org/language/faq#If_Str_is_immutable,_how_does_s///_work?_If_Int_is_immutable,_how_does_$i%2B%2B_work?>.
+L<read the FAQ to understand precisely what this means|/language/faq#If_Str_is_immutable,_how_does_s///_work?_If_Int_is_immutable,_how_does_$i%2B%2B_work?>.
 
 =head1 Methods
 

--- a/doc/Type/StrDistance.pod6
+++ b/doc/Type/StrDistance.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Contains the result of a string transformation.
 
-C<StrDistance> objects are used to represent the return of the L<string transformation|https://docs.perl6.org/syntax/tr$SOLIDUS$SOLIDUS$SOLIDUS> operator.
+C<StrDistance> objects are used to represent the return of the L<string transformation|/syntax/tr$SOLIDUS$SOLIDUS$SOLIDUS> operator.
 
     say (($ = "fold") ~~ tr/old/new/).^name;# OUTPUT: «StrDistance␤»
 


### PR DESCRIPTION
## The problem
Pod sources contain explicit hard links to the documentation site `docs.perl6.org` instead of relative links, that is: `L<some reference|https://docs.perl6.org/language/a-file#subsection>` instead of `L<some reference|/language/a-file#subsection>`.

When the reference html are generated for use locally (ie., not at docs.perl6.org) clicking on the link will goto the internet site instead of the local site. Since the purpose of a local site is when there is a need to use the docs offline, the link will be invalid.

## Solution provided

I ran a script to match on `m/'https://docs.perl6.org/.+` (so that any references to the site itself when appropriate are ignored), and then stripped out the site url.

The changes are in the PR.

28 files are affected, and ~ 50 links are changed.

The full script to do this follows:
```perl6
#! /usr/bin/env perl6
use v6.c;

my  $top-dir = '../perl6-doc/doc/';
my $url = 'https\:\/\/docs\.perl6\.org';
my @extensions = <pod pod6>;

#| Recursively finds all pod files
my @pods = my sub recurse ($dir) {
     gather for dir($dir) {
         take .Str if  .extension ~~ any( @extensions );
         take slip sort recurse $_ if .d;
     }
}($top-dir); # is the first definition of $dir

for @pods -> $p {
    my @file = $p.IO.lines;
    my $tainted = False;
    for @file {
        next unless m/<$url> '/' .+ /;
        .subst-mutate(/<$url>/,'',:g);
        $tainted = True;
    }
    $p.IO.spurt(@file.join("\n")) if $tainted;
    say "Changed: $p" if $tainted;
}
```