### PR TITLE
add .map, .flat, .concise, and .summary for Backtrace

### DIFF
--- a/doc/Type/Backtrace.pod6
+++ b/doc/Type/Backtrace.pod6
@@ -68,6 +68,69 @@ Defined as:
 
 Returns a list of L<Backtrace::Frame> objects for this backtrace.
 
+=head2 method summary
+
+Defined as:
+
+    method summary(Backtrace:D: --> Str:D)
+
+Returns a summary string representation of the backtrace, filtered
+by C<!.is-hidden && (.is-routine || !.is-setting)>.
+
+    sub inner { say Backtrace.new.summary }
+    sub outer { inner; }
+    outer;
+
+    #OUTPUT:
+    #perl6 test.p6
+    #  in method new at SETTING::src/core/Backtrace.pm6 line 85
+    #  in sub inner at test.p6 line 1
+    #  in sub outer at test.p6 line 2
+    #  in block <unit> at test.p6 line 3
+
+=head2 method concise
+
+Defined as:
+
+    method concise(Backtrace:D: --> Str:D)
+
+Returns a concise string representation of the backtrace, filtered
+by C<!.is-hidden && .is-routine && !.is-setting>.
+
+    sub inner { say Backtrace.new.concise }
+    sub outer { inner; }
+    outer;
+
+    #OUTPUT:
+    #perl6 test.p6
+    #  in sub inner at test.p6 line 1
+    #  in sub outer at test.p6 line 2
+
+=head2 method map
+
+It invokes &code for each element and gathers the return values in a sequence and returns it.
+
+    sub inner { Backtrace.new.map({ say "{$_.file}: {$_.line}" }); }
+    sub outer { inner; }
+    outer;
+
+    #OUTPUT:
+    #perl6 test.p6
+    #  SETTING::src/core/Backtrace.pm6: 85
+    #  SETTING::src/core/Backtrace.pm6: 85
+    #  test.p6: 1
+    #  test.p6: 2
+    #  test.p6: 3
+    #  test.p6: 1
+
+=head2 method flat
+
+Defined as:
+
+    multi method flat(Backtrace:D: --> List:D }
+
+Returns the backtrace same as L<list|#method_list>.
+
 =end pod
 
 # vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
add .map, .flat, .concise, and .summary for Backtrace as list missed in https://github.com/perl6/doc/issues/2632