### PR TITLE
Workaround for aspell backslash escaping issues (#975).

### DIFF
--- a/xt/aspell.t
+++ b/xt/aspell.t
@@ -60,8 +60,8 @@ sub test-it($promises, $file) {
 for @files -> $file {
     my $input-file = $file.ends-with('.pod6') ?? Pod::Cache.cache-file($file) !! $file;
 
-    my $fixer = Proc::Async.new('awk', 'BEGIN {print "!"} {gsub("\\\\","",$0); print "^" $0}', $input-file);
-    my $proc = Proc::Async.new(<aspell -a -l en_US --ignore-case --extra-dicts=./xt/aspell.pws>);
+    my $fixer = Proc::Async.new(«perl -pne ｢BEGIN {print "!\n"} s/\S\K\\[tn]/ /g; s/^/^/｣ $input-file»);
+    my $proc = Proc::Async.new(<aspell -a -l en_US --ignore-case --extra-dicts=./xt/aspell.pws --mode=url>);
     $proc.bind-stdin: $fixer.stdout: :bin;
     %output{$file}="";
     $proc.stdout.tap(-> $buf { %output{$file} = %output{$file} ~ $buf });


### PR DESCRIPTION
This is an attempt at addressing #975.

Aspell's URL mode turned out to yield the fewest false positives (`--mode=none` gets thrown by "%3Aopen…", increasing the FP count); awk was dropped in favour of Perl for lookbehind assertions. 

"\suffix" no longer causes problems (it's treated as "suffix"), nor does "foo\tbar" ("foo bar"). No doubt the `s///` pattern can be further improved.

(Please don't merge without testing.)