### PR TITLE
Two Pod table fixes

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -2858,7 +2858,7 @@ language:
 Operator class | Identity value
 ===============+===============
 Equality       | Bool::True
-Arithmetic +   | 0
+Arithmetic \+  | 0
 Arithmetic *   | 1
 Comparison     | True
 Bitwise        | 0

--- a/doc/Type/Str.pod6
+++ b/doc/Type/Str.pod6
@@ -692,9 +692,13 @@ One or more of:
 
 =begin table
    space |  prefix non-negative number with a space
-   +     |  prefix non-negative number with a plus sign
+----------------------------------------------------------------
+  \+     |  prefix non-negative number with a plus sign
+----------------------------------------------------------------
    -     |  left-justify within the field
+----------------------------------------------------------------
    0     |  use leading zeros, not spaces, for required padding
+----------------------------------------------------------------
    #     |  ensure the leading "0" for any octal,
          |  prefix non-zero hexadecimal with "0x" or "0X",
          |  prefix non-zero binary with "0b" or "0B"


### PR DESCRIPTION
This fixes two small issues with Pod tables: the first is an unescaped column separator '+' and the second is missing multi-line row separators in a table with multi-line content.