### PR TITLE
Add next in whenever example

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -1028,7 +1028,8 @@ for @x -> $x {
 
 prints "1245".
 
-If the L<C<NEXT> phaser|/language/phasers#NEXT> is present, it runs before the next iteration:
+If the L<C<NEXT> phaser|/language/phasers#NEXT> is present, it runs
+before the next iteration:
 
 =begin code
 my Int $i = 0;
@@ -1045,6 +1046,19 @@ while ($i < 10) {
 }
 # OUTPUT: «1 is odd.␤3 is odd.␤5 is odd.␤7 is odd.␤9 is odd.␤»
 =end code
+
+In a L<whenever|/language/concurrency#index-entry-whenever-whenever>
+block C<next> immediately exits the block for the current value:
+
+    react {
+        whenever Supply.interval(1) {
+            next if .is-prime;
+            say $_;
+            done if $_ == 4;
+        }
+    }
+
+prints "0", "1" and "4" - integers from 0 to 4 with primes skipped.
 
 *Since version 6.d, the C<next> command in a loop that collects its last statement values
 returns C<Empty> for the iterations they run on.*


### PR DESCRIPTION
## The problem

Part of 6.d changelog, `next can be used in whenever`.