### PR TITLE
Revise :skip-test

### DIFF
--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -578,7 +578,7 @@ arguments. For example, C<31 | 33> returns a different result than C<"31" |
 In Perl 6, those single-character ops have been removed, and replaced by
 two-character ops which coerce their arguments to the needed context.
 
-=begin code :skip-test
+=begin code :lang<text>
 # Infix ops (two arguments; one on each side of the op)
 +&  +|  +^  And Or Xor: Numeric
 ~&  ~|  ~^  And Or Xor: String
@@ -1581,7 +1581,7 @@ sub baz($z) { say "baz $z" }
 To use this module, simply C<use Bar> and the functions C<foo> and
 C<bar> will be available
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar;
 foo(1);    #=> "foo 1"
 bar(2);    #=> "bar 2"
@@ -1628,7 +1628,7 @@ module.
 So, to import only the C<foo> routine, we do the following in the
 calling code:
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar <foo>;
 foo(1);       #=> "foo 1"
 
@@ -1636,14 +1636,14 @@ Here we see that even though C<bar> is exportable, if we don't
 explicitly import it, it's not available for use.  Hence this causes an
 "Undeclared routine" error at compile time:
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar <foo>;
 foo(1);
 bar(5);       #!> "Undeclared routine: bar used at line 3"
 
 However, this will work
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar <foo bar>;
 foo(1);       #=> "foo 1"
 bar(5);       #=> "bar 5"
@@ -1651,7 +1651,7 @@ bar(5);       #=> "bar 5"
 Note also that C<baz> remains unimportable even if specified in the
 C<use> statement:
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar <foo bar baz>;
 baz(3);       #!> "Undeclared routine: baz used at line 2"
 
@@ -1678,7 +1678,7 @@ sub baz() is export(:DEFAULT:FNORBL) { }  # added to both
 
 So now you can use the C<Bar> module like this:
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use Bar;                     # imports foo / baz
 use Bar :FNORBL;             # imports bar / baz
 use Bar :ALL;                # imports foo / bar / baz

--- a/doc/Language/5to6-nutshell.pod6
+++ b/doc/Language/5to6-nutshell.pod6
@@ -42,7 +42,7 @@ an embedded instance of the C<perl> interpreter to run Perl 5 code.
 
 This is as simple as:
 
-=for code :skip-test<Inline module not always present when testing>
+=for code :skip-test<needs ecosystem>
 # the :from<Perl5> makes Perl 6 load Inline::Perl5 first (if installed)
 # and then load the Scalar::Util module from Perl 5
 use Scalar::Util:from<Perl5> <looks_like_number>;

--- a/doc/Language/5to6-perlvar.pod6
+++ b/doc/Language/5to6-perlvar.pod6
@@ -173,7 +173,7 @@ No longer exists in Perl 6.  Because each Repository is responsible for
 remembering which modules have been loaded already. You can get a list
 of all loaded modules (compilation units) like so:
 
-=for code :skip-test<missing module>
+=for code :skip-test<needs dummy module>
 use Test;
 use MyModule;
 say flat $*REPO.repo-chain.map(*.loaded); #-> (MyModule Test)

--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -71,7 +71,7 @@ All of the paragraphs and blocks following that directive, up until the
 next directive of the same level, will be considered part of the
 documentable. So, in:
 
-=begin code :allow<R> :skip-test
+=begin code :allow<R> :lang<pod6>
 =head2 R<My Definition>
 
 Some paragraphs, followed by some code:

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -223,8 +223,8 @@ this attribute is private to the class.
 
 The second declaration also uses the private twigil:
 
-=for code :skip-test
-has Task @!dependencies;
+    =for code :preamble<class Task {}>
+    has Task @!dependencies;
 
 However, this attribute represents an array of items, so it requires the
 C<@> sigil. These items each specify a task that must be completed before
@@ -276,9 +276,9 @@ those with and without accessors):
 The assignment is carried out at object build time. The right-hand side is
 evaluated at that time, and can even reference earlier attributes:
 
-=for code :skip-test
-has Task @!dependencies;
-has $.ready = not @!dependencies;
+    =for code :preamble<class Task {}>
+    has Task @!dependencies;
+    has $.ready = not @!dependencies;
 
 Writable attributes are accessible through writable containers:
 
@@ -367,7 +367,7 @@ ignore the C<new> method temporarily; it's a special type of method.
 Consider the second method, C<add-dependency>, which adds a new task to a
 task's dependency list.
 
-    =begin code :skip-test
+    =begin code :skip-test<incomplete code>
     method add-dependency(Task $dependency) {
         push @!dependencies, $dependency;
     }
@@ -386,7 +386,7 @@ attribute.
 
 The C<perform> method contains the main logic of the dependency handler:
 
