### PR TITLE
Make .Str vs .IO example more explicit

### DIFF
--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -268,10 +268,10 @@ value of the L«C<$.CWD> attribute|/type/IO::Path#attribute_CWD». For example, 
 code is broken:
 
 =for code
-# WRONG!! .Str DOES NOT USE $.CWD!
 my $path = 'foo'.IO;
 chdir 'bar';
-run <tar -cvvf archive.tar>, ~$path;
+# WRONG!! .Str DOES NOT USE $.CWD!
+run <tar -cvvf archive.tar>, $path.Str;
 
 The L«C<chdir>|/routine/chdir» call changed the value of the current directory,
 but the C<$path> we created is relative to the directory before that change.
@@ -283,9 +283,9 @@ a L«C<Str>|/type/Str» object; they only differ in whether the result is an
 absolute or relative path. So, we can fix our code like this:
 
 =for code
-# RIGHT!! .absolute does consider the value of $.CWD!
 my $path = 'foo'.IO;
 chdir 'bar';
+# RIGHT!! .absolute does consider the value of $.CWD!
 run <tar -cvvf archive.tar>, $path.absolute;
 # Also good:
 run <tar -cvvf archive.tar>, $path.relative;


### PR DESCRIPTION
## The problem

As mentioned on #perl6 today, the original introductory text here
could lead one to think the difference was between `my IO $path` and
`my Str $path`, when it's actually in using `~` for getting the value
rather than `.absolute` or `.relative`.

## Solution provided

This version uses `.Str` explicitly so it lines up more obviously with
the text.