### PR TITLE
.Int on Bool objects returns an Int object

### DIFF
--- a/doc/Type/Bool.pod6
+++ b/doc/Type/Bool.pod6
@@ -105,6 +105,15 @@ C<$count> an infinite L<Seq|/type/Seq> of C<Bool>s is returned.
     say Bool.roll(3);                                 # OUTPUT: «(True False False)␤»
     say Bool.roll(*);                                 # OUTPUT: «(...)␤»
 
+=head2 routine Int
+
+    multi method Int(Bool:D --> Int:D)
+
+Returns the value part of the C<enum> pair.
+
+    say False.Int;                                # OUTPUT: «0␤»
+    say True.Int;                                 # OUTPUT: «1␤»
+
 =head2 routine Numeric
 
     multi method Numeric(Bool:D --> Int:D)


### PR DESCRIPTION
 Documentation for ".Int on Bool objects returns an Int object" from 
https://github.com/perl6/doc/issues/2632 checklist for 6.d.