### PR TITLE
Fix broken link for IO::Glob

### DIFF
--- a/doc/Language/5to6-perlfunc.pod6
+++ b/doc/Language/5to6-perlfunc.pod6
@@ -749,7 +749,7 @@ IO::Socket object, but details are unclear.
 Not available in core, although some of the functionality is offered by
 L<dir|/routine/dir> routine and its C<test> argument.
 
-See L«C<IO::Glob> module in ecosystem|https://modules.perl6.org/dist/IO::Glob»
+See L«C<IO::Glob> module in ecosystem|https://modules.perl6.org/dist/IO::Glob:cpan:HANENKAMP»
 
 =head2 gmtime
 


### PR DESCRIPTION
## The problem

Current link for IO::Glob (https://modules.perl6.org/dist/IO::Glob) gives this error

> Proxy Error
> The proxy server received an invalid response from an upstream server.
> The proxy server could not handle the request GET /dist/IO::Glob.
> 
> Reason: Error reading from remote server
> 
> Apache/2.4.25 (Debian)
>
> Server at modules.perl6.org Port 443

## Solution provided

Update link to https://modules.perl6.org/dist/IO::Glob:cpan:HANENKAMP
<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
