### PR TITLE
Allow examples-compilation.t to pass for subs with multiline signatures

### DIFF
--- a/xt/examples-compilation.t
+++ b/xt/examples-compilation.t
@@ -109,7 +109,12 @@ for @examples -> $eg {
 
         for $eg<contents>.lines -> $line {
             $code ~= $line;
-            if $line.trim.starts-with(any(<multi method proto only sub>)) && !$line.trim.ends-with(any('}',',')) && $eg<method> eq "" {
+            # Heuristically add an empty block after things like C<method foo ($x)>
+            # to make it compilable. We do *not* do this in particular if
+            # the signature is split into multiple lines: i.e. the declaration
+            # ends in '(' or ','.
+            if $line.trim.starts-with(any(<multi method proto only sub>))
+             && !$line.trim.ends-with(any(« } , ( »)) && $eg<method> eq "" {
                $code ~= " \{}";
             }
             if $eg<method> eq "" || $eg<method> eq "False" {

--- a/xt/examples-compilation.t
+++ b/xt/examples-compilation.t
@@ -108,14 +108,18 @@ for @examples -> $eg {
         $code ~= $eg<preamble> ~ ";\n";
 
         for $eg<contents>.lines -> $line {
+            state $in-signature;
+
             $code ~= $line;
             # Heuristically add an empty block after things like C<method foo ($x)>
-            # to make it compilable. We do *not* do this in particular if
-            # the signature is split into multiple lines: i.e. the declaration
-            # ends in '(' or ','.
-            if $line.trim.starts-with(any(<multi method proto only sub>))
-             && !$line.trim.ends-with(any(« } , ( »)) && $eg<method> eq "" {
+            # to make it compilable. Be careful with multiline signatures:
+            # '(' and ',' at the end of a line indicate a continued sig.
+            # We wait until none of them is encountered before adding '{}'.
+            $in-signature ?|= $line.trim.starts-with(any(<multi method proto only sub>))
+                           && $eg<method> eq "";
+            if $in-signature && !$line.trim.ends-with(any(« } , ( »)) {
                $code ~= " \{}";
+               $in-signature = False;
             }
             if $eg<method> eq "" || $eg<method> eq "False" {
                 $code ~= "\n";


### PR DESCRIPTION
examples-compilation.t wraps code to test into a template and
heuristically adds some other bits, so that a bare

``` perl6
method foo ($x)
```

would compile successfully. This includes adding empty blocks at
the end of a line when a situation like above is detected. Previously,
the heuristic was triggered also with this way to split a signature:

``` perl6
submethod BUILD (
    ...
) {}
```

introducing a syntax error that wasn't the example code's fault.

Fixes #2750