### PR TITLE
Traps: point at operator trap in whitespace section

### DIFF
--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -357,7 +357,7 @@ say 3 < 5 > 4
 =head3 Exclusive sequences vs. sequences with Ranges
 
 See the section on L<operator traps|#Exclusive_sequence_operator> for
-more information about how the C<...^> operator can be confused with
+more information about how the C<...^> operator can be mistaken for
 the C<...> operator with a C<^> operator immediately following it. You
 must use whitespace correctly to indicate which interpretation will be
 followed.

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -354,6 +354,14 @@ say 3<5>4
 say 3 < 5 > 4
 =end code
 
+=head3 Exclusive sequences vs. sequences with Ranges
+
+See the section on L<operator traps|#Exclusive_sequence_operator> for
+more information about how the C<...^> operator can be confused with
+the C<...> operator with a C<^> operator immediately following it. You
+must use whitespace correctly to indicate which interpretation will be
+followed.
+
 =head1 Captures
 
 =head2 Containers versus values in a capture


### PR DESCRIPTION
This particular trap is regarding an operator, but is created by
incorrect use of whitespace, so it should probably be mentioned in
both places.