### PR TITLE
Correct description of `hex`

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -793,9 +793,10 @@ also be used as a method: C<@foo = @bar.grep(/^f/)>
 
 In Perl 6 an expression B<must> be specified.
 
-Replaced by the adverbial form C<:16>. E. g. C<:16("aF")> returns 175.
+Replaced by the adverbial form C<:16>. E. g. C<:16("aF")> returns 175. This is 
+Str->Int.
 
-Alternately, the same result can be achieved by using the C<.base> method:
+The opposite result can be achieved (Int->Str) by using the C<.base> method:
 C<0xaF.base(10)>
 
 It just so happens that C<.Str> defaults to base 10, so if you just C<say


### PR DESCRIPTION
## The problem
It is incorrect to say that `.base` is an alternative to `:16`, since `:16` is Str -> Int and `.base` is Int -> Str.


## Solution provided
Reworded