### PR TITLE
Note non-ASCII numerics in Pair colonpair

### DIFF
--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -21,6 +21,11 @@ There are many syntaxes for creating C<Pair>s:
     :foo(127);                # short for  foo => 127
     :127foo;                  # the same   foo => 127
 
+Note that last form supports Non-ASCII numerics as well:
+
+    # use MATHEMATICAL DOUBLE-STRUCK DIGIT THREE
+    say (:𝟛math-three);         # OUTPUT: «math-three => 3␤»
+
 You can also use an I<identifier-like literal> as key; this will not need the
 quotes as long as it follows the syntax of
 L<ordinary identifiers|/syntax/identifiers#Ordinary_identifiers>:


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `Non-ASCII numerics can be used in :42foo colonpair shortcut`.