### PR TITLE
Adds output to nextsame example.

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -1025,7 +1025,9 @@ say square-root(-4);    # OUTPUT: «0+2i␤»
 
 Another use case is to re-dispatch to methods from parent classes.
 
-=begin code
+=begin code 
+say Version.new('1.0.2') # OUTPUT: v1.0.2
+
 class LoggedVersion is Version {
     method new(|c) {
         note "New version object created with arguments " ~ c.perl;
@@ -1034,6 +1036,10 @@ class LoggedVersion is Version {
 }
 
 say LoggedVersion.new('1.0.2');
+
+# OUTPUT:
+# New version object created with arguments \("1.0.2")
+# v1.0.2
 =end code
 
 =head1 Coercion types


### PR DESCRIPTION
This way new users can understand the point of the call without having to open a REPL and figuring it out for themselves.

## The problem

The example does not provide the proper context. A new user needs to start a REPL, copy the example, and then run it before the docs make sense. While this should be encouraged, it should not be REQUIRED.

## Solution provided

Reworked the example so that the output of the code is clear.
