### PR TITLE
Fixed array slice with [0..^*]

### DIFF
--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -475,7 +475,7 @@ mathematicians that C<Inf> equals C<Inf-1>.
     say @a[0..2];     # OUTPUT: «(1 2 3)␤»
     say @a[0..^2];    # OUTPUT: «(1 2)␤»
     say @a[0..*];     # OUTPUT: «(1 2 3 4 5)␤»
-    say @a[0..^*];    # OUTPUT: «(1 2 3 4 5)␤»
+    say @a[0..^*];    # OUTPUT: «(1 2 3 4)␤»
     say @a[0..Inf-1]; # OUTPUT: «(1 2 3 4 5)␤»
 
 =head2 Array constructor context


### PR DESCRIPTION
Documentation had mentioned a wrong result of a array slice.
```
$ perl6 -e 'my @a = 1..5; say @a[0..^*]'
(1 2 3 4)
```
