### PR TITLE
Document $*USAGE and $*COLLATE

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -1540,6 +1540,25 @@ X<|$*SAMPLER>
 The current L<Telemetry::Sampler> used for making snapshots of system state.
 Only available if L<Telemetry|/type/Telemetry> has been loaded.
 
+X<|$*USAGE>
+=head4 C<$*USAGE>
+
+This is a L<Str> object that holds value of the auto-generated USAGE
+message.
+
+=for code
+sub MAIN($a, :$b, UInt :$ehehe) {
+    say $*USAGE; # OUTPUT: «Usage:␤  perl6.pl6 [-a=<Int>] [-b=<Str>] [--<opts>=...]»
+}
+
+It is accessible only inside of MAIN sub.
+
+X<|$*COLLATION>
+=head4 C<$*COLLATION>
+
+This is a L<Collation|/type/Collation> object that can be used to
+configure Unicode collation levels.
+
 =head1 Naming conventions
 
 It is helpful to know our naming conventions in order to understand what codes


### PR DESCRIPTION
## The problem

$*USAGE and $*COLLATE were mentioned in other places, but absent from Variables page. Also, $*COLLATION explanation depends on `Collation` type, which is not documented at all.

## Solution provided

Add brief explanations to Variables page, file an issue about `Collation` type absence(https://github.com/perl6/doc/issues/2644)