### PR TITLE
Document StrDistance.Str

### DIFF
--- a/doc/Type/StrDistance.pod6
+++ b/doc/Type/StrDistance.pod6
@@ -27,14 +27,14 @@ This is actually a class attribute, and called as a method returns the string
 before the transformation:
 
 =for code :preamble<my $str = "fold"; my $str-dist = ($str ~~ tr/old/new/); >
-say $str-dist.before; #OUTPUT: «fold␤»
+say $str-dist.before; # OUTPUT: «fold␤»
 
 =head2 method after
 
 Also a class attribute, returns the string after the transformation:
 
 =for code :preamble<my $str = "fold"; my $str-dist = ($str ~~ tr/old/new/); >
-say $str-dist.after; #OUTPUT: «fnew␤»
+say $str-dist.after;  # OUTPUT: «fnew␤»
 
 =head2 method Bool
 
@@ -51,6 +51,18 @@ Defined as:
     multi method Int(StrDistance:D:)
 
 Returns the distance between the string before and after the transformation.
+
+=head2 method Str
+
+Defined as:
+
+    multi method Str(StrDistance:D: --> Str)
+
+Returns an C<After> string value.
+
+    my $str-dist = ($str ~~ tr/old/new/);
+    say $str-dist.Str; # OUTPUT: «fnew␤»
+    say ~$str-dist;    # OUTPUT: «fnew␤»
 
 =end pod
 


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `StrDistance stringifies to its .after string`.