### PR TITLE
Add cando example with Block

### DIFF
--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -146,7 +146,7 @@ L<Capture|/type/Capture>.  Since C<Code> objects do not have any multiple
 dispatch, this either returns a list with the object, or an empty list.
 
     my $single = \'a';         # a single argument Capture
-    my $plural = \'a', 42;     # a two argument Capture
+    my $plural = \('a', 42);   # a two argument Capture
     my &block = { say $^a };   # a Block object, that is a subclass of Code, taking one argument
     say &block.cando($single); # OUTPUT: «(-> $a { #`(Block|94212856419136) ... })␤»
     say &block.cando($plural); # OUTPUT: «()␤»

--- a/doc/Type/Code.pod6
+++ b/doc/Type/Code.pod6
@@ -145,6 +145,12 @@ Returns a list of candidates that can be called with the given
 L<Capture|/type/Capture>.  Since C<Code> objects do not have any multiple
 dispatch, this either returns a list with the object, or an empty list.
 
+    my $single = \'a';         # a single argument Capture
+    my $plural = \'a', 42;     # a two argument Capture
+    my &block = { say $^a };   # a Block object, that is a subclass of Code, taking one argument
+    say &block.cando($single); # OUTPUT: «(-> $a { #`(Block|94212856419136) ... })␤»
+    say &block.cando($plural); # OUTPUT: «()␤»
+
 =head2 method Str
 
 Defined as:


### PR DESCRIPTION
Tries to address `WhateverCode and Block provide .cando` item from 6.d changelog.

Both `WhateverCode` and `Block` inherit from `Code`, so have this method. On the other hand, it says "thunks of code" and it is unclear how to create them explicitly.