### PR TITLE
Align Mu.so & Mu.not docs with design

### DIFF
--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -609,7 +609,7 @@ Returns the given item to the enclosing C<gather> block, without introducing a n
 
     method so()
 
-Evaluates the item in boolean context (and thus collapses Junctions),
+Evaluates the item in boolean context (and thus, for instance, collapses Junctions),
 and returns the result.
 It is the opposite of C<not>, and equivalent to the
 L«C<?> operator|/language/operators#prefix_?».
@@ -623,13 +623,19 @@ then do this thing".  For instance,
         say "Verbose option detected in arguments";
     } # OUTPUT: «Verbose option detected in arguments␤»
 
+The C<$verbose-selected> variable in this case contains a
+L<C<Junction>|/type/Junction>, whose value is C<any(any(False, False),
+any(False, False), any(False, False), any(True, False))>. That is actually a
+I<truish> value; thus, negating it will yield C<False>. The negation of that
+result will be C<True>. C<so> is performing all those operations under the hood.
+
 =head2 method not
 
     method not()
 
-Evaluates the item in boolean context (and thus collapses Junctions),
+Evaluates the item in boolean context (leading to final evaluation of Junctions, for instance),
 and negates the result.
-It is the opposite of C<so>, and equivalent to the
+It is the opposite of C<so> and its behavior is equivalent to the
 L«C<!> operator|/language/operators#prefix_!».
 
     my @args = <-a -e -b>;

--- a/doc/Type/Mu.pod6
+++ b/doc/Type/Mu.pod6
@@ -609,9 +609,10 @@ Returns the given item to the enclosing C<gather> block, without introducing a n
 
     method so()
 
-Returns a C<Bool> value representing the result of negating (with implicit
-conversion to C<Bool>) the expression and then again computing the negation of
-the result, thus computing the C<Bool> equivalent to the original expression.
+Evaluates the item in boolean context (and thus collapses Junctions),
+and returns the result.
+It is the opposite of C<not>, and equivalent to the
+L«C<?> operator|/language/operators#prefix_?».
 
 One can use this method similarly to the English sentence: "If that is B<so>,
 then do this thing".  For instance,
@@ -622,18 +623,14 @@ then do this thing".  For instance,
         say "Verbose option detected in arguments";
     } # OUTPUT: «Verbose option detected in arguments␤»
 
-The C<$verbose-selected> variable in this case contains a
-L<C<Junction>|/type/Junction>, whose value is C<any(any(False, False),
-any(False, False), any(False, False), any(True, False))>. That is actually a
-I<truish> value; thus, negating it will yield C<False>. The negation of that
-result will be C<True>. C<so> is performing all those operations under the hood.
-
 =head2 method not
 
     method not()
 
-Returns a C<Bool> value representing the logical negation of an expression.
-Thus it is the opposite of C<so>.
+Evaluates the item in boolean context (and thus collapses Junctions),
+and negates the result.
+It is the opposite of C<so>, and equivalent to the
+L«C<!> operator|/language/operators#prefix_!».
 
     my @args = <-a -e -b>;
     my $verbose-selected = any(@args) eq '-v' | '-V';
@@ -641,8 +638,9 @@ Thus it is the opposite of C<so>.
         say "Verbose option not present in arguments";
     } # OUTPUT: «Verbose option not present in arguments␤»
 
-Since there is also a prefix version of C<not>, the above code reads better
-like so:
+Since there is also a
+L«prefix version of C<not>|/language/operators#prefix_not»,
+this example reads better as:
 
     my @args = <-a -e -b>;
     my $verbose-selected = any(@args) eq '-v' | '-V';


### PR DESCRIPTION
This aligns with the docs for `prefix:<so>` and `:<not>`, too. Ref #2693.

## The problem

The previous explanation of so() wasn't consistent with implementation or mentioned in design docs. Double-negation is a common JavaScript idiom but not relevant to Perl 6.

The extra description of the example isn't necessary, since the parenthetical mention of Junction resolution hints at why the example is relevant. Although a better example might be found, since `if` creates a Bool context and `.so()` is redundant. But it's not wrong, so it's fine for now.

## Solution provided

Copied the text from operators#prefix_? with appropriate tweak to text. The implementation in Radudo for `method so()` calls `self.Bool`, and the docs can be just as simple.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
