### PR TITLE
Extend example of fail method

### DIFF
--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -105,10 +105,31 @@ constructed from the concatenation of C<@text>. If the caller
 activated fatal exceptions via the pragma C<use fatal;>, the exception is
 thrown instead of being returned as a C<Failure>.
 
+
+    # A custom exception defined
+    class ForbiddenDirectory is Exception {
+        has Str $.name;
+
+        method message { "This directory is forbidden: '$!name'" }
+    }
+
     sub copy-directory-tree ($dir) {
+        # We don't allow for non-directories to be copied
         fail "$dir is not a directory" if !$dir.IO.d;
+        # We don't allow 'foo' directory to be copied too
+        fail ForbiddenDirectory.new(:name($dir)) if $dir eq 'foo';
+        # Do some actual copying here
         ...
     }
+
+    # A Failure with X::AdHoc exception object is returned and
+    # assigned, so no throwing Would be thrown without an assignment
+    my $result = copy-directory-tree("cat.jpg");
+    say $result.exception; # OUTPUT: «cat.jpg is not a directory␤»
+
+    # A Failure with a custom Exception object is returned
+    $result = copy-directory-tree('foo');
+    say $result.exception; # OUTPUT: «This directory is forbidden: 'foo'␤»
 
 =head2 method gist
 

--- a/doc/Type/Exception.pod6
+++ b/doc/Type/Exception.pod6
@@ -118,6 +118,8 @@ thrown instead of being returned as a C<Failure>.
         fail "$dir is not a directory" if !$dir.IO.d;
         # We don't allow 'foo' directory to be copied too
         fail ForbiddenDirectory.new(:name($dir)) if $dir eq 'foo';
+        # or above can be written in method form as:
+        # ForbiddenDirectory.new(:name($dir)).fail if $dir eq 'foo';
         # Do some actual copying here
         ...
     }


### PR DESCRIPTION
Extends the example to use both X::AdHoc and a custom Exception forms, adds more explanations too.
Tries to address https://github.com/perl6/doc/issues/2793