### PR TITLE
Add section on exporting multi methods in a Module

### DIFF
--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -263,6 +263,11 @@ authors and versions).
     constant FOO is export = "foobar";
     enum FooBar is export <one two three>;
 
+    # for multi methods, mark the proto with is export
+    proto sub quux(Str $x, |) is export { * };
+    multi sub quux(Str $x) { ... };
+    multi sub quux(Str $x, $y) { ... };
+
     # Packages like classes can be exported too
     class MyClass is export {};
 

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -263,10 +263,16 @@ authors and versions).
     constant FOO is export = "foobar";
     enum FooBar is export <one two three>;
 
-    # for multi methods, mark the proto with is export
+    # for multi methods, if you declare a proto you
+    # only need to mark the proto with is export
     proto sub quux(Str $x, |) is export { * };
     multi sub quux(Str $x) { ... };
     multi sub quux(Str $x, $y) { ... };
+
+    # for multi methods, you only need to mark one with is export
+    # but the code is most consistent if all are marked
+    multi sub quux(Str $x) is export { ... };
+    multi sub quux(Str $x, $y) is export { ... };
 
     # Packages like classes can be exported too
     class MyClass is export {};


### PR DESCRIPTION
## The problem
I searched the docs for information on exporting a multi method and didn't find anything.  The behavior works as you might guess, but I thought it might be helpful to make it explicit in the documentation.

## Solution provided

Added a short section with what seems to be the correct information.  I tested it with a toy module on Rakudo Star 18.10.