### PR TITLE
Document how to use unicode in XTerm and URxvt, reorganise

### DIFF
--- a/doc/Language/unicode_entry.pod6
+++ b/doc/Language/unicode_entry.pod6
@@ -2,7 +2,7 @@
 
 =TITLE Entering unicode characters
 
-=SUBTITLE Input methods for unicode characters in editors and the shell
+=SUBTITLE Input methods for unicode characters in terminals, the shell, and editors
 
 Perl 6 allows the use of unicode characters as variable names.  Many
 operators are defined with unicode symbols (in particular the L<set/bag
@@ -95,7 +95,71 @@ Sequences can be viewed by right clicking the tray icon and selecting C<Show Seq
 If you wish to add your own sequences, you can do so by either adding/modifying
 C<.XCompose> in C<%USERPROFILE%>, or editing user-defined sequences in the options menu.
 
-=head1 Editors and shells
+=head1 Terminals, shells, and editors:
+
+=head2 XTerm
+
+Unicode support is enabled in XTerm primarily by setting its C<utf8> and
+C<utf8Fonts> options to C<1>, along with its C<locale> option to C<UTF-8>, in
+C<~/.Xdefaults>. Here is a sample configuration that supports displaying enough
+of unicode to program in Perl 6:
+
+    =begin code :lang<.Xdefaults>
+    XTerm*combiningChars:     0
+    XTerm*faceName:           xft:Noto Mono:style=Regular
+    XTerm*faceNameDoublesize: xft:Noto Emoji:style=Regular
+    XTerm*faceSize:           10
+    XTerm*locale:             UTF-8
+    XTerm*titleModes:         16
+    XTerm*useClipping:        false
+    XTerm*utf8                1
+    XTerm*utf8Fonts           1
+    XTerm*utf8Title:          true
+    =end code
+
+=head2 URxvt
+
+Similarly to xterm, unicode support is enabled in URxvt primarily by setting
+its C<locale> option to C<en_US.UTF-8> in C<~/.Xdefaults>. Here is a sample
+configuration that supports displaying enough of unicode to program in Perl 6:
+
+    =begin code :lang<.Xdefaults>
+    URxvt*font:              xft:Noto Mono:pixelsize=14:style=Regular,\
+                             xft:Noto Emoji:pixelsize=14:style=Regular
+    URxvt*letterspace:       -1
+    URxvt*locale:            en_US.UTF-8
+    URxvt*skipBuiltInGlyphs: true
+    =end code
+
+=head2 Unix shell
+
+At the bash shell, one enters unicode characters by using entering
+C<Ctrl-Shift-u>, then the unicode code point value followed by enter.  For
+instance, to enter the character for the element-of operator (∈) use the
+following key combination (whitespace has been added for clarity):
+
+    =begin code :lang<shell>
+    Ctrl-Shift-u 2208 Enter
+    =end code
+
+This also the method one would use to enter unicode characters into the
+C<perl6> REPL, if one has started the REPL inside a Unix shell.
+
+=head2 Screen
+
+L<GNU Screen|https://www.gnu.org/software/screen/> does sport a B<digraph>
+command but with a rather limited digraph table. Thanks to B<bindkey> and
+B<exec> an external program can be used to insert characters to the current
+screen window.
+
+    =begin code :lang<screen>
+    bindkey ^K exec .! digraphs
+    =end code
+
+This will bind control-k to the shell command digraphs. You can use
+L<digraphs|https://github.com/gfldex/digraphs> if you prefer a Perl 6 friendly
+digraph table over L<RFC 1345|https://tools.ietf.org/html/rfc1345> or change it
+to your needs.
 
 =head2 Vim
 X<|Vim>
@@ -183,36 +247,6 @@ run the C<describe-input-method> command:
     =begin code :lang<tex>
     C-h I TeX
     =end code
-
-=head2 Unix shell
-
-At the bash shell, one enters unicode characters by using entering
-C<Ctrl-Shift-u>, then the unicode code point value followed by enter.  For
-instance, to enter the character for the element-of operator (∈) use the
-following key combination (whitespace has been added for clarity):
-
-    =begin code :lang<shell>
-    Ctrl-Shift-u 2208 Enter
-    =end code
-
-This also the method one would use to enter unicode characters into the
-C<perl6> REPL, if one has started the REPL inside a Unix shell.
-
-=head2 Screen
-
-L<GNU Screen|https://www.gnu.org/software/screen/> does sport a B<digraph>
-command but with a rather limited digraph table. Thanks to B<bindkey> and
-B<exec> an external program can be used to insert characters to the current
-screen window.
-
-    =begin code :lang<screen>
-    bindkey ^K exec .! digraphs
-    =end code
-
-This will bind control-k to the shell command digraphs. You can use
-L<digraphs|https://github.com/gfldex/digraphs> if you prefer a Perl 6 friendly
-digraph table over L<RFC 1345|https://tools.ietf.org/html/rfc1345> or change it
-to your needs.
 
 =head1 Some characters useful in Perl 6
 


### PR DESCRIPTION
## The problem
The unicode entry page has information on how to use unicode with certain shells and editors, but nothing about terminals. Terminal support needs to be documented since it's required in order to use unicode in editors and shells.

## Solution provided
Document how to use unicode in XTerm and URxvt.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
