### PR TITLE
Add a note about coercion overhead to Any.pick (addresses #2537).

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -627,6 +627,9 @@ L«C<List.pick>|/type/List#routine_pick» on it.
     my Range $rg = 'α'..'ω';
     say $rg.pick(3); # OUTPUT: «(β α σ)␤»
 
+Note that coercion may induce significant overhead; when picking
+more than one item, be sure to supply a count of C<$n> rather than
+picking single items in a loop.
 
 =head2 method skip
 


### PR DESCRIPTION
Draft wording for #2537.

(Please only merge this if `Any` is deemed an appropriate place for this warning.)