### PR TITLE
Mention 6.d standard value of minimal interval

### DIFF
--- a/doc/Type/Supply.pod6
+++ b/doc/Type/Supply.pod6
@@ -297,6 +297,7 @@ C<$delay> seconds from the call. The emitted value is an integer, starting from
 
 Implementations may treat too-small values as lowest resolution they support,
 possibly warning in such situations; e.g. treating C<0.0001> as C<0.001>.
+For 6.d language version, the minimal value specified is C<0.001>.
 
 =head2 method grep
 


### PR DESCRIPTION
As it was standardized in 6.d version, it is healthy to mention it without a bind to "implementations" word.