### PR TITLE
nativecall: Add language to address #2684

### DIFF
--- a/doc/Language/nativecall.pod6
+++ b/doc/Language/nativecall.pod6
@@ -653,8 +653,17 @@ say $esponja;
 
 NativeCall also supports native functions that take functions as arguments.  One
 example of this is using function pointers as callbacks in an event-driven
-system.  When binding these functions via NativeCall, one need only provide the
+system.  When binding these functions via NativeCall, one should need only provide the
 equivalent signature as L<a constraint on the code parameter|/type/Signature#Constraining_signatures_of_Callables>:
+
+    # See below--this syntax does not work on Rakudo currently
+    use NativeCall;
+    # void SetCallback(int (*callback)(const char *))
+    my sub SetCallback(&callback:(Str --> int32)) is native('mylib') { * }
+
+However, in the case of NativeCall, currently Rakudo requires a space between the
+function argument and the signature, and the colon of a normal Signature
+literal is ommitted, as in:
 
     use NativeCall;
     # void SetCallback(int (*callback)(const char *))


### PR DESCRIPTION
The syntax for NativeCall callable signature constraints under Rakudo
deviates from the usual syntax. There is an issue at
rakudo/rakudo#2878 addressing this, but until this is addressed, some
minimal explanation for the strange syntax is needed.