### PR TITLE
Document Int method on Match

### DIFF
--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -118,9 +118,10 @@ Defined as:
 
 Tries to convert stringified result of the matched text into Int.
 
-    say ('12345' ~~ /234/).Int;   # OUTPUT: «234␤»
+    say ('12345' ~~ /234/).Int;       # OUTPUT: «234␤»
+    say ('12345' ~~ /234/).Int.^name; # OUTPUT: «Int␤»
     # the next line produces a warning about using Nil (result of a no match) in numeric context
-    say ('one-two' ~~ /234/).Int; # OUTPUT: «0␤» # because Nil.Int returns 0
+    say ('one-two' ~~ /234/).Int;     # OUTPUT: «0␤» # because Nil.Int returns 0
 
 =head2 method caps
 

--- a/doc/Type/Match.pod6
+++ b/doc/Type/Match.pod6
@@ -110,6 +110,18 @@ Returns the matched text.
     "abc123def" ~~ /\d+/;
     say $/.Str;               # OUTPUT: «123␤»
 
+=head2 method Int
+
+Defined as:
+
+    method Int(Match:D: --> Int:D)
+
+Tries to convert stringified result of the matched text into Int.
+
+    say ('12345' ~~ /234/).Int;   # OUTPUT: «234␤»
+    # the next line produces a warning about using Nil (result of a no match) in numeric context
+    say ('one-two' ~~ /234/).Int; # OUTPUT: «0␤» # because Nil.Int returns 0
+
 =head2 method caps
 
 Returns a list of pairs, with the index or submatch name as key and


### PR DESCRIPTION
```
Match provides .Int and .actions
```
from 6.d changelog.
`actions` method was documented already, this adds `Int`.