### PR TITLE
- Improved wording for IO::Path.slurp and IO::Path.spurt.

### DIFF
--- a/doc/Type/IO/Path.pod6
+++ b/doc/Type/IO/Path.pod6
@@ -821,7 +821,7 @@ Defined as:
 
 Read all of the file's content and return it as either L<Buf|/type/Buf>, if C<:$bin>
 is C<True>, or if not, as L<Str|/type/Str> decoded with C<:$enc> encoding, which defaults
-to C<utf8>. See L«C<&open>|/routine/open» for valid values for C<:$enc>.
+to C<utf8>. File will be closed, afterwards. See L«C<&open>|/routine/open» for valid values for C<:$enc>.
 
 =head2 method spurt
 
@@ -829,10 +829,10 @@ Defined as:
 
     method spurt(IO::Path:D: $data, :$enc, :$append, :$createonly)
 
-Opens the file path for writing, and writes all of the C<$data> into it.
-Will L«C<fail>|/routine/fail» if it cannot succeed for any reason.
-The C<$data> can be any L«C<Cool>|/type/Cool» type or any L«C<Blob>|/type/Blob»
-type. Arguments are as follows:
+Opens the file path for writing, and writes all of the C<$data> into it.File
+will be closed, afterwards. Will L«C<fail>|/routine/fail» if it cannot succeed
+for any reason. The C<$data> can be any L«C<Cool>|/type/Cool» type or any
+L«C<Blob>|/type/Blob» type. Arguments are as follows:
 
 =item C<:$enc> — character encoding of the data. Takes same values as C<:$enc>
 in L«C<IO::Handle.open>|/routine/open». Defaults to C<utf8>. Ignored if C<$data>


### PR DESCRIPTION
## The problem

It is not clear that IO::Path.slurp and .spurt close the file after use. This small patch corrects that issue.

## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
