### PR TITLE
Note arg-less Complex.new call

### DIFF
--- a/doc/Type/Complex.pod6
+++ b/doc/Type/Complex.pod6
@@ -30,6 +30,11 @@ Defined as:
 Creates a new C<Complex> object from real and imaginary parts.
 
     my $complex = Complex.new(1, 1);
+    say $complex;    # OUTPUT: «1+1i␤»
+
+When created without arguments, both parts are considered to be zero.
+
+    say Complex.new; # OUTPUT: «0+0i␤»
 
 =head2 method re
 


### PR DESCRIPTION
`Complex.new` is working since 2016.10, so I assume it is old enough to just document it. It was stabilized into spec for 6.d.