### PR TITLE
Document Kernel.free-memory and Kernel.total-memory

### DIFF
--- a/doc/Type/Kernel.pod6
+++ b/doc/Type/Kernel.pod6
@@ -53,6 +53,22 @@ Instance / Class method returning the number of CPU cores that are available.
 Instance / Class method returning the amount of CPU uses since the start of
 the program (in microseconds).
 
+=head2 method free-memory
+
+    method free-memory(--> Int)
+
+Instance / Class method returning the available memory on the system. When
+using the JVM, this returns the available memory to the JVM instead. This
+method is only available in release v2019.06 and later.
+
+=head2 method total-memory
+
+    method total-memory(--> Int)
+
+Instance / Class method returning the total memory available to the system.
+When using the JVM, this returns the total memory available to the JVM instead.
+This method is only available in release v2019.06 and later.
+
 =head2 method desc
 
     method desc(--> Str)


### PR DESCRIPTION
## The problem
`Kernel.free-memory` and `Kernel.total-memory` from https://github.com/rakudo/rakudo/pull/2959/ are undocumented.

## Solution provided
Document them.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
