### PR TITLE
Map and Range: Iterable is a role; use 'does' not 'is'

### DIFF
--- a/doc/Type/Map.pod6
+++ b/doc/Type/Map.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE Immutable mapping from strings to values
 
 =for code :skip-test<compile time error>
-class Map does Associative is Iterable { }
+class Map does Associative does Iterable { }
 
 A Map is an immutable mapping from string keys to values of arbitrary
 types. It serves as a base class for L<Hash|/type/Hash>, which is mutable.

--- a/doc/Type/Range.pod6
+++ b/doc/Type/Range.pod6
@@ -5,7 +5,7 @@
 =SUBTITLE Interval of ordered values
 
 =for code :skip-test<compile time error>
-class Range is Iterable does Positional {}
+class Range does Iterable does Positional {}
 
 Ranges serve two main purposes: to generate lists of consecutive
 numbers or strings, and to act as a matcher to check if a number


### PR DESCRIPTION
## The problem

Docs for Map and Range classes say `is Iterable`, but Iterable is a class.

## Solution provided

Change to `does`.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