-    =begin code :skip-test
+    =begin code :skip-test<incomplete code>
     method perform() {
         unless $!done {
             .perform() for @!dependencies;
@@ -490,8 +490,9 @@ allowed to bind things to C<&!callback> and C<@!dependencies> directly. To
 do this, we override the C<BUILD> submethod, which is called on the brand
 new object by C<bless>:
 
-=for code :skip-test
-submethod BUILD(:&!callback, :@!dependencies) { }
+    =begin code :preamble<has &.callback; has @.dependencies;>
+    submethod BUILD(:&!callback, :@!dependencies) { }
+    =end code
 
 Since C<BUILD> runs in the context of the newly created C<Task> object, it
 is allowed to manipulate those private attributes. The trick here is that
@@ -503,7 +504,7 @@ more information.
 The C<BUILD> method is responsible for initializing all attributes and must also
 handle default values:
 
-    =begin code :skip-test
+    =begin code
     has &!callback;
     has @!dependencies;
     has Bool ($.done, $.ready);

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -512,7 +512,7 @@ handle default values:
             :&!callback,
             :@!dependencies,
             :$!done = False,
-            :$!ready = not @!dependencies
+            :$!ready = not @!dependencies,
         ) { }
     =end code
 

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -89,7 +89,7 @@ Class bodies behave like simple blocks for any top level expression; same goes
 to roles and other packages, like grammars (which are actually classes)
 or modules.
 
-=begin code :skip-test<Fails>
+=begin code :skip-test<dies deliberately>
 class C {
     say "I live";
     die "I will never live!"

--- a/doc/Language/experimental.pod6
+++ b/doc/Language/experimental.pod6
@@ -61,7 +61,7 @@ Macro processing happens during parsing time. A macro generates an abstract
 syntax tree, which is grafted into the program syntax tree. C<quasi> is the
 routine that performs this task.
 
-=begin code :skip-test<need use experimental>
+=begin code :skip-test<needs experimental>
 macro does-nothing() {
     quasi {}
 };
@@ -72,7 +72,7 @@ X<|quasi (macros)>
 Macros are a kind of routine, so they can take arguments in exactly the same
 way, and act also in almost the same way.
 
-=begin code :skip-test<need use experimental>
+=begin code :skip-test<needs experimental>
 macro is-mighty( $who ) {
     quasi { "$who is mighty!"}
 };
@@ -86,7 +86,7 @@ including the quotes. Please note that we can also eliminate the parentheses for
 a macro call, following the same rules as a routine. You can use the unquoting
 construct C<{{{}}}> to get rid of this kind of thing:
 
-=begin code :skip-test<need use experimental>
+=begin code :skip-test<needs experimental>
 macro is-mighty( $who ) {
     quasi { {{{$who}}} ~ " is mighty!"}
 };
@@ -96,7 +96,7 @@ say is-mighty "Freija";  # OUTPUT: «Freija is mighty!␤»
 Since macro expansion happens at parse time, care must be taken when using
 external variables in them:
 
-=begin code :skip-test<need use experimental>
+=begin code :skip-test<needs experimental>
 use experimental :macros;
 my $called;
 macro called() {
@@ -136,7 +136,7 @@ It can be used when heavy calculations are involved, as in this sample that uses
 L<amicable numbers|https://perl6advent.wordpress.com/2018/12/25/calling-numbers-names/#more-7528>,
 taken from the 2018 Advent Calendar:
 
-=begin code :skip-test<Uses experimental>
+=begin code :skip-test<needs experimental>
 use experimental :cached;
 
 sub aliquot-parts( $number ) is cached {

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -764,7 +764,7 @@ type, variable, routine, attribute, or other language object.
 
 Examples of traits are:
 
-=for code :skip-test
+=for code :skip-test<incomplete code>
 class ChildClass is ParentClass { ... }
 #                ^^ trait, with argument ParentClass
 has $.attrib is rw;
@@ -1025,9 +1025,10 @@ say square-root(-4);    # OUTPUT: «0+2i␤»
 
 Another use case is to re-dispatch to methods from parent classes.
 
-=begin code 
+=for code
 say Version.new('1.0.2') # OUTPUT: v1.0.2
 
+=begin code
 class LoggedVersion is Version {
     method new(|c) {
         note "New version object created with arguments " ~ c.perl;

--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -362,7 +362,7 @@ arguments. Consider this basic example:
     congratulate('being a cool number', 'Fred');     # OK
     congratulate('being a cool number', 'Fred', 42); # OK
 
-=for code :skip-test<Proto match error>
+=for code :skip-test<illustrates error>
 congratulate('being a cool number', 42);         # Proto match error
 
 The proto insists that all C<multi congratulate> subs conform to the basic
@@ -395,7 +395,7 @@ with. Parameter defaults and type coercions will work but are not passed on.
 proto mistake-proto(Str() $str, Int $number = 42) {*}
 multi mistake-proto($str, $number) { say $str.^name }
 mistake-proto(7, 42);  # OUTPUT: «Int␤» -- not passed on
-=for code :skip-test<compilation error>
+=for code :skip-test<illustrates error>
 mistake-proto('test'); # fails -- not passed on
 
 =head2 X<only|declarator>

--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -131,7 +131,7 @@ that name:
 # anonymous, but knows its own name
 my $s = anon sub triple($x) { 3 * $x }
 say $s.name;        # OUTPUT: «triple␤»
-=for code :skip-test<error>
+=for code :skip-test<illustrates error>
 say triple(42);     # OUTPUT: «Undeclared routine: triple␤»
 
 X<|API>

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -322,7 +322,7 @@ Will output exactly the same as the code above.  Symptomatic of the difference
 between Classes and Roles, a conflict like defining C<token quote> twice
 using Role composition will result in an error:
 
-=begin code :skip-test<compilation error>
+=begin code :skip-test<compile-time error>
 grammar Quoted-Quotes does Letters does Quote-Quotes does Quote-Other { ... }
 # OUTPUT: ... Error while compiling ... Method 'quote' must be resolved ...
 =end code

--- a/doc/Language/grammar_tutorial.pod6
+++ b/doc/Language/grammar_tutorial.pod6
@@ -43,7 +43,7 @@ Grammars are a special kind of class. You declare and define a grammar exactly
 as you would any other class, except that you use the I<grammar> keyword instead
 of I<class>.
 
-=begin code :skip-test
+=begin code :skip-test<incomplete code>
 grammar G { ... }
 =end code
 
@@ -447,7 +447,7 @@ To work with actions, you use a named parameter called C<actions> which
 should contain an instance of your actions class. With the code above, if our
 actions class called REST-actions, we would parse the URI string like this:
 
-    =begin code :skip-test
+    =begin code :skip-test<illustrates pattern>
     my $matchObject = REST.parse($uri, actions => REST-actions.new);
 
     #   …or if you prefer…
@@ -530,7 +530,7 @@ if we need to.
 If we want to access just the ID of 7 from that long URI, we access the first
 element of the list returned from the C<data> action that we C<made>:
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     my $uri = '/product/update/7/notify';
 
     my $match = REST.parse($uri, actions => REST-actions.new);
@@ -582,7 +582,7 @@ After we C<make> something in the C<TOP> method of a grammar action, we can then
 access all the custom values by calling the C<made> method on the grammar
 result object. The code now becomes
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     my $uri = '/product/update/7/notify';
 
     my $match = REST.parse($uri, actions => REST-actions.new);
@@ -596,7 +596,7 @@ result object. The code now becomes
 If the complete return match object is not needed, you could return only the made
 data from your action's C<TOP>.
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     my $uri = '/product/update/7/notify';
 
     my $rest = REST.parse($uri, actions => REST-actions.new).made;
@@ -626,7 +626,7 @@ C<subject-id> and have it set to element 0 of C«<data>».
 
 Now we can do this instead:
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     my $uri = '/product/update/7/notify';
 
     my $rest = REST.parse($uri, actions => REST-actions.new).made;

--- a/doc/Language/hashmap.pod6
+++ b/doc/Language/hashmap.pod6
@@ -211,7 +211,7 @@ the C<%()> hash constructor:
 If one or more values reference the topic variable, C<$_>, the right-hand side
 of the assignment will be interpreted as a L<Block|/type/Block>, not a Hash:
 
-=begin code :skip-test
+=begin code :skip-test<illustrates error>
 my @people = [
     %( id => "1A", firstName => "Andy", lastName => "Adams" ),
     %( id => "2B", firstName => "Beth", lastName => "Burke" ),

--- a/doc/Language/io-guide.pod6
+++ b/doc/Language/io-guide.pod6
@@ -238,13 +238,13 @@ Tip: you can join path parts with C</> and feed them to
 L«C<IO::Path>|/type/IO::Path»'s routines; they'll still do The Right Thing™ with
 them, regardless of the operating system.
 
-=for code :skip-test
+=for code :skip-test<needs filesystem>
 # WRONG!! TOO MUCH WORK!
 my $fh = open $*SPEC.catpath: '', 'foo/bar', $file;
 my $data = $fh.slurp;
 $fh.close;
 
-=for code :skip-test
+=for code :skip-test<needs filesystem>
 # RIGHT! Use IO::Path to do all the dirty work
 my $data = 'foo/bar'.IO.add($file).slurp;
 

--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -710,7 +710,7 @@ In Perl 6, variables can be typed by placing the type between the declarator
 match the variable's type will throw either a compile-time or runtime error,
 depending on how the value is evaluated:
 
-=begin code :skip-test<deliberate compile-time error>
+=begin code :skip-test<compile-time error>
 enum Name <Phoebe Daniel Joe>;
 my Str $name = 'Phoebe';
 $name = Phoebe; # Throws a compile-time error

--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -710,7 +710,7 @@ In Perl 6, variables can be typed by placing the type between the declarator
 match the variable's type will throw either a compile-time or runtime error,
 depending on how the value is evaluated:
 
-=begin code :skip-test
+=begin code :skip-test<deliberate compile-time error>
 enum Name <Phoebe Daniel Joe>;
 my Str $name = 'Phoebe';
 $name = Phoebe; # Throws a compile-time error

--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -570,7 +570,7 @@ However, the following calls will all fail, due to passing an untyped array,
 even if the array just happens to contain Int values at the point it is
 passed:
 
-    =begin code :skip-test<compilation errors>
+    =begin code :skip-test<illustrates error>
     my @c = 1, 3, 5;
     say mean(@c);                       # Fails, passing untyped Array
     say mean([1, 3, 5]);                # Same

--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -279,7 +279,7 @@ parameter.
 How can we translate that into Perl 6? Well Math::Model brings some help
 with a very understandable way to do that--let's see it:
 
-=begin code :skip-test<can't use>
+=begin code :skip-test<needs ecosystem>
 use Math::Model;
 
 my $m = Math::Model.new(
@@ -394,7 +394,7 @@ where the constant g defines the growth rate and k is the carrying
  capacity.
 Modifying the above code we can simulate its behavior in time:
 
-=begin code :skip-test<can't use>
+=begin code :skip-test<needs ecosystem>
 use Math::Model;
 
 my $m = Math::Model.new(
@@ -444,7 +444,7 @@ I<critical point>.
 
 Our code would be:
 
-=begin code :skip-test<can't use>
+=begin code :skip-test<needs ecosystem>
 use Math::Model;
 
 my $m = Math::Model.new(
@@ -484,7 +484,7 @@ I<dx/dt=r*x*(1-x/k)*(x/a)**n>, with n>0
 
 Our code would be:
 
-=begin code :skip-test<can't use>
+=begin code :skip-test<needs ecosystem>
 use Math::Model;
 
 my $m = Math::Model.new(

--- a/doc/Language/module-packages.pod6
+++ b/doc/Language/module-packages.pod6
@@ -57,7 +57,7 @@ scoped it is aliased in the module's symbol table. Finally,
 C<friendly-greeting> is marked for export; it will be registered in the
 I<caller's> symbol table when the module is imported:
 
-=begin code :skip-test<can't import>
+=begin code :skip-test<needs dummy module>
 import M;               # import the module
 say M::loud-greeting;   # OUTPUT: «GREETINGS, CAMELIA!␤»
 say friendly-greeting;  # OUTPUT: «Greetings, friend!␤»
@@ -75,7 +75,7 @@ using, it needs to declare one with C<module> as documented above.
 For example, by placing module C<M> inside C<Foo.pm6>, we can load
 and use the module as follows:
 
-=begin code :skip-test<filesystem related>
+=begin code :skip-test<needs dummy module>
 use Foo;                # find Foo.pm6, run need followed by import
 say M::loud-greeting;   # OUTPUT: «GREETINGS, CAMELIA!␤»
 say friendly-greeting;  # OUTPUT: «Greetings, friend!␤»
@@ -104,7 +104,7 @@ module Foo {
 which can be used more consistently by the caller (note the
 relationship between the C<use Foo> and C<Foo::>):
 
-=begin code :skip-test<filesystem related>
+=begin code :skip-test<needs dummy module>
 use Foo;
 say Foo::loud-greeting;  # OUTPUT: «GREETINGS, CAMELIA!␤»
 say friendly-greeting;   # OUTPUT: «Greetings, friend!␤»
@@ -153,7 +153,7 @@ sub friendly-greeting is export  { greeting('friend')           }
 
 As a reminder, here's how we used C<Foo.pm6> before,
 
-=begin code :skip-test<filesystem related>
+=begin code :skip-test<needs dummy module>
 use Foo;
 say Foo::loud-greeting;  # OUTPUT: «GREETINGS, CAMELIA!␤»
 say friendly-greeting;   # OUTPUT: «Greetings, friend!␤»
@@ -161,7 +161,7 @@ say friendly-greeting;   # OUTPUT: «Greetings, friend!␤»
 
 and here's how we use C<Bar.pm6>,
 
-=begin code :skip-test<filesystem related>
+=begin code :skip-test<needs dummy module>
 use Bar;
 say loud-greeting;       # OUTPUT: «GREETINGS FROM BAR, CAMELIA!␤»
 say friendly-greeting;   # OUTPUT: «Greetings from Bar, friend!␤»
@@ -188,7 +188,7 @@ This creates a lexical alias, hiding the C<say> builtin I<inside>
 C<Bar.pm6> but leaving the caller's C<say> unchanged. Consequently,
 the following call to C<say> still works as expected:
 
-=begin code :skip-test<filesystem related>
+=begin code :skip-test<needs dummy module>
 use Bar;
 say 'Carry on, carry on...';  # OUTPUT: «Carry on, carry on...␤»
 =end code

--- a/doc/Language/modules.pod6
+++ b/doc/Language/modules.pod6
@@ -70,7 +70,7 @@ the importing statement.
 
 C<need> loads a C<compunit> at compile time.
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 need MyModule;
 
 Any packages in the namespace defined within will also be available.
@@ -96,7 +96,7 @@ class Class is export {}
 
 And then
 
-=begin code :skip-test<needs to load module>
+=begin code :skip-test<needs dummy module>
 use MyModule;
 
 my $class = Class.new();
@@ -110,12 +110,12 @@ files that end in C<.pm6> (C<.pm> is also supported, but discouraged). See
 L<here|/language/modules#Finding_installed_modules>
 for where the runtime will look for modules.
 
-=for code :skip-test
+=for code :skip-test<needs dummy module>
 use MyModule;
 
 This is equivalent to:
 
-=begin code :allow<L> :skip-test
+=begin code :allow<L> :skip-test<needs dummy module>
 L<need|/language/modules#need> MyModule;
 import MyModule;
 =end code
@@ -203,7 +203,7 @@ N<This change was introduced in late 2016. If you are using versions older than
 this, behavior will be different>. This means that we will have to C<use> a
 class in every scope in which we actually employ it.
 
-=for code :skip-test<Dummy, undefined classes>
+=for code :skip-test<needs dummy module>
 use Foo;           # Foo has "use Bar" somewhere.
 use Bar;
 my $foo = Foo.new;
@@ -265,7 +265,7 @@ tags: C<ALL>, C<DEFAULT> and C<MANDATORY>.
     sub underpants is export(:ALL)       { ... }
     =end code
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     # main.p6
     use lib 'lib';
     use MyModule;          # bag, pants
@@ -284,13 +284,13 @@ the author can provide such access is to give each C<export> trait its
 own unique tag. (And the tag can be the object name!) Then the user can
 either (1) import all objects:
 
-=begin code :skip-test
+=begin code :skip-test<needs dummy module>
 use Foo :ALL;
 =end code
 
 or (2) import one or more objects selectively:
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     use Foo :bar, :s5;
     =end code
 
@@ -305,7 +305,7 @@ no matter whether the using program adds any tag or not.
 
 4. Multiple import tags may be used (separated by commas).  For example:
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     # main.p6
     use lib 'lib';
     use MyModule :day, :night; # pants, sunglasses, torch
@@ -365,7 +365,7 @@ dynamically. For example:
 
     =end code
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     # main.p6
     use MyModule;
     say sqrt-of-four; # OUTPUT: «2␤»
@@ -396,7 +396,7 @@ the values are the desired values. The names should include the sigil
     }
     =end code
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     # main.p6
     use lib 'lib';
     use MyModule;
@@ -434,7 +434,7 @@ passing C<:DEFAULT> to C<use> along with your positional parameters.
     sub shy is export { say "you found me!" }
     =end code
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     # main.p6
     use lib 'lib';
     use MyModule 'foo';
@@ -458,7 +458,7 @@ L<Cool|/type/Cool>s.
     }
     =end code
 
-    =begin code :skip-test
+    =begin code :skip-test<needs dummy module>
     use MakeQuestionable Cool;
     say ( 0?, 1?, {}?, %( a => "b" )? ).join(' '); # OUTPUT: «False True False True␤»
     =end code

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -672,7 +672,7 @@ to be prepended with "lib" and appended with ".so" (or just appended with
 ".dll" on Windows), and will be searched for in the paths in the
 LD_LIBRARY_PATH (PATH on Windows) environment variable.
 
-=begin code :skip-test<don't have library>
+=begin code :skip-test<external dependency>
 use NativeCall;
 constant LIBMYSQL = 'mysqlclient';
 constant LIBFOO = '/usr/lib/libfoo.so.1';

--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -210,7 +210,7 @@ members of Structures like, e.g., structs and unions.
 Example of invoking a function pointer "$fptr" returned by a function "f", using a
 signature defining the desired function parameters and return value:
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 sub f() returns Pointer is native('mylib') { * }
 
 my $fptr    = f();
@@ -231,7 +231,7 @@ a much more primitive CArray type, which you must use if working with C arrays.
 
 Here is an example of passing a C array.
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 sub RenderBarChart(Str, int32, CArray[Str], CArray[num64]) is native("chart") { * }
 my @titles := CArray[Str].new;
 @titles[0]  = 'Me';
@@ -268,7 +268,7 @@ elements that are going to be populated before passing it to the native
 subroutine, otherwise the C function may stomp all over Perl's memory
 leading to possibly unpredictable behavior:
 
-=begin code :skip-test
+=begin code :preamble<use NativeCall; sub get_n_ints($, $) {}>
 my $number_of_ints = 10;
 my $ints = CArray[int32].allocate($number_of_ints); # instantiates an array with 10 elements
 my $n = get_n_ints($ints, $number_of_ints);
@@ -277,7 +277,7 @@ my $n = get_n_ints($ints, $number_of_ints);
 I<Note>: C<allocate> was introduced in Rakudo 2018.05. Before that, you had to
 use this mechanism to extend an array to a number of elements:
 
-=begin code :skip-test
+=begin code :preamble<use NativeCall>
 my $ints = CArray[int32].new;
 my $number_of_ints = 10;
 $ints[$number_of_ints - 1] = 0; # extend the array to 10 items
@@ -381,7 +381,7 @@ NativeCall currently doesn't put object members in containers, so assigning new 
 to them (with =) doesn't work. Instead, you have to bind new values to the private
 members:
 
-=begin code :skip-test
+=begin code :skip-test<continued example>
 class MyStruct is repr('CStruct') {
     has CArray[num64] $!arr;
     has Str $!str;
@@ -415,7 +415,8 @@ class MyUnion is repr('CUnion') {
     has int64 $.flags64;
 }
 
-say nativesizeof(MyUnion.new);  # 8, ie. max(sizeof(MyUnion.flags32), sizeof(MyUnion.flags64))
+say nativesizeof(MyUnion.new);  # OUTPUT: «8␤»
+                                # ie. max(sizeof(MyUnion.flags32), sizeof(MyUnion.flags64))
 =end code
 
 =head2 Embedding CStructs and CUnions
@@ -425,20 +426,22 @@ surrounding CStruct and CUnion. To say the former we use C<has>
 as usual, and to do the latter we use the C<HAS> declarator
 instead:
 
-=begin code :skip-test
+=begin code :skip-test<continued example>
 class MyStruct is repr('CStruct') {
     has Point $.point;  # referenced
     has int32 $.flags;
 }
 
-say nativesizeof(MyStruct.new);  # 16, ie. sizeof(struct Point *) + sizeof(int32_t)
+say nativesizeof(MyStruct.new);  # OUTPUT: «16␤»
+                                 # ie. sizeof(struct Point *) + sizeof(int32_t)
 
 class MyStruct2 is repr('CStruct') {
     HAS Point $.point;  # embedded
     has int32 $.flags;
 }
 
-say nativesizeof(MyStruct2.new);  # 24, ie. sizeof(struct Point) + sizeof(int32_t)
+say nativesizeof(MyStruct2.new);  # OUTPUT: «24␤»
+                                  # ie. sizeof(struct Point) + sizeof(int32_t)
 =end code
 
 =head2 Notes on memory management
@@ -451,7 +454,7 @@ function.
 
 =head3 In your Perl 6 code...
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 
 class AStringAndAnInt is repr("CStruct") {
   has Str $.a_string;
@@ -530,7 +533,7 @@ when dereferenced. Please note that the original
 L<C<strdup>|https://en.cppreference.com/w/c/experimental/dynamic/strdup> returns
 a pointer to C<char>; we are using C<Pointer<Str>>.
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 my Pointer[int32] $p; #For a pointer on int32;
 my Pointer[MyCstruct] $p2 = some_c_routine();
 my MyCstruct $mc = $p2.deref;
@@ -541,7 +544,7 @@ It's quite common for a native function to return a pointer to an array of
 elements. Typed pointers can be dereferenced as an array to obtain individual
 elements.
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 my $n = 5;
 # returns a pointer to an array of length $n
 my Pointer[Point] $plot = some_other_c_routine($n);
@@ -555,7 +558,7 @@ for 1 .. $n -> $i {
 
 Pointers can also be updated to reference successive elements in the array:
 
-=begin code :skip-test
+=begin code :skip-test<continued example>
 my Pointer[Point] $elem = $plot;
 # show differences between successive points
 for 1 ..^ $n {
@@ -578,7 +581,7 @@ for more information on the subject.
 
 Let's say there is some C code that caches strings passed, like so:
 
-=begin code :skip-test :lang<C>
+=begin code :lang<C>
 #include <stdlib.h>
 
 static char *__VERSION;
@@ -601,7 +604,7 @@ set_version(char *version)
 If you were to write bindings for C<get_version> and C<set_version>, they would
 initially look like this, but will not work as intended:
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 sub get_version(--> Str)     is native('./version') { * }
 sub set_version(Str --> Str) is native('./version') { * }
 
@@ -615,7 +618,7 @@ the string passed on the first call after the garbage collector had already
 done so. If the garbage collector shouldn't free a string passed to a native
 function, use C<explicitly-manage> with it:
 
-=begin code :skip-test
+=begin code :skip-test<external dependency>
 say set_version(explicitly-manage('1.0.0')); # 1.0.0
 say get_version;                             # 1.0.0
 say set_version(explicitly-manage('1.0.1')); # 1.0.1
@@ -756,7 +759,7 @@ Though of course C<$*HOME> is a much easier way :-)
 Variables exported by a library – also named "global" or "extern"
 variables – can be accessed using C<cglobal>.  For example:
 
-=for code :skip-test
+=for code :preamble<use NativeCall>
 my $var := cglobal('libc.so.6', 'errno', int32)
 
 This code binds to C<$var> a new L<Proxy|/type/Proxy> object that

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -631,7 +631,7 @@ Since passing arguments to a routine binds the arguments to the parameters,
 a separate binding step is unnecessary if the attribute is used as a
 parameter. Hence the example above could also have been written as:
 
-    =begin code :skip-test
+    =begin code :preamble<has $!enc; has $!data>
     submethod BUILD(:encoding(:$!enc), :$!data) {
         # nothing to do here anymore, the signature binding
         # does all the work for us.
@@ -789,7 +789,7 @@ With this setup, your poor customers will find themselves unable to turn
 their Taurus and you won't be able to make more of your product! In this
 case, it may have been better to use roles:
 
-    =begin code :skip-test
+    =begin code :skip-test<illustrates error>
     role Bull-Like {
         has Bool $.castrated = False;
         method steer {
@@ -854,7 +854,7 @@ a non-stubbed version of a method of the same name must be supplied
 at the time the role is applied to a class. This allows you to
 create roles that act as abstract interfaces.
 
-    =begin code :skip-test
+    =begin code :skip-test<illustrates error>
     role AbstractSerializable {
         method serialize() { ... }        # literal ... here marks the
                                           # method as a stub

--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -543,10 +543,8 @@ L<C<|> a. k. a. I<the flattener>|/routine/|>, which puts it in a list context:
 
 =head2 postcircumfix C«[ ]»
 
-=begin code :skip-test
-sub postcircumfix:<[ ]>(@container, **@index,
-                        :$k, :$v, :$kv, :$p, :$exists, :$delete)
-=end code
+    sub postcircumfix:<[ ]>(@container, **@index,
+                            :$k, :$v, :$kv, :$p, :$exists, :$delete)
 
 Universal interface for positional access to zero or more elements of a
 @container, a.k.a. "X<array indexing operator|array indexing operator;array subscript operator>".
@@ -567,10 +565,8 @@ operator's behavior and for how to implement support for it in custom types.
 
 =head2 postcircumfix C«{ }»
 
-=begin code :skip-test
-sub postcircumfix:<{ }>(%container, **@key,
-                        :$k, :$v, :$kv, :$p, :$exists, :$delete)
-=end code
+    sub postcircumfix:<{ }>(%container, **@key,
+                            :$k, :$v, :$kv, :$p, :$exists, :$delete)
 
 Universal interface for associative access to zero or more elements of a
 %container, a.k.a. "X<hash indexing operator|hash indexing operator;hash subscript operator>".
@@ -1064,7 +1060,7 @@ precedence is lower:
 my $a = -5;
 say ++$a.=abs;
 # OUTPUT: «6␤»
-=for code :skip-test<error>
+=for code :skip-test<illustrates error>
 say ++$a .= abs;
 # OUTPUT: «Cannot modify an immutable Int␤
 #           in block <unit> at <tmp> line 1␤␤»
@@ -2312,9 +2308,8 @@ This operator cannot be overloaded, as it's handled specially by the compiler.
 X<|item =>
 =head2 infix C«=»
 
-=begin code :skip-test
-sub infix:<=>(Mu $a is rw, Mu $b)
-=end code
+    =for code :skip-test<compile-time error>
+    sub infix:<=>(Mu $a is rw, Mu $b)
 
 Called the I<item assignment operator>, it Places the value of the right-hand side into the container on the left-hand
 side. Its exact semantics are left to the container type on the left-hand side.

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -140,7 +140,7 @@ entire names, since the construct starts with C<::>, and either ends immediately
 or is continued with another C<::> outside the parentheses. Most symbolic
 references are done with this notation:
 
-=for code :skip-test
+=for code :skip-test<showcasing syntaxes>
 my $foo = "Foo";
 my $bar = "Bar";
 my $foobar = "Foo::Bar";
@@ -199,7 +199,7 @@ X<|A."$m"()>
 To do direct lookup in a package's symbol table without scanning, treat the
 package name as a hash:
 
-=for code :skip-test
+=for code :skip-test<showcasing syntaxes>
 Foo::Bar::{'&baz'}  # same as &Foo::Bar::baz
 PROCESS::<$IN>      # Same as $*IN
 Foo::<::Bar><::Baz> # same as Foo::Bar::Baz
@@ -212,7 +212,7 @@ compile time.
 The null pseudo-package is the same search list as an ordinary name search.
 That is, the following are all identical in meaning:
 
-=for code :skip-test
+=for code :skip-test<showcasing syntaxes>
 $foo
 ::{'$foo'}
 ::<$foo>
@@ -227,7 +227,7 @@ Subscript the package object itself as a hash object, the key of which is
 the variable name, including any sigil. The package object can be derived
 from a type name by use of the C<::> postfix:
 
-=for code :skip-test
+=for code :skip-test<showcasing syntax>
 MyType::<$foo>
 
 =head2 Class member lookup

--- a/doc/Language/phasers.pod6
+++ b/doc/Language/phasers.pod6
@@ -23,7 +23,7 @@ C<Failure> or exception in the process.
 
 Here is a summary:
 
-=begin code :skip-test
+=begin code :skip-test<listing>
   BEGIN {...} #  * at compile time, as soon as possible, only ever runs once
   CHECK {...} #  * at compile time, as late as possible, only ever runs once
    INIT {...} #  * at runtime, as soon as possible, only ever runs once
@@ -127,64 +127,64 @@ teardown usually want to happen in the opposite order from each other.
 
 Compilation begins
 
-=for code :skip-test
+=for code :skip-test<listing>
       BEGIN {...} #  at compile time, As soon as possible, only ever runs once
       CHECK {...} #  at compile time, As late as possible, only ever runs once
     COMPOSE {...} #  when a role is composed into a class (Not yet implemented)
 
 Execution begins
 
-=for code :skip-test
+=for code :skip-test<listing>
        INIT {...} #  at runtime, as soon as possible, only ever runs once
 
 Before block execution begins
 
-=for code :skip-test
+=for code :skip-test<listing>
         PRE {...} #  assert precondition at every block entry, before ENTER
 
 Loop execution begins
 
-=for code :skip-test
+=for code :skip-test<listing>
       FIRST {...} #  at loop initialization time, before any ENTER
 
 Block execution begins
 
-=for code :skip-test
+=for code :skip-test<listing>
       ENTER {...} #  at every block entry time, repeats on loop blocks.
 
 Exception maybe happens
 
-=for code :skip-test
+=for code :skip-test<listing>
       CATCH {...} #  catch exceptions, before LEAVE
     CONTROL {...} #  catch control exceptions, before LEAVE
 
 End of loop, either continuing or finished
 
-=for code :skip-test
+=for code :skip-test<listing>
        NEXT {...} #  at loop continuation time, before any LEAVE
        LAST {...} #  at loop termination time, after any LEAVE
 
 End of block
 
-=for code :skip-test
+=for code :skip-test<listing>
       LEAVE {...} #  when blocks exits, even stack unwinds from exceptions
        KEEP {...} #  at every successful block exit, part of LEAVE queue
        UNDO {...} #  at every unsuccessful block exit, part of LEAVE queue
 
 Postcondition for block
 
-=for code :skip-test
+=for code :skip-test<listing>
        POST {...} #  assert postcondition at every block exit, after LEAVE
 
 Async whenever-block is complete
 
-=for code :skip-test
+=for code :skip-test<listing>
        LAST {...} #  if ended normally with done, runs once after block
        QUIT {...} #  catch async exceptions
 
 Program terminating
 
-=for code :skip-test
+=for code :skip-test<listing>
         END {...} #  at runtime, ALAP, only ever runs once
 
 =head1 Program execution phasers

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -129,7 +129,7 @@ document classes, roles, subroutines and in general any statement or block.
 The C<WHY> method can be used on these classes, roles, subroutines etc. to
 return the attached Pod value.
 
-=begin code :skip-test
+=begin code
 #| Base class for magicians
 class Magician {
   has Int $.level;
@@ -198,7 +198,7 @@ The paragraph is terminated by the first blank line or block directive.
 
 For example:
 
-=begin code :skip-test
+=begin code :lang<pod6>
 =head1 This is a heading block
 
 This is an ordinary paragraph.
@@ -260,7 +260,7 @@ The implicit code block is then terminated by a blank line.
 
 For example:
 
-=begin code :skip-test
+=begin code :lang<pod6>
 This ordinary paragraph introduces a code block:
 
     my $name = 'John Doe';
@@ -295,7 +295,7 @@ Lists in Pod are specified as a series of C<=item> blocks.
 
 For example:
 
-=begin code :skip-test
+=begin code :lang<pod6>
 The three suspects are:
 
 =item  Happy
@@ -364,7 +364,7 @@ we can specify items that contain multiple paragraphs.
 
 For example:
 
-=begin code :skip-test
+=begin code :lang<pod6>
 Let's consider two common proverbs:
 
 =begin item
@@ -456,7 +456,7 @@ B<R>, B<T>, B<U>, B<V>, B<X>, and B<Z>.
 =head2 Bold
 
 To format a text in bold enclose it in C<B< >>
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 is B<awesome>
 
 Perl 6 is B<awesome>
@@ -464,7 +464,7 @@ Perl 6 is B<awesome>
 =head2 Italic
 
 To format a text in italic enclose it in C<I< >>
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 is I<awesome>
 
 Perl 6 is I<awesome>
@@ -472,7 +472,7 @@ Perl 6 is I<awesome>
 =head2 Underlined
 
 To underline a text enclose it in C<U< >>
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 is U<awesome>
 
 Z<If used will bust Pod::To::BigPage>
@@ -480,7 +480,7 @@ Z<If used will bust Pod::To::BigPage>
 =head2 Code
 
 To flag text as Code and treat it verbatim enclose it in C<C< >>
-=for code :skip-test
+=for code :lang<pod6>
 C<my $var = 1; say $var;>
 
 C<my $var = 1; say $var;>
@@ -494,7 +494,7 @@ A vertical bar (optional) separates label and target.
 The target location can be an URL (first example) or a local POD document (second example).
 Local file names are relative to the base of the project, not the current document.
 
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 homepage L<https://perl6.org>
 L<Perl 6 homepage|https://perl6.org>
 
@@ -502,7 +502,7 @@ Perl 6 homepage L<https://perl6.org>
 
 L<Perl 6 homepage|https://perl6.org>
 
-=for code :skip-test
+=for code :lang<pod6>
 Structure L</language/about#Structure>
 L<Structure|/language/about#Structure>
 
@@ -511,7 +511,7 @@ Structure L</language/about#Structure>
 L<Structure|/language/about#Structure>
 
 To create a link to a section in the same document:
-=for code :skip-test
+=for code :lang<pod6>
 Comments L<#Comments>
 L<Comments|#Comments>
 
@@ -582,7 +582,7 @@ placement link.
 A comment is text that is never rendered.
 
 To create a comment enclose it in C<Z< >>
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 is awesome Z<Of course it is!>
 
 Perl 6 is awesome Z<Of course it is!>
@@ -592,7 +592,7 @@ Perl 6 is awesome Z<Of course it is!>
 Notes are rendered as footnotes.
 
 To create a note enclose it in C<N< >>
-=for code :skip-test
+=for code :lang<pod6>
 Perl 6 is multi-paradigmatic N<Supporting Procedural, Object Oriented, and Functional programming>
 
 Z<Perl 6 is multi-paradigmatic N<Supporting Procedural, Object Oriented, and Functional programming> >
@@ -600,7 +600,7 @@ Z<Perl 6 is multi-paradigmatic N<Supporting Procedural, Object Oriented, and Fu
 =head2 Keyboard input
 
 To flag text as keyboard input enclose it in C<K< >>
-=for code :skip-test
+=for code :lang<pod6>
 Enter your name K<John Doe>
 
 Z<If used will bust Pod::To::BigPage>
@@ -616,7 +616,7 @@ The basic C<ln> command is: C<ln> R<source_file> R<target_file>
 
 or:
 
-=begin code :allow<R> :skip-test
+=begin code :allow<R> :lang<pod6>
     Then enter your details at the prompt:
 
     =for input
@@ -628,7 +628,7 @@ or:
 =head2 Terminal output
 
 To flag text as terminal output enclose it in C<T< >>
-=for code :skip-test
+=for code :lang<pod6>
 Hello T<John Doe>
 
 Z<If used will bust Pod::To::BigPage>
@@ -640,7 +640,7 @@ To include Unicode code points or HTML5 character references in a Pod document, 
 C<E< >> can enclose a number, that number is treated as the decimal Unicode value for the desired code point.
 It can also enclose explicit binary, octal, decimal, or hexadecimal numbers using the Perl 6 notations for explicitly based numbers.
 
-=begin code :skip-test
+=begin code :lang<pod6>
 Perl 6 makes considerable use of the E<171> and E<187> characters.
 
 Perl 6 makes considerable use of the E<laquo> and E<raquo> characters.
@@ -663,7 +663,7 @@ This code is not implemented by C<Pod::To::HTML>, but is implemented in C<Pod::T
 The C<V<>> formatting code treats its entire contents as being B<verbatim>,
 disregarding every apparent formatting code within it. For example:
 
-=for code :skip-test
+=for code :lang<pod6>
     The B<V< V<> >> formatting code disarms other codes
     such as V< I<>, C<>, B<>, and M<> >.
 
@@ -684,7 +684,7 @@ Anything enclosed in an C<X<>> code is an B<index entry>. The contents
 of the code are both formatted into the document and used as the
 (case-insensitive) index entry:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :lang<pod6>
     An B<X<array>> is an ordered list of scalars indexed by number,
     starting with 0. A B<X<hash>> is an unordered collection of scalar
     values indexed by their associated string key.
@@ -693,7 +693,7 @@ of the code are both formatted into the document and used as the
 You can specify an index entry in which the indexed text and the index
 entry are different, by separating the two with a vertical bar:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :lang<pod6>
     An B<X<array|arrays>> is an ordered list of scalars indexed by number,
     starting with 0. A B<X<hash|hashes>> is an unordered collection of
     scalar values indexed by their associated string key.
@@ -705,7 +705,7 @@ case-sensitive.
 You can specify hierarchical index entries by separating indexing levels
 with commas:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :lang<pod6>
     An X<array|B<arrays, definition of>> is an ordered list of scalars
     indexed by number, starting with 0. A X<hash|B<hashes, definition of>>
     is an unordered collection of scalar values indexed by their
@@ -715,7 +715,7 @@ with commas:
 You can specify two or more entries for a single indexed text, by separating
 the entries with semicolons:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :lang<pod6>
     A X<hash|B<hashes, definition of; associative arrays>>
     is an unordered collection of scalar values indexed by their
     associated string key.
@@ -723,7 +723,7 @@ the entries with semicolons:
 
 The indexed text can be empty, creating a "zero-width" index entry:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :lang<pod6>
     B<X<|puns, deliberate>>This is called the "Orcish Maneuver"
     because you "OR" the "cache".
 =end code

--- a/doc/Language/pragmas.pod6
+++ b/doc/Language/pragmas.pod6
@@ -144,7 +144,7 @@ Allow for some other language constructs that were deemed to be a trap that
 warranted a warning and/or an error in normal Perl 6 programming.  Currently,
 C<Perl5> and C<C++> are allowed.
 
-=begin code :skip-test<compilation error>
+=begin code :skip-test<compile-time error>
 sub abs() { say "foo" }
 abs;
 # Unsupported use of bare "abs"; in Perl 6 please use .abs if you meant

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -14,7 +14,7 @@ described in more detail in the following sections.
 
 =head2 X<Literal strings: Q|quote,Q;quote,｢ ｣>
 
-=for code :allow<B> :skip-test
+=for code :allow<B> :skip-test<listing>
 B<Q[>A literal stringB<]>
 B<｢>More plainly.B<｣>
 B<Q ^>Almost any non-word character can be a delimiter!B<^>
@@ -34,13 +34,13 @@ with a space. Please note that some natural languages use a left delimiting
 quote on the right side of a string. C<Q> will not support those as it relies
 on unicode properties to tell left and right delimiters apart.
 
-=for code :allow<B> :skip-test
+=for code :allow<B> :skip-test<listing>
 B<Q'>this will not work!B<'>
 B<Q(>this won't work either!B<)>
 
 The examples above will produce an error. However, this will work
 
-=for code :allow<B> :skip-test
+=for code :allow<B> :skip-test<listing>
 B<Q (>this is fine, because of space after QB<)>
 B<Q '>and so is thisB<'>
 Q<Make sure you B«<»matchB«>» opening and closing delimiters>
@@ -111,7 +111,7 @@ delimiter, but it's also available as an adverb on C<Q>, as in the fifth and
 last example above.
 
 These examples produce:
-=for code :allow<B> :skip-test
+=for code :allow<B> :lang<text>
 Very plain
 This back\slash stays
 This back\slash stays
@@ -132,10 +132,12 @@ in your strings, to avoid interpretation of angle brackets as hash keys:
 
 =head2 X<Interpolation: qq|quote,qq;quote," ">
 
-=begin code :allow<B L> :skip-test
+=begin code :allow<B L>
 my $color = 'blue';
 L<say|/routine/say> B<">My favorite color is B<$color>!B<">
+=end code
 
+=begin code :lang<text>
 My favorite color is blue!
 =end code
 
@@ -146,20 +148,24 @@ written within the string so that the content of the variable is inserted into
 the string. It is also possible to escape variables within a C<qq>-quoted
 string:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B> :preamble<my $color = 'blue'>
 say B<">The B<\>$color variable contains the value '$color'B<">;
+=end code
 
+=begin code :lang<text>
 The $color variable contains the value 'blue'
 =end code
 
 Another feature of C<qq> is the ability to interpolate Perl 6 code from
 within the string, using curly braces:
 
-=begin code :allow<B L> :skip-test
+=begin code :allow<B L>
 my ($x, $y, $z) = 4, 3.5, 3;
 say "This room is B<$x> m by B<$y> m by B<$z> m.";
 say "Therefore its volume should be B<{ $x * $y * $z }> m³!";
+=end code
 
+=begin code :lang<text>
 This room is 4 m by 3.5 m by 3 m.
 Therefore its volume should be 42 m³!
 =end code
@@ -169,10 +175,12 @@ This way, when you write C<"documentation@perl6.org">, you aren't
 interpolating the C<@perl6> variable. If that's what you want to do, append
 a C<[]> to the variable name:
 
-=begin code :allow<B> :skip-test
+=begin code :allow<B>
 my @neighbors = "Felix", "Danielle", "Lucinda";
 say "@neighborsB<[]> and I try our best to coexist peacefully."
+=end code
 
+=begin code :lang<text>
 Felix Danielle Lucinda and I try our best to coexist peacefully.
 =end code
 
@@ -180,9 +188,11 @@ Often a method call is more appropriate.  These are allowed within C<qq>
 quotes as long as they have parentheses after the call. Thus the following
 code will work:
 
-=begin code :allow<B L> :skip-test
+=begin code :allow<B L> :preamble<my @neighbors = "Felix", "Danielle", "Lucinda">
 say "@neighborsB<.L<join|/routine/join>(', ')> and I try our best to coexist peacefully."
+=end code
 
+=begin code :lang<text>
 Felix, Danielle, Lucinda and I try our best to coexist peacefully.
 =end code
 
@@ -234,10 +244,10 @@ L<CONTROL|/language/phasers#CONTROL>.
 =head2 Word quoting: qw
 X<|qw word quote>
 
-=for code :allow<B L> :skip-test
-B<qw|>! @ # $ % ^ & * \| < > B<|> eqv '! @ # $ % ^ & * | < >'.words.list
-B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}')
-B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}')
+=for code :allow<B L>
+B<qw|>! @ # $ % ^ & * \| < > B<|> eqv '! @ # $ % ^ & * | < >'.words.list;
+B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}');
+B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}');
 
 The C<:w> form, usually written as C<qw>, splits the string into
 "words".  In this context, words are defined as sequences of non-whitespace
@@ -282,14 +292,15 @@ angle brackets around the number, without any extra spaces:
 Compared to C<42/10> and C<1+42i>, there's no division (or addition) operation
 involved. This is useful for literals in routine signatures, for example:
 
-    =begin code :skip-test
+    =begin code
     sub close-enough-π (<355/113>) {
         say "Your π is close enough!"
     }
     close-enough-π 710/226; # OUTPUT: «Your π is close enough!␤»
+    =end code
 
+    =begin code :skip-test<illustrates error>
     # WRONG: can't do this, since it's a division operation
-
     sub compilation-failure (355/113) {}
     =end code
 
@@ -373,7 +384,7 @@ prints simply C<hello>.  Nevertheless, if you have declared an environment
 variable before calling C<perl6>, this will be available within C<qx>, for
 instance
 
-    =begin code :skip-test
+    =begin code :skip-test<REPL>
     WORLD="there" perl6
     > say qx{echo "hello $WORLD"}
     =end code
@@ -425,7 +436,7 @@ END
 The contents of the heredoc always begin on the next line, so you can (and
 should) finish the line.
 
-=begin code :skip-test
+=begin code :preamble<sub my-escaping-function { $^x }>
 my $escaped = my-escaping-function(q:to/TERMINATOR/, language => 'html');
 Here are the contents of the heredoc.
 Potentially multiple lines.
@@ -445,7 +456,7 @@ say q:to/END/;
 
 produces this output:
 
-=begin code :skip-test
+=begin code :lang<text>
 Here is
 some multi line
     string
@@ -468,7 +479,7 @@ C<{\> as well as C<$> if it is not the sigil for a defined variable.  For exampl
 
 would produce:
 
-=begin code :skip-test
+=begin code :lang<text>
 option {
     file "db.7.3.8";
 };

--- a/doc/Language/rb-nutshell.pod6
+++ b/doc/Language/rb-nutshell.pod6
@@ -71,7 +71,7 @@ coding styles:
 =begin item
 I<No space allowed before the opening parenthesis of an argument list.>
 
-=begin code :skip-test<error>
+=begin code :skip-test<illustrates error>
 foo (3, 4, 1); # Not right in Ruby or Perl 6 (in Perl 6 this would
                # try to pass a single argument of type List to foo)
 =end code
@@ -1091,7 +1091,7 @@ sub baz($z) { say "baz $z" }
 To use this module, simply C<use Bar> and the functions C<foo> and C<bar>
 will be available:
 
-=for code :skip-test<can't use>
+=for code :skip-test<needs dummy module>
 use Bar;
 foo(1);    #=> "foo 1"
 bar(2);    #=> "bar 2"
@@ -1100,7 +1100,7 @@ If you try to use C<baz> an "Undeclared routine" error is raised at compile time
 
 Some modules allow for selectively importing functions, which would look like:
 
-=begin code :skip-test<can't use>
+=begin code :skip-test<needs dummy module>
 use Bar <foo>; # Import only foo
 foo(1);        #=> "foo 1"
 bar(2);        # Error!

--- a/doc/Language/regexes-best-practices.pod6
+++ b/doc/Language/regexes-best-practices.pod6
@@ -99,7 +99,7 @@ in what you expect, but only so long as there are no possible ambiguities.
 
 For example, in C<ini> files:
 
-    =begin code :skip-test
+    =begin code :lang<ini>
     [section]
     key=value
     =end code

--- a/doc/Language/regexes.pod6
+++ b/doc/Language/regexes.pod6
@@ -1376,7 +1376,7 @@ really does pay attention to the left delimiter as well, and it actually
 rewrites our example to something more like:
 
 X<|SETGOAL>
-    =begin code :skip-test
+    =begin code :skip-test<incomplete code>
     $<OPEN> = '(' <SETGOAL: ')'> <expression> [ $GOAL || <FAILGOAL> ]
     =end code
 
@@ -1651,7 +1651,7 @@ part of the regex that comes afterwards, lexically. Note that regex adverbs
 appearing before the regex must appear after something that introduces the regex
 to the parser, like 'rx' or 'm' or a bare '/'. This is NOT valid:
 
-=begin code :skip-test
+=begin code :skip-test<illustrates error>
 my $rx1 = :i/a/;      # adverb is before the regex is recognized => exception
 =end code
 
@@ -1729,10 +1729,10 @@ have it parse the input in a way you don't expect.
 Since ratcheting behavior is often desirable in parsers, there's a
 shortcut to declaring a ratcheting regex:
 
-    =begin code :skip-test
-    my token thing { .... }
+    =begin code :skip-test<illustrates pattern>
+    my token thing { ... };
     # short for
-    my regex thing { :r ... }
+    my regex thing { :r ... };
     =end code
 
 =head3 X<Sigspace|regex adverb,:sigspace;regex adverb,:s>
@@ -1904,18 +1904,17 @@ C<:ex>) adverb.
 
 The above code produces this output:
 
-=begin code :skip-test
-abracadabra
-abracada
-abraca
-abra
-   acadabra
-   acada
-   aca
-     adabra
-     ada
-       abra
-=end code
+    =for code :lang<text>
+    abracadabra
+    abracada
+    abraca
+    abra
+       acadabra
+       acada
+       aca
+         adabra
+         ada
+           abra
 
 =head3 X<Global|matching adverb,:global;matching adverb,:g>
 
@@ -1964,12 +1963,11 @@ adverb:
 
 produces
 
-=begin code :skip-test
-abracadabra
-   acadabra
-     adabra
-       abra
-=end code
+    =for code :lang<text>
+    abracadabra
+       acadabra
+         adabra
+           abra
 
 =head2 Substitution adverbs
 

--- a/doc/Language/setbagmix.pod6
+++ b/doc/Language/setbagmix.pod6
@@ -327,9 +327,9 @@ X<Intersection operator>. It is of precedence "Junctive and".
 Returns the B<intersection> of all of its arguments. Generally, this creates
 a new C<Set> that contains only the elements common to all of the arguments.
 
-    =begin code :skip-test
-    <a b c> (&) <b c d> === set <b c>
-    <a b c d> (&) <b c d e> (&) <c d e f> === set <c d>
+    =begin code
+    <a b c> (&) <b c d> === set <b c>; # OUTPUT: «True␤»
+    <a b c d> (&) <b c d e> (&) <c d e f> === set <c d>; # OUTPUT: «True␤»
     =end code
 
 If any of the arguments are C<Baggy>, the result is a new C<Bag> containing
@@ -364,9 +364,9 @@ If the first argument is C<Baggy>, this returns a C<Bag> that contains each
 element of the first argument with its weight subtracted by the weight of
 that element in each of the other arguments.
 
-    =begin code :skip-test
-    bag(<a a b c a d>) (-) bag(<a a b c c>) === bag(<a d>)
-    bag(<a a a a c d d d>) (-) bag(<a b d a>) (-) bag(<d c>) === bag(<a a d>)
+    =begin code
+    bag(<a a b c a d>) (-) bag(<a a b c c>) === bag(<a d>); # OUTPUT: «True␤»
+    bag(<a a a a c d d d>) (-) bag(<a b d a>) (-) bag(<d c>) === bag(<a a d>); # OUTPUT: «True␤»
     =end code
 
 =head3 infix ∖
@@ -408,9 +408,10 @@ Returns the Baggy B<multiplication> of its arguments, i.e., a C<Bag> that
 contains each element of the arguments with the weights of the element
 across the arguments multiplied together to get the new weight.
 
-    =begin code :skip-test
-    <a b c> (.) <a b c d> === bag <a b c> # Since 1 * 0 == 0, in the case of 'd'
-    bag(<a a b c a d>) (.) bag(<a a b c c>) === ("a"=>6,"c"=>2,"b"=>1).Bag
+    =begin code
+    <a b c> (.) <a b c d> === bag <a b c>; # OUTPUT: «True␤»
+                                           # Since 1 * 0 == 0, in the case of 'd'
+    bag(<a a b c a d>) (.) bag(<a a b c c>) === ("a"=>6,"c"=>2,"b"=>1).Bag; # OUTPUT: «True␤»
     =end code
 
 =head3 infix ⊍

--- a/doc/Language/subscripts.pod6
+++ b/doc/Language/subscripts.pod6
@@ -237,7 +237,7 @@ Both versions also L<de-cont|https://perl6advent.wordpress.com/2017/12/02/perl-6
 
 So even a one-element list returns a slice, whereas a bare scalar value doesn't:
 
-    =begin code :skip-test
+    =begin code :preamble<my @alphabet = 'a' .. 'z'>
     say @alphabet[2,];        # OUTPUT: «(c)␤»
     say @alphabet[2,].^name;  # OUTPUT: «List␤»
 
@@ -253,7 +253,7 @@ In fact, the list structure of (L<the current dimension of|#Multiple
 dimensions>) the subscript is preserved across the slice operation
 (but the kind of Iterable is not – the result is always just lists.)
 
-    =begin code :skip-test
+    =begin code :preamble<my @alphabet = 'a' .. 'z'>
     say @alphabet[0, (1..2, (3,))];       # OUTPUT: «(a ((b c) (d)))␤»
     say @alphabet[0, (1..2, [3,])];       # OUTPUT: «(a ((b c) (d)))␤»
     say @alphabet[flat 0, (1..2, (3,))];  # OUTPUT: «(a b c d)␤»
@@ -472,7 +472,7 @@ L<operators|/language/operators#Method_postfix_precedence>.
 Beware of the relatively loose precedence of operator adverbs, which may
 require you to add parentheses in compound expressions:
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 if $foo || %hash<key>:exists { ... }    # WRONG, tries to adverb the || op
 =for code :preamble<my $foo; my %hash;>
 if $foo || (%hash<key>:exists) { ... }  # correct
@@ -501,7 +501,7 @@ an undefined value, and elements that aren't part of the collection at all:
 
 May also be negated to test for non-existence:
 
-    =begin code :skip-test
+    =begin code :preamble<my %fruit = :apple(Any), :orange(10)>
     say %fruit<apple banana>:!exists; # OUTPUT: «(False True)␤»
     =end code
 
@@ -560,7 +560,7 @@ instead.
 With the negated form of the adverb, the element is not actually deleted. This
 means you can pass a flag to make it conditional:
 
-    =begin code :skip-test
+    =begin code :preamble<my %fruit = :10apple; my $flag = True>
     say %fruit<apple> :delete($flag);  # deletes the element only if $flag is
                                        # true, but always returns the value.
     =end code
@@ -588,7 +588,7 @@ L<Pair|/type/Pair>, and silently skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
-    =begin code :skip-test
+    =begin code :preamble<my %month = :1Jan, :2Feb, :3Mar>
     say %month<Jan Foo Mar>:!p;  # OUTPUT: «(Jan => 1 Foo => (Any) Mar => 3)␤»
     =end code
 
@@ -614,7 +614,7 @@ and values:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
-    =begin code :skip-test
+    =begin code :preamble<my %month = :1Jan, :2Feb, :3Mar>
     say %month<Jan Foo Mar>:!kv;  # OUTPUT: «(Jan 1 Foo (Any) Mar 3)␤»
     =end code
 
@@ -646,7 +646,7 @@ skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
-    =begin code :skip-test
+    =begin code :preamble<my %month = :1Jan, :2Feb, :3Mar>
     say %month<Jan Foo Mar>:!k;  # OUTPUT: «(Jan Foo Mar)␤»
     =end code
 
@@ -672,7 +672,7 @@ mutable value container), and silently skip nonexistent elements:
 
 If you I<don't> want to skip nonexistent elements, use the negated form:
 
-    =begin code :skip-test
+    =begin code :preamble<my %month = :1Jan, :2Feb, :3Mar>
     say %month<Jan Foo Mar>:!v;  # OUTPUT: «(1 (Any) 3)␤»
     =end code
 
@@ -750,7 +750,7 @@ preferred in camel-case). We can accommodate this by taking the C<*-KEY>
 and C<push> methods out of the C<handles> list, and implementing them
 separately like this:
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     method AT-KEY     ($key) is rw { %!fields{normalize-key $key}        }
     method EXISTS-KEY ($key)       { %!fields{normalize-key $key}:exists }
     method DELETE-KEY ($key)       { %!fields{normalize-key $key}:delete }
@@ -768,7 +768,7 @@ the C<StrOrArrayOfStr> type constraint on C<%!fields>, and replace our
 C<AT-KEY> implementation with one that returns a custom C<Proxy> container
 which takes care of sanitizing values on assignment:
 
-    =begin code :skip-test
+    =begin code :skip-test<continued example>
     multi method AT-KEY (::?CLASS:D: $key) is rw {
         my $element := %!fields{normalize-key $key};
 

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -166,7 +166,7 @@ whitespace disambiguates possible parses.
 The most common form of comments in Perl 6 starts with a single hash character
 C<#> and goes until the end of the line.
 
-=begin code :skip-test
+=begin code :skip-test<dies deliberately>
 if $age > 250 {     # catch obvious outliers
     # this is another comment!
     die "That doesn't look right"
@@ -469,7 +469,7 @@ expression (and thus also a statement).
 
 The C<do> prefix turns statements into expressions. So while
 
-=begin code :skip-test
+=begin code :skip-test<illustrates error>
 my $x = if True { 42 };     # Syntax error!
 =end code
 
@@ -535,7 +535,7 @@ Named entities, such as variables, constants, classes, modules or subs, are part
 of a namespace. Nested parts of a name use C<::> to separate the hierarchy. Some
 examples:
 
-=begin code :skip-test
+=begin code :skip-test<identifiers only>
 $foo                # simple identifiers
 $Foo::Bar::baz      # compound identifiers separated by ::
 $Foo::($bar)::baz   # compound identifiers that perform interpolations
@@ -587,7 +587,7 @@ In all literal formats, you can use underscores to group digits, although they
 don't carry any semantic information; the following literals all evaluate to the
 same number:
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 1000000
 1_000_000
 10_00000
@@ -599,7 +599,7 @@ same number:
 Integers default to signed base-10, but you can use other bases. For details,
 see L<Int|/type/Int>.
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 # not a single literal, but unary - operator applied to numeric literal 2
 -2
 12345
@@ -614,7 +614,7 @@ L<Rat|/type/Rat> literals (rationals) are very common, and take the
 place of decimals or floats in many other languages. Integer division
 also results in a C<Rat>.
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     1.0
     3.14159
     -2.5        # Not actually a literal, but still a Rat
@@ -628,7 +628,7 @@ also results in a C<Rat>.
 Scientific notation with an integer exponent to base ten after an C<e> produces
 L<floating point number|/type/Num>:
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     1e0
     6.022e23
     1e-9
@@ -642,7 +642,7 @@ L<Complex|/type/Complex> numbers are written either as an imaginary number
 (which is just a rational number with postfix C<i> appended), or as a sum of
 a real and an imaginary number:
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     1+2i
     6.123e5i    # note that this is 6.123e5 * i, not 6.123 * 10 ** (5i)
     =end code
@@ -660,7 +660,7 @@ Arrow pairs can have an expression, a string literal or a "bare
 identifier", which is a string with ordinary-identifier syntax that does
 not need quotes on the left-hand side:
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 like-an-identifier-ain't-it => 42
 "key" => 42
 ('a' ~ 'b') => 1
@@ -692,7 +692,7 @@ the I<thaa> letter precedes the number.
 
 Long forms with explicit values:
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 :thing($value)              # same as  thing => $value
 :thing<quoted list>         # same as  thing => <quoted list>
 :thing['some', 'values']    # same as  thing => ['some', 'values']
@@ -791,8 +791,7 @@ a coercion, using B<is> L<trait|/language/traits> on declaration:
 
     my %mixy is Mixy;            # Mixy
     my %mix is Mix;              # Mix
-    my mix-hash is MixHash;      # MixHash
-
+    my %mix-hash is MixHash;     # MixHash
 
 Note that using a usual type declaration with a hash sigil creates a
 typed Hash, not a particular type:
@@ -809,7 +808,7 @@ typed Hash, not a particular type:
 A L<Regex|/type/Regex> is declared with slashes like C</foo/>. Note that
 this C<//> syntax is shorthand for the full C<rx//> syntax.
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     /foo/          # Short version
     rx/foo/        # Longer version
     Q :regex /foo/ # Even longer version
@@ -911,7 +910,7 @@ can be used in the lexical scope to invoke the subroutine. A subroutine
 is an instance of type L<Sub|/type/Sub> and can be assigned to any
 container.
 
-    =begin code :skip-test
+    =begin code :preamble<sub foo {}; my &f = &foo>
     foo;   # Invoke the function foo with no arguments
     foo(); # Invoke the function foo with no arguments
     &f();  # Invoke &f, which contains a function
@@ -972,7 +971,7 @@ context-specific usage.
 There are five types (arrangements) for operators, each taking either
 one or two arguments.
 
-    =begin code :skip-test
+    =begin code :skip-test<showcasing syntaxes>
     ++$x           # prefix, operator comes before single input
     5 + 3          # infix, operator is between two inputs
     $x++           # postfix, operator is after single input
@@ -986,7 +985,7 @@ Operators can be composed. A common example of this is combining an
 infix (binary) operator with assignment. You can combine assignment with
 any binary operator.
 
-    =begin code :skip-test
+    =begin code :skip-test<showcasing syntaxes>
     $x += 5     # Adds 5 to $x, same as $x = $x + 5
     $x min= 3   # Sets $x to the smaller of $x and 3, same as $x = $x min 3
     $x .= child # Equivalent to $x = $x.child
@@ -1005,7 +1004,7 @@ new hyper operator that works pairwise on two lists.
 
 The direction of the arrows indicates what to do when the lists are not the same size.
 
-    =begin code :skip-test
+    =begin code :skip-test<showcasing syntaxes>
     @a «+« @b # Result is the size of @b, elements from @a will be re-used
     @a »+» @b # Result is the size of @a, elements from @b will be re-used
     @a «+» @b # Result is the size of the biggest input, the smaller one is re-used

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -311,7 +311,7 @@ or C<[' ']> which quotes one or more arbitrary characters C<value>.N<Starting
 with Perl 6 language version 6.d, colon pairs with C<sym> as the C<key> (e.g.
 C«:sym<foo>») are reserved for possible future use.>
 
-=begin code :skip-test<Identifiers good and bad>
+=begin code :skip-test<partly bad identifiers>
 # exemplary valid extended identifiers:
 postfix:<²>               # the official long name of the operator in $x²
 WOW:That'sAwesome
@@ -361,7 +361,7 @@ say $a:b<c>:d<e>;               # OUTPUT: «100␤», NOT: «200␤»
 An exception to this rule is I<module versioning>; so these identifiers
 effectively name the same module:
 
-=begin code :skip-test<fake modules>
+=begin code :skip-test<needs dummy module>
 use ThatModule:auth<Somebody>:ver<2.7.18.28.18>
 use ThatModule:ver<2.7.18.28.18>:auth<Somebody>
 =end code

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -13,7 +13,7 @@ Here you can find an overview of different kinds of terms.
 
 =head2 Int
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 42
 12_300_00
 :16<DEAD_BEEF>
@@ -26,7 +26,7 @@ To specify a base other than ten, use the colonpair form C<< :radix<number> >>.
 
 =head2 Rat
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     12.34
     1_200.345_678
     =end code
@@ -40,7 +40,7 @@ with a dot, for example the C<..> L<Range|/type/Range> operator).
 
 =head2 Num
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 12.3e-32
 3e8
 =end code
@@ -51,7 +51,7 @@ exponent. C<3e8> constructs a L<Num|/type/Num> with value C<3 * 10**8>.
 
 =head2 Str
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 'a string'
 'I\'m escaped!'
 "I don't need to be"
@@ -65,7 +65,7 @@ L<Quoting Constructs|/language/quoting>.
 
 =head2 Regex
 
-=begin code :skip-test
+=begin code :skip-test<literals only>
 / match some text /
 rx/slurp \s rest (.*) $/
 =end code
@@ -74,7 +74,7 @@ These forms produce regex literals. See L<quoting constructs|/language/quoting>.
 
 =head2 Pair
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     a => 1
     'a' => 'b'
     :identifier
@@ -108,7 +108,7 @@ with the exception of C<< 'quoted string' => $value >>.
 
 =head2 List
 
-    =begin code :skip-test
+    =begin code :skip-test<literals only>
     ()
     1, 2, 3
     <a b c>

--- a/doc/Language/terms.pod6
+++ b/doc/Language/terms.pod6
@@ -251,7 +251,7 @@ available. Auto-coercion on %-sigiled constants requires 6.d>
 An optional type constraint can be used, in which case the use
 of scope declarator is required:
 
-=begin code :skip-test<showcasing deliberate syntax error>
+=begin code :skip-test<illustrates error>
 # !!WRONG!! missing scope declarator before type:
 Int constant bar = 42;
 
@@ -263,7 +263,7 @@ Unlike L<variables|/language/variables>, you cannot parameterize C<@>-,
 C<%>-, and C<&>-sigiled constants by specifying the parameterization
 type in the declarator itself:
 
-    =begin code :skip-test<showcasing deliberate compile-time error>
+    =begin code :skip-test<illustrates error>
     # !!WRONG!! cannot parameterize @-sigiled constant with Int
     our Int constant @foo = 42;
 

--- a/doc/Language/testing.pod6
+++ b/doc/Language/testing.pod6
@@ -31,8 +31,7 @@ project's base directory.
 
 A typical test file looks something like this:
 
-=begin code :skip-test
-use v6.c;
+=begin code :solo :preamble<my $num-tests = 0>
 use Test;      # a Standard module included with Rakudo
 use lib 'lib';
 

--- a/doc/Language/traps.pod6
+++ b/doc/Language/traps.pod6
@@ -233,7 +233,7 @@ method is automatically generated.
 
 Thus the correct way to write the method C<double> is
 
-=for code :skip-test
+=for code :preamble<has ($.x, $.y)>
 method double {
     $!x *= 2;
     $!y *= 2;
@@ -271,7 +271,7 @@ L<TWEAK|/language/objects#index-entry-TWEAK> method since release
 One possible remedy is to explicitly initialize the attribute in
 C<BUILD>:
 
-=for code :skip-test
+=for code :preamble<has ($.x, $.y)>
 submethod BUILD(:$x) {
     $!y = 18;
     $!x := $x;
@@ -279,7 +279,7 @@ submethod BUILD(:$x) {
 
 which can be shortened to:
 
-=for code :skip-test
+=for code :preamble<has ($.x, $.y)>
 submethod BUILD(:$!x) {
     $!y = 18;
 }
@@ -318,7 +318,7 @@ The common areas you should watch out for are:
 
 =head3 Block vs. Hash slice ambiguity
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 # WRONG; trying to hash-slice a Bool:
 while ($++ > 5){ .say }
 
@@ -332,7 +332,7 @@ while $++ > 5 { .say }
 
 =head3 Reduction vs. Array constructor ambiguity
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 # WRONG; ambiguity with `[<]` meta op:
 my @a = [[<foo>],];
 
@@ -345,7 +345,7 @@ my @a = [[<foo bar ber>],];
 =end code
 
 =head3 Less than vs. Word quoting/Associative indexing
-=for code :skip-test
+=for code :skip-test<illustrates error>
 # WRONG; trying to index 3 associatively:
 say 3<5>4
 
@@ -573,7 +573,7 @@ The problem here is that [1, 2, 3] is not an C<Array[Int]>, it is a plain
 old Array that just happens to have Ints in it.  To get it to work,
 the argument must also be an C<Array[Int]>.
 
-=for code :skip-test
+=for code :preamble<sub bar (Int @a) { 42.say }>
 my Int @b = 1, 2, 3;
 bar(@b);                    # OUTPUT: «42␤»
 bar(Array[Int].new(1, 2, 3));
@@ -619,12 +619,14 @@ Some problems that might arise when dealing with L<strings|/type/Str>.
 
 Interpolation in string literals can be too clever for your own good.
 
-=for code :skip-test
-"$foo<html></html>" # Perl 6 understands that as:
+=for code :preamble<my $foo>
+# "HTML tags" interpreted as associative indexing:
+"$foo<html></html>" eq
 "$foo{'html'}{'/html'}"
 
-=for code :skip-test
-"$foo(" ~ @args ~ ")" # Perl 6 understands that as:
+=for code :preamble<my $foo = { $^x }>
+# Parentheses interpreted as call with argument:
+"$foo(" ~ @args ~ ")" eq
 "$foo(' ~ @args ~ ')"
 
 You can avoid those problems using non-interpolating single quotes and switching
@@ -1103,7 +1105,7 @@ say (-1).abs; # OUTPUT: «1␤»
 
 Subroutine and method calls can be made using one of two forms:
 
-=for code :skip-test
+=for code :skip-test<illustrates pattern>
 foo(...); # function call form, where ... represent the required arguments
 foo ...;  # list op form, where ... represent the required arguments
 
@@ -1119,7 +1121,7 @@ sub bar($a) { say "one arg: $a" }
 
 Then execute each with and without a space after the name:
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 foo();    # okay: no arg
 foo ();   # FAIL: Too many positionals passed; expected 0 arguments but got 1
 bar($a);  # okay: one arg: 1
@@ -1132,7 +1134,7 @@ sub foo($a, $b) { say "two args: $a, $b" }
 
 Execute it with and without the space after the name:
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 foo($a, $b);  # okay: two args: 1, 2
 foo ($a, $b); # FAIL: Too few positionals passed; expected 2 arguments but got 1
 
@@ -1164,7 +1166,7 @@ What happened? That second argument is not a named parameter argument, but a
 L<Pair|/type/Pair> passed as a positional argument. If you want a named
 parameter it has to look like a name to Perl:
 
-=begin code :skip-test
+=begin code :preamble<sub foo ($a, *%arg) {}>
 foo(1, b => 2); # okay
 foo(1, :b(2));  # okay
 foo(1, :b<it>); # okay
@@ -1186,13 +1188,13 @@ means to treat them as named arguments.
 If you really do want to pass them as pairs you should use a L<List|/type/List>
 or L<Capture|/type/Capture> instead:
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 my $list = ('b' => 2),; # this is a List containing a single Pair
 foo(|$list, :$b);       # okay: we passed the pair 'b' => 2 to the first argument
 foo(1, |$list);         # FAIL: Too many positionals passed; expected 1 argument but got 2
 foo(1, |$list.Capture); # OK: .Capture call converts all Pair objects to named args in a Capture
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 my $cap = \('b' => 2); # a Capture with a single positional value
 foo(|$cap, :$b); # okay: we passed the pair 'b' => 2 to the first argument
 foo(1, |$cap);   # FAIL: Too many positionals passed; expected 1 argument but got 2
@@ -1407,7 +1409,7 @@ loop {
 
 And the output it may produce:
 
-=begin code :skip-test
+=begin code :lang<text>
 0
 1
 2
@@ -1424,7 +1426,7 @@ Resolving this is easy because C<.print> returns a promise that you
 can await on. The solution is even more beautiful if you are
 working in a L<react|/language/concurrency#index-entry-react> block:
 
-=begin code :skip-test
+=begin code :skip-test<incomplete code>
 whenever $proc.print: “one\ntwo\nthree\nfour” {
     $proc.close-stdin;
 }
@@ -1446,7 +1448,7 @@ react {
 
 The output is clearly not just 1 line:
 
-=begin code :skip-test
+=begin code :lang<text>
 A
 A's
 AMD
@@ -1665,7 +1667,7 @@ die ‘Dying because of unhandled exception’ if rand < ½; # ② ｢die｣ is 
 =end code
 
 There are three possible results:
-=begin code :skip-test
+=begin code :lang<text>
 ①
 Opened some resource
 

--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -455,7 +455,7 @@ L<X::Attribute::Required>.
 
 You can provide a reason why it's required as an argument to C<is required>
 
-=for code :skip-test
+=for code :skip-test<illustrates error>
 class Correct {
     has $.attr is required("it's so cool")
 };
@@ -791,6 +791,7 @@ b 2>
 
 We can create an enum using it with this code:
 
+    =for code :skip-test<needs filesystem>
     enum ConfigValues ('config'.IO.lines.map({ my ($key, $value) = $_.words; $key => $value }));
     say ConfigValues.enums;          # OUTPUT: «Map.new((a => 1, b => 2))␤»
 

--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -167,7 +167,7 @@ L<containers|/language/containers>. This means C<degrees> and C<θ>, above,
 actually directly represent C<Num>s. To illustrate, try assigning to one after
 you've defined it:
 
-=begin code :skip-test
+=begin code :skip-test<dies deliberately>
 θ = 3; # Dies with the error "Cannot modify an immutable Num"
 =end code
 
@@ -370,7 +370,7 @@ understood in the correct order, to avoid surprise on behalf of the reader.
 Normal blocks and subroutines may also make use of placeholder variables but
 only if they do not have an explicit parameter list.
 
-=begin code :skip-test
+=begin code :skip-test<illustrates error>
 sub say-it    { say $^a; } # valid
 sub say-it()  { say $^a; } # invalid
               { say $^a; } # valid
@@ -483,7 +483,7 @@ predefined variables:
 Declaring a variable with C<my> gives it lexical scope. This means it only
 exists within the current block. For example:
 
-=begin code :skip-test
+=begin code :skip-test<illustrates error>
 {
     my $foo = "bar";
     say $foo; # OUTPUT: «"bar"␤»
@@ -526,7 +526,7 @@ If a variable has been redefined, any code that referenced the outer
 variable will continue to reference the outer variable. So here,
 C<&outer-location> still prints the outer C<$location>:
 
-=begin code :skip-test
+=begin code :skip-test<continued example>
 sub new-location {
     my $location = "nowhere";
     outer-location;
@@ -720,14 +720,14 @@ as an anonymous state variable without an explicit C<state> declaration.
 Furthermore, state variables can be used outside of subroutines. You
 could, for example, use C<$> in a one-liner to number the lines in a file.
 
-=begin code :skip-test
+=begin code :lang<shell>
 perl6 -ne 'say ++$ ~ " $_"' example.txt
 =end code
 
 Each reference to C<$> within a lexical scope is in effect a separate
 variable.
 
-=begin code :skip-test
+=begin code :lang<shell>
 perl6 -e '{ say ++$; say $++  } for ^5'
 # OUTPUT: «1␤0␤2␤1␤3␤2␤4␤3␤5␤4␤»
 =end code
@@ -965,7 +965,7 @@ To force all variables to have a L<definiteness|/language/mop#index-entry-syntax
 constraint, use the pragma C<use variables :D>. The pragma is lexically scoped and can be
 switched off with C<use variables :_>.
 
-=begin code :skip-test
+=begin code :skip-test<compile-time error>
 use variables :D;
 my Int $i;
 # OUTPUT: «===SORRY!=== Error while compiling <tmp>␤Variable definition of type Int:D (implicit :D by pragma) requires an initializer ...
@@ -1054,7 +1054,7 @@ match and so usually contains objects of type L<Match|/type/Match>.
 The C<Grammar.parse> method also sets the caller's C<$/> to the resulting
 L<Match|/type/Match> object.  For the following code:
 
-=begin code :skip-test
+=begin code :skip-test<needs ecosystem>
 use XML::Grammar; # zef install XML
 XML::Grammar.parse("<p>some text</p>");
 say $/;

--- a/doc/Type/Array.pod6
+++ b/doc/Type/Array.pod6
@@ -80,9 +80,7 @@ values that are stored in a single array.
 
 Defined as
 
-=begin code :skip-test
-sub append(\array, elems)
-=end code
+    sub append(\array, |elems)
     multi method append(Array:D: \values)
     multi method append(Array:D: **@values is raw)
 
@@ -189,9 +187,7 @@ list or array.
 
 Defined as
 
-=begin code :skip-test
-sub prepend(\array, elems)
-=end code
+    sub prepend(\array, |elems)
     multi method prepend(Array:D: \values)
     multi method prepend(Array:D: **@values is raw)
 

--- a/doc/Type/Cool.pod6
+++ b/doc/Type/Cool.pod6
@@ -1708,14 +1708,14 @@ format to each integer in turn, then joins the resulting strings with
 a separator (a dot, C<'.'>, by default). This can be useful for
 displaying ordinal values of characters in arbitrary strings:
 
-=begin code :skip-test
-NYI sprintf "%vd", "AB\x{100}";           # "65.66.256"
+=begin code :skip-test<not yet implemented>
+NYI sprintf "%vd", "AB\x[100]";           # "65.66.256"
 =end code
 
 You can also explicitly specify the argument number to use for the
 join string using something like C<*2$v>; for example:
 
-=begin code :skip-test
+=begin code :skip-test<not yet implemented>
 NYI sprintf '%*4$vX %*4$vX %*4$vX',       # 3 IPv6 addresses
         @addr[1..3], ":";
 =end code
@@ -1727,13 +1727,13 @@ display the given value. You can override the width by putting a
 number here, or get the width from the next argument (with C<*> ) or
 from a specified argument (e.g., with C<*2$>):
 
+=begin code :skip-test<partly not yet implemented>
  sprintf "<%s>", "a";           # RESULT: «<a>␤»
  sprintf "<%6s>", "a";          # RESULT: «<     a>␤»
  sprintf "<%*s>", 6, "a";       # RESULT: «<     a>␤»
-=begin code :skip-test
  NYI sprintf '<%*2$s>', "a", 6; # "<     a>"
-=end code
  sprintf "<%2s>", "long";       # RESULT: «<long>␤» (does not truncate)
+=end code
 
 If a field width obtained through C<*> is negative, it has the same
 effect as the C<-> flag: left-justification.
@@ -1773,7 +1773,7 @@ the C<0> flag is ignored:
 (Note that this feature currently works for unsigned integer conversions, but
 not for signed integer.)
 
-  =begin code :skip-test
+  =begin code :skip-test<partly not yet implemented>
   sprintf '<%.6d>', 1;      # <000001>
   NYI sprintf '<%+.6d>', 1;     # <+000001>
   NYI sprintf '<%-10.6d>', 1;   # <000001    >
@@ -1797,7 +1797,7 @@ fit the specified width:
 You can also get the precision from the next argument using C<.*>, or
 from a specified argument (e.g., with C<.*2$>):
 
-  =begin code :skip-test
+  =begin code :skip-test<partly not yet implemented>
   sprintf '<%.6x>', 1;       # RESULT: «<000001>␤»
   sprintf '<%.*x>', 6, 1;    # RESULT: «<000001>␤»
   NYI sprintf '<%.*2$x>', 1, 6;  # "<000001>"
@@ -1857,7 +1857,7 @@ So:
 uses C<$a> for the width, C<$b> for the precision, and C<$c> as the value to
 format; while:
 
-=for code :skip-test
+=for code :skip-test<not yet implemented>
 NYI sprintf '<%*1$.*s>', $a, $b;
 
 would use C<$a> for the width and precision and C<$b> as the value to format.
@@ -1865,7 +1865,7 @@ would use C<$a> for the width and precision and C<$b> as the value to format.
 Here are some more examples; be aware that when using an explicit
 index, the C<$> may need escaping:
 
-=for code :skip-test<a part is not yet implemented>
+=for code :skip-test<partly not yet implemented>
 sprintf "%2\$d %d\n",      12, 34;     # RESULT: «34 12␤␤»
 sprintf "%2\$d %d %d\n",   12, 34;     # RESULT: «34 12 34␤␤»
 sprintf "%3\$d %d %d\n",   12, 34, 56; # RESULT: «56 12 34␤␤»
@@ -1874,7 +1874,7 @@ NYI sprintf "%*1\$.*f\n",       4,  5, 10; # "5.0000\n"
 
 Other examples:
 
-=for code :skip-test
+=for code :skip-test<partly not yet implemented>
 NYI sprintf "%ld a big number", 4294967295;
 NYI sprintf "%%lld a bigger number", 4294967296;
 sprintf('%c', 97);                  # RESULT: «a␤»

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -949,7 +949,7 @@ to work with textual read/write methods and doesn't use the standard C<.open>
 method, be sure to call C<.encoding> method in your custom handle to get
 decoder/encoder properly set up:
 
-=begin code :skip-test<uses ecosystem modules>
+=begin code :skip-test<needs ecosystem>
 class IO::URL is IO::Handle {
     has $.URL is required;
     has Buf $!content;

--- a/doc/Type/Rational.pod6
+++ b/doc/Type/Rational.pod6
@@ -26,8 +26,8 @@ both do the C<Rational> role.
 
 =head2 method new
 
-=for code :skip-test<compile time error>
-method new(NuT:D: $numerator, DeT:D: $denominator --> Rational:D)
+    =for code :preamble<subset NuT of Int; subset DeT of Int>
+    method new(NuT:D $numerator, DeT:D $denominator --> Rational:D)
 
 Creates a new rational object from numerator and denominator, which it
 normalizes to the lowest terms. The C<$denominator> can be zero, in which
@@ -85,23 +85,22 @@ is zero, L<fails|/routine/fail> with C<X::Numeric::DivideByZero>.
 
 =head2 method isNaN
 
-=for code
-method isNaN(Rational:D: --> Bool:D)
+    method isNaN(Rational:D: --> Bool:D)
 
 Tests whether the invocant's Num value is a NaN, an acronym for I<Not available
 Number>. That is both its numerator and denominator are zero.
 
 =head2 method numerator
 
-=for code :skip-test
-method numerator(Rational:D: --> NuT:D)
+    =for code :preamble<subset NuT of Int; subset DeT of Int>
+    method numerator(Rational:D: --> NuT:D)
 
 Returns the numerator.
 
 =head2 method denominator
 
-=for code :skip-test
-method denominator(Rational:D: --> DeT:D)
+    =for code :preamble<subset NuT of Int; subset DeT of Int>
+    method denominator(Rational:D: --> DeT:D)
 
 Returns the denominator.
 

--- a/doc/Type/StrDistance.pod6
+++ b/doc/Type/StrDistance.pod6
@@ -60,6 +60,7 @@ Defined as:
 
 Returns an C<After> string value.
 
+    =for code :preamble<my $str = "fold">
     my $str-dist = ($str ~~ tr/old/new/);
     say $str-dist.Str; # OUTPUT: «fnew␤»
     say ~$str-dist;    # OUTPUT: «fnew␤»


### PR DESCRIPTION
Concerns #2738.

This set of commits reduces the number of :skip-test tags from 368 to 290, and so that no :skip-test without an explanation remains. Measures applied:
  * stating the proper non-perl6 :lang instead of :skip-test,
  * minor reflow of code to allow tests to pass (e.g. adding semicolons + rearranging comments),
  * adding :preambles, or ultimately
  * explaining why the test would fail.

Next the number of distinct :skip-test explanations is reduced where the different wording adds no information. Improving the grouping by :skip-test reason can ease removing more :skip-test's in the future when the tester makes the filesystem or ecosystem available or when pulling in context from "continued examples" is supported by the example-compilation.t.

Lastly, all examples test successfully in my machine now (xt/examples-compilation.t).