### PR TITLE
Show multi-dim :exists adverb

### DIFF
--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -510,6 +510,17 @@ To check if I<all> elements of a slice exist, use an L<all|/routine/all> junctio
     if all %fruit<apple orange banana>:exists { ... }
     =end code
 
+It can be used on multi-dimensional arrays and hashes:
+
+    my @multi-dim = 1, [2, 3, [4, 5]];
+    say @multi-dim[1;2;0]:exists;                # OUTPUT: «True␤»
+    say @multi-dim[1;2;5]:exists;                # OUTPUT: «False␤»
+
+    my %multi-dim = 1 => { foo => { 3 => 42 } };
+    say %multi-dim{1;'foo';3}:exists;            # OUTPUT: «True␤»
+    say %multi-dim{1;'bar';3}:exists;            # OUTPUT: «False␤»
+
+
 C<:exists> can be combined with the L<#:delete> and L<#:p>/L<#:kv> adverbs -
 in which case the behavior is determined by those adverbs, except that any
 returned element I<value> is replaced with the corresponding L<Bool|/type/Bool> indicating


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `:exists can be used with multi-dimensional associative subscripts`.