### PR TITLE
Replace -v with --verbose

### DIFF
--- a/doc/Language/create-cli.pod6
+++ b/doc/Language/create-cli.pod6
@@ -124,7 +124,7 @@ Verbosity off
 Or this way with C<--verbose>:
 
 =begin code :lang<shell>
-$ perl6 frobnicate.p6 -v
+$ perl6 frobnicate.p6 --verbose
 24
 file.dat
 Verbosity on


### PR DESCRIPTION
commit c8eef326fc7efe6f0e09de6677e9dd1c1e7a9aa1
Author: Harrison Chienjo <hhathersage@gmail.com>
Date:   Fri Dec 7 17:25:16 2018 +0300

    Replace -v with --verbose.

## The problem
Supplying ```-v``` as one of the command line argument triggers help message display instead of toggling verbose on

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
