### PR TITLE
Clarify Setty/Baggy and add examples

### DIFF
--- a/doc/Type/QuantHash.pod6
+++ b/doc/Type/QuantHash.pod6
@@ -49,14 +49,24 @@ typically L<Mu>.
     method Setty(--> Setty:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Setty>
-role.
+role. Note that for L<Mixy> type coercion items with negative values will be skipped.
+
+    my %b is Bag = one => 1, two => 2;
+    say %b.Setty; # OUTPUT: «set(one two)␤»
+    my %m is Mix = one => 1, minus => -1;
+    say %m.Setty; # OUTPUT: «set(one)␤»
 
 =head2 method Baggy
 
     method Baggy(--> Baggy:D)
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Baggy>
-role.
+role. Note that for L<Mixy> type coercion items with negative values will be skipped.
+
+    my %s is Set = <one two>;
+    say %s.Baggy; # OUTPUT: «Bag(one, two)␤»
+    my %m is Mix = one => 1, minus => -1;
+    say %m.Baggy; # OUTPUT: «Bag(one)␤»
 
 =head2 method Mixy
 
@@ -64,6 +74,11 @@ role.
 
 Coerce the C<QuantHash> object to the equivalent object that uses the L<Mixy>
 role.
+
+    my %s is Set = <one two>;
+    say %s.Mixy; # OUTPUT: «Mix(one, two)␤»
+    my %b is Bag = one => 1, two => 2;
+    say %b.Mixy; # OUTPUT: «Mix(one, two)␤»
 
 =end pod
 


### PR DESCRIPTION
Resolves `Items with negative weights are removed when coercing a Mixy to Setty/Baggy` item in 6.d checklist.