### PR TITLE
Document Scheduler.cue edge cases with :at/:in/:every

### DIFF
--- a/doc/Type/Scheduler.pod6
+++ b/doc/Type/Scheduler.pod6
@@ -51,6 +51,11 @@ C<$times> tells the scheduler how many times to run the code.
 C<&catch> is called with the L<Exception|/type/Exception> as its sole argument
 if C<&code> dies.
 
+If C<$at>, C<$in>, or C<$every> are C<Inf>, C<&code> will never be run. If any
+of them are C<-Inf>, C<&code> will be run immediately. If any of them are
+C<NaN>, an C<X::AdHoc> exception will be thrown with the message "Cannot set
+NaN as a number of seconds".
+
 One should call the C<cancel> method on the returned C<Cancellation> object
 to cancel the (possibly repeated) cueing of the code.
 


### PR DESCRIPTION
## The problem
The changes in https://github.com/rakudo/rakudo/pull/2819 are undocumented.

## Solution provided
This documents them.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
