### PR TITLE
Explain $! and $/ in start block

### DIFF
--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -178,7 +178,7 @@ If the code inside the block has not finished, the call to C<.result> will
 wait until it is done.
 
 A C<start> may also be used on a bare statement (without curly braces).
-This is mainly just useful when calling a subroutine / method on an object
+This is mainly useful when calling a subroutine / method on an object
 is the only thing to do asynchronously.
 
     sub get42 { 42 }
@@ -187,7 +187,8 @@ is the only thing to do asynchronously.
 
 Note that code executed this way does not have access to the special
 variables L«C<$!>|/syntax/$!» and L«C<$/>|/syntax/$/» of its outer
-block, but receives new ones.
+block, but receives new ones, so every asynchronous task has its
+per-task state.
 
 Thus, C<try> expressions and regex matches executed in the
 asynchronous task have their per-task state.

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -185,8 +185,12 @@ is the only thing to do asynchronously.
     my $promise = start get42;
     say $promise.result; # OUTPUT: «42␤»
 
-Note that code executed this way does not have access to special variables L«C<$!>|/syntax/$!»
-and L«C<$/>|/syntax/$/» of its outer block, but receives new ones.
+Note that code executed this way does not have access to the special
+variables L«C<$!>|/syntax/$!» and L«C<$/>|/syntax/$/» of its outer
+block, but receives new ones.
+
+Thus, C<try> expressions and regex matches executed in the
+asynchronous task have their per-task state.
 
     'a' ~~ /a/; # $/ is set to ｢a｣
     try die;    # $! is defined now with an anonymous AdHoc exception

--- a/doc/Language/control.pod6
+++ b/doc/Language/control.pod6
@@ -181,6 +181,22 @@ A C<start> may also be used on a bare statement (without curly braces).
 This is mainly just useful when calling a subroutine / method on an object
 is the only thing to do asynchronously.
 
+    sub get42 { 42 }
+    my $promise = start get42;
+    say $promise.result; # OUTPUT: «42␤»
+
+Note that code executed this way does not have access to special variables L«C<$!>|/syntax/$!»
+and L«C<$/>|/syntax/$/» of its outer block, but receives new ones.
+
+    'a' ~~ /a/; # $/ is set to ｢a｣
+    try die;    # $! is defined now with an anonymous AdHoc exception
+    # as a code block
+    await start { say $! }; # OUTPUT: «Nil␤»
+    await start { say $/ }; # OUTPUT: «Nil␤»
+    # as a single statement
+    await start $!.say;     # OUTPUT: «Nil␤»
+    await start $/.say;     # OUTPUT: «Nil␤»
+
 =head1 X<if|control flow,if>
 
 To conditionally run a block of code, use an C<if> followed by a condition.


### PR DESCRIPTION
Addresses `start blocks and thunks get fresh $/ and $!` from 6.d changelog.

On the other hand, I am not sure where we can indicate `thunks` part. Any ideas?