### PR TITLE
Show a non-coercing hash/array subclass init

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -730,8 +730,9 @@ items:
     say [@a, 3, 4].perl;  # OUTPUT: «[[1, 2], 3, 4]␤»
     say [|@a, 3, 4].perl; # OUTPUT: «[1, 2, 3, 4]␤»
 
-L<List|/type/List> type can be explicitly created from an array literal declaration without a coercion
-coercion from Array, using B<is> L<trait|/language/traits> on declaration.
+L<List|/type/List> type can be explicitly created from an array
+literal declaration without a coercion from Array, using B<is>
+L<trait|/language/traits> on declaration.
 
     my @a is List = 1, 2; # a List, not an Array
     # wrong: creates an Array of Lists
@@ -792,8 +793,16 @@ a coercion, using B<is> L<trait|/language/traits> on declaration:
     my %mix is Mix;              # Mix
     my mix-hash is MixHash;      # MixHash
 
-    # This is wrong: creates a Hash of Mixes, not Mix
+
+Note that using a usual type declaration with a hash sigil creates a
+typed Hash, not a particular type:
+
+    # This is wrong: creates a Hash of Mixes, not Mix:
     my Mix %mix;
+    # Works with $ sigil:
+    my Mix $mix;
+    # Can be typed:
+    my Mix[Int] $mix-of-ints;
 
 =head3 Regex literals
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -730,6 +730,13 @@ items:
     say [@a, 3, 4].perl;  # OUTPUT: «[[1, 2], 3, 4]␤»
     say [|@a, 3, 4].perl; # OUTPUT: «[1, 2, 3, 4]␤»
 
+L<List|/type/List> type can be explicitly created from an array literal declaration without a coercion
+coercion from Array, using B<is> L<trait|/language/traits> on declaration.
+
+    my @a is List = 1, 2; # a List, not an Array
+    # wrong: creates an Array of Lists
+    my List @a;
+
 =head3 Hash literals
 
 A leading associative sigil and pair of parenthesis C<%( )> can surround
@@ -759,6 +766,34 @@ Note that with objects as keys, you cannot access non-string keys as strings:
 
     say :{ -1 => 41, 0 => 42, 1 => 43 }<0>;  # OUTPUT: «(Any)␤»
     say :{ -1 => 41, 0 => 42, 1 => 43 }{0};  # OUTPUT: «42␤»
+
+Particular types that implement L<Associative|/type/Associative> role,
+L<Map|/type/Map> (including L<Hash|/type/Hash> and
+L<Stash|/type/Stash> subclasses) and L<QuantHash|/type/QuantHash> (and
+its subclasses), can be explicitly created from a hash literal without
+a coercion, using B<is> L<trait|/language/traits> on declaration:
+
+    my %hash;                    # Hash
+    my %hash is Hash;            # explicit Hash
+    my %map is Map;              # Map
+    my %stash is Stash;          # Stash
+
+    my %quant-hash is QuantHash; # QuantHash
+
+    my %setty is Setty;          # Setty
+    my %set is Set;              # Set
+    my %set-hash is SetHash;     # SetHash
+
+    my %baggy is Baggy;          # Baggy
+    my %bag is Bag;              # Bag
+    my %bag-hash is BagHash;     # BagHash
+
+    my %mixy is Mixy;            # Mixy
+    my %mix is Mix;              # Mix
+    my mix-hash is MixHash;      # MixHash
+
+    # This is wrong: creates a Hash of Mixes, not Mix
+    my Mix %mix;
 
 =head3 Regex literals
 


### PR DESCRIPTION
Part of 6.d checklist.

```
QuantHashes/Map in % variables and List in @ variablescan be declared with is trait (e.g. my %h is Set)
```
