### PR TITLE
Document trap on set subroutines on Associative

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -152,6 +152,31 @@ Alternatively, you can also use the L<concatenation operator|/routine/~> instead
     sub count-it { say "Count is " ~ $++ }
     =end code
 
+=head2 Using set subroutines on Associative when the value is falsey
+
+Using L<(cont)|/routine/(cont)>, L<∋|/routine/∋>, L<∌|/routine/∌>,
+L<(elem)|/routine/(elem)>, L<∈|/routine/∈>, or L<∉|/routine/∉> on classes
+implementing L<Associative|/type/Associative> will return C<False> if the value
+of the key is falsey:
+
+    =begin code
+    enum Foo «a b»;
+    say Foo.enums ∋ 'a';
+
+    # OUTPUT:
+    # False
+    =end code
+
+Instead, use C<:exists>:
+
+    =begin code
+    enum Foo «a b»;
+    say Foo.enums<a>:exists;
+
+    # OUTPUT:
+    # True
+    =end code
+
 =head1 Blocks
 
 =head2 Beware of empty "blocks"


### PR DESCRIPTION
Fixes https://github.com/rakudo/rakudo/issues/2604

## The problem
`Map/Bag/BagHash/Hash (cont) <string>` returns `False` if the value of the key is falsey.

## Solution provided
Document the trap.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
