### PR TITLE
examples-compilation.t memory and code quality

### DIFF
--- a/doc/Language/about.pod6
+++ b/doc/Language/about.pod6
@@ -136,7 +136,7 @@ You can add emphasis with bold (B<V< B<> >>) or italicized (B<V< I<> >>),
 with or without code formatting (B<V< C<> >>).  Due to current parser limitations,
 special steps have to be taken to use B<V< X<> >> with other formatting codes; for example:
 
-=begin code
+=begin code :lang<pod6>
 =item X<B<foo>|foo> a fancy subroutine
 =end code
 

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -12,7 +12,7 @@ Every Pod document has to begin with C<=begin pod> and end with C<=end pod>.
 Everything between these two delimiters will be processed and used to generate
 documentation.
 
-=begin code
+=begin code :lang<pod6>
 =begin pod
 
 A very simple Perl 6 Pod document
@@ -35,7 +35,7 @@ C<typename> of the block. Typenames that are entirely lowercase (for
 example: C<=begin head1>) or entirely uppercase (for example: C<=begin
 SYNOPSIS>) are reserved.
 
-=begin code
+=begin code :lang<pod6>
 =begin head1
 Top Level Heading
 =end head1
@@ -92,7 +92,7 @@ The C<=for> marker is followed by the C<typename> of the block
 plus, optionally, any configuration data as in the delimited
 blocks described above.
 
-=begin code
+=begin code :lang<pod6>
 =for head1
 Top Level Heading
 =end code
@@ -104,7 +104,7 @@ C<typename> of the block. All following data are part of the contents of the
 block, thus configuration data B<cannot> be specified for an I<abbreviated>
 block. The block ends at the next Pod directive or the first blank line.
 
-=begin code
+=begin code :lang<pod6>
 =head1 Top level heading
 =end code
 
@@ -178,7 +178,7 @@ Pod offers a wide range of standard block types.
 Headings can be defined using C<=headN>,
 where N is greater than zero (e.g., C<=head1>, C<=head2>, …).
 
-=begin code
+=begin code :lang<pod6>
 =head1 A top level heading
 
 =head2 A second level heading
@@ -222,7 +222,7 @@ Ordinary paragraphs do not require an explicit marker or delimiters.
 
 Alternatively, there is also an explicit C<=para> marker that can be used to explicitly mark a paragraph.
 
-=begin code
+=begin code :lang<pod6>
 =para
 This is an ordinary paragraph.
 Its text  will   be     squeezed     and
@@ -233,7 +233,7 @@ In addition, the longer C<=begin para> and C<=end para> form can be used.
 
 For example:
 
-=begin code
+=begin code :lang<pod6>
 
 =begin para
 This is an ordinary paragraph.
@@ -269,7 +269,7 @@ This ordinary paragraph introduces a code block:
 
 Code blocks can also be explicitly defined by enclosing them in C<=begin code> and C<=end code>
 
-=begin code
+=begin code :lang<pod6>
     =begin code
     my $name = 'John Doe';
     say $name;
@@ -313,7 +313,7 @@ The three suspects are:
 
 Lists that define terms or commands use C<=defn>, equivalent to the C<DL> lists in HTML
 
-=begin code
+=begin code :lang<pod6>
 =defn Happy
 When you're not blue.
 
@@ -337,7 +337,7 @@ Note that C<=item> is just an abbreviation for C<=item1>.
 
 For example:
 
-=begin code
+=begin code :lang<pod6>
 =item1  Animal
 =item2     Vertebrate
 =item2     Invertebrate
@@ -415,13 +415,13 @@ Pod comments are comments that Pod renderers ignore.
 
 Comments are useful for meta-documentation (documenting the documentation). Single-line comments use the C<comment> keyword:
 
-=begin code
+=begin code :lang<pod6>
 =comment Add more here about the algorithm
 =end code
 
 For multi-line comments use a delimited C<comment> block:
 
-=begin code
+=begin code :lang<pod6>
 =begin comment
 This comment is
 multi-line.
@@ -433,7 +433,7 @@ multi-line.
 All uppercase block typenames are reserved for specifying standard documentation,
 publishing, source components, or meta-information.
 
-=begin code
+=begin code :lang<pod6>
 =NAME
 =AUTHOR
 =VERSION
@@ -536,7 +536,7 @@ code itself.
 C<P<>> codes are handy for breaking out standard elements of
 your documentation set into reusable components that can then be
 incorporated directly into multiple documents. For example:
-=begin code
+=begin code :lang<pod6>
 =COPYRIGHT
 P<file:/shared/docs/std_copyright.pod>
 


### PR DESCRIPTION
I'm trying to address #2798. This restores a rough test plan, now showing the number of files in the test and processing each file in a subtest. I've also removed an `if False` wrapper around non-`solo` code which was needed to prevent EVAL from executing code. I don't see how any more can be eliminated to close that issue. Suggestions welcome.

Concerning #2764, I've run the test five times on `doc/Type/*.pod6` measuring maximum memory usage and cpu time using `Telemetry` and computed mean and std. deviation:

Commit | `max-rss` µ | `cpu` µ | `max-rss` σ | `cpu` σ
--- | :---: | :---: | :---: | :---:
29952fc^ (before #2764) | 1.72 GiB | 66 s | 10.9 MiB | 0.5 s
8afc8a1 (@JJ's current) | 1.51 GiB | 51 s | 4.4 MiB | 0.3 s
taboege/doc@95e3a46 (this PR) | 1.46 GiB | 47.7 s | 9.8 MiB | 0.5 s