### PR TITLE
Show typed array of syntax

### DIFF
--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -523,6 +523,8 @@ change its type by specifying the type of the elements when declaring it:
 
     =begin code
     my Int @a = 1, 2, 3;              # An Array that contains only Ints
+    # the same as
+    my @a of Int = 1, 2, 3;           # An Array of Ints
     my @b := Array[Int].new(1, 2, 3); # Same thing, but the variable is not typed
     my @b := Array[Int](1, 2, 3);     # Rakudo shortcut for the same code
     say @b eqv @a;                    # says True.


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `Typed arrays can be created with both my SomeType @array and my @array of SomeType`.