### PR TITLE
examples-compilation.t: always add :preamble code

### DIFF
--- a/xt/examples-compilation.t
+++ b/xt/examples-compilation.t
@@ -101,7 +101,8 @@ for @examples -> $eg {
 
     my $code;
     if $eg<solo> {
-        $code = $eg<contents>;
+        $code = $eg<preamble> ~ ";\n" if $eg<preamble>;
+        $code ~= $eg<contents>;
     } else {
         $code = 'no worries; ';
         $code ~= "if False \{\nclass :: \{\n";


### PR DESCRIPTION
Add :preamble code to an example test even if it was marked as :solo,
fixes 2754

***

Currently, there are no uses of `:preamble` and `:solo`on the same code block so this change is a priori harmless, but there will be uses after I'm done with #2738.