### PR TITLE
Add example of dynamically created enum

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -780,6 +780,19 @@ the keys.
     say @keys.map: *.enums;
     # OUTPUT: «(Map.new((one => 0, two => 1)) Map.new((one => 0, two => 1)))␤»
 
+With the use of B<()> parentheses, an enum can be defined using any
+arbitrary dynamically defined list. The list should consist of contain Pair
+objects:
+
+    # For example, in file `config` we have:
+    # a 1
+    # b 2
+    # We read lines from `config` file,
+    # then apply `words` method for every line to split by space
+    # and as a result the enum declarator gets a list of pairs to work with
+    enum ConfigValues ('config'.IO.lines.map({ my ($key, $value) = $_.words; $key => $value }));
+    say ConfigValues.enums;          # OUTPUT: «Map.new((a => 1, b => 2))␤»
+
 =head3 Metaclass
 
 To test if a given type object is an C<enum>, test the meta object method

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -781,17 +781,22 @@ the keys.
     # OUTPUT: «(Map.new((one => 0, two => 1)) Map.new((one => 0, two => 1)))␤»
 
 With the use of B<()> parentheses, an enum can be defined using any
-arbitrary dynamically defined list. The list should consist of contain Pair
+arbitrary dynamically defined list. The list should consist of Pair
 objects:
 
-    # For example, in file `config` we have:
-    # a 1
-    # b 2
-    # We read lines from `config` file,
-    # then apply `words` method for every line to split by space
-    # and as a result the enum declarator gets a list of pairs to work with
+For example, in file C<config> we have:
+
+C<a 1
+b 2>
+
+We can create an enum using it with this code:
+
     enum ConfigValues ('config'.IO.lines.map({ my ($key, $value) = $_.words; $key => $value }));
     say ConfigValues.enums;          # OUTPUT: «Map.new((a => 1, b => 2))␤»
+
+Firstly, we read lines from C<config> file, split every line using
+C<words> method and return resulting pair for every line, thus
+creating a List of Pairs.
 
 =head3 Metaclass
 


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `Dynamically created lists can be used to define an enum`.