### PR TITLE
Document Pair.Pair method

### DIFF
--- a/doc/Type/Pair.pod6
+++ b/doc/Type/Pair.pod6
@@ -336,7 +336,7 @@ B<NOTE:> this method is deprecated as of B<6.d> language version. Instead,
 create a new C<Pair>, with a L<decontainerized|/language/glossary#decont> key/value.
 
 =for code :preamble<my $p>
-$p.=Map.=head.say;                # OUTPUT: «orange␤»
+$p.=Map.=head.say;                                    # OUTPUT: «orange␤»
 
 =head2 method Str
 
@@ -349,6 +349,17 @@ as I<key ~ \t ~ value>.
 
     my $b = eggs => 3;
     say $b.Str;                                       # OUTPUT: «eggs  3␤»
+
+=head2 method Pair
+
+Defined as:
+
+    method Pair()
+
+Returns the invocant Pair object.
+
+    my $pair = eggs => 3;
+    say $pair.Pair === $pair;                         # OUTPUT: «True␤»
 
 =end pod
 


### PR DESCRIPTION
Last thing we need for `Pair provides .ACCEPTS, .Pair, and .invert` item in 6.d changelog.