### PR TITLE
Point out difference between finite and infinite Range subscripts

### DIFF
--- a/doc/Language/list.pod6
+++ b/doc/Language/list.pod6
@@ -504,7 +504,9 @@ list's C<.elems> as an argument and uses the resulting range to slice:
     say @a[0..^*/2];  # OUTPUT: «(1 2 3)␤»
 
 Notice that C<0..^*> and C<0..^*+0> behave consistently in subscripts despite
-one being an infinite range and the other a WhateverCode producing ranges.
+one being an infinite range and the other a WhateverCode producing ranges,
+but C<0..*+0> will give you an additional trailing C<Nil> because, unlike the
+infinite range C<0..*>, it does not truncate.
 
 =head2 Array constructor context
 


### PR DESCRIPTION
## The problem
From the example of `0..^*` and `0..^*+0` being consistent in Range subscripts (even though they are technically very different), it might sound like WhateverCode (finite) ranges and infinite ranges might be consistent everywhere. This is not the case.

## Solution provided
Add a half-sentence pointing out and explaining the difference one should expect between `0..*` and `0..*+0` when used as subscript.