### PR TITLE
Replace "two's complement" with "bitwise negation" to better reflect the meaning and usage of the operator

### DIFF
--- a/doc/Language/js-nutshell.pod6
+++ b/doc/Language/js-nutshell.pod6
@@ -328,7 +328,7 @@ console.log(~1);      // OUTPUT: -2
 =end code
 
 In Perl 6, there is no equivalent to C«>>>». All bitwise operators are
-prefixed with C<+>, however two's complement uses C<+^> instead of C<~>:
+prefixed with C<+>, however bitwise negation uses C<+^> instead of C<~>:
 
 =begin code
 say 1 +< 1; # OUTPUT: 2


### PR DESCRIPTION
The original documentation referred to "the two's complement" of a number.  Which is technically correct, but that's a very strange phrasing; everyone just says bitnot or bitwise not (or, in context, just not).