### PR TITLE
Exception for infix:<x> and infix:<xx> with -Inf and NaN

### DIFF
--- a/doc/Language/operators.pod6
+++ b/doc/Language/operators.pod6
@@ -1258,7 +1258,8 @@ operation.
 X<String repetition operator>.
 
 Repeats the string C<$a> C<$b> times, if necessary coercing C<$a> to L«C<Str>|/type/Str»
-and C<$b> L«C<Int>|/type/Int». Returns an empty string if C<< $b <= 0 >>.
+and C<$b> L«C<Int>|/type/Int». Returns an empty string if C<< $b <= 0 >>. An exception
+C<X::Numeric::CannotConvert> will be thrown if C<$b> is C<-Inf> or C<NaN>.
 
     say 'ab' x 3;           # OUTPUT: «ababab␤»
     say 42 x 3;             # OUTPUT: «424242␤»
@@ -1286,7 +1287,8 @@ Defined as:
 In general, it returns a Sequence of C<$a> repeated and evaluated C<$b> times
 (C<$b> is coerced to L<Int|/type/Int>). If C<< $b <= 0 >>, the empty list is
 returned. It will return an error with no operand, and return the operand itself
-with a single operand.
+with a single operand. An exception C<X::Numeric::CannotConvert> will be
+thrown if C<$b> is C<-Inf> or C<NaN>.
 
 The left-hand side is evaluated for each repetition, so
 


### PR DESCRIPTION
X::Numeric::CannotConvert Exception for infix:<x> and infix:<xx> with -Inf and NaN. Open item in 6.d Checklist https://github.com/perl6/doc/issues/2632
