### PR TITLE
Improve consistency and completeness of Packages document

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -73,6 +73,11 @@ E: cmasak@gmail.com
 N: Carlin
 E: carbin@users.noreply.github.com
 
+N: Chloé Kekoa
+E: rightfold+ck@gmail.com
+W: foldr.nl
+U: chloekek
+
 N: Christopher Bottoms
 E: molecules@users.noreply.github.com
 

--- a/doc/Language/packages.pod6
+++ b/doc/Language/packages.pod6
@@ -33,13 +33,13 @@ class Foo {
     }
 }
 
-my $foo;               # simple identifiers
-say Foo::Bar.baz;      # Calling a method; OUTPUT: «Þor is mighty␤»
-say Foo::Bar::zape;    # compound identifiers separated by ::; OUTPUT: «zipi␤»
+my $foo;                # simple identifiers
+say Foo::Bar.baz;       # calling a method; OUTPUT: «Þor is mighty␤»
+say Foo::Bar::zape;     # compound identifiers separated by ::; OUTPUT: «zipi␤»
 my $bar = 'Bar';
-say $Foo::($bar)::quux;# compound identifiers with interpolations; OUTPUT: «42␤»
-$42;                   # numeric names
-$!;                    # certain punctuation variables
+say $Foo::($bar)::quux; # compound identifiers with interpolations; OUTPUT: «42␤»
+$42;                    # numeric names
+$!;                     # certain punctuation variables
 =end code
 
 X<|::,package>
@@ -53,7 +53,7 @@ exists.
 =begin code
 package Foo:ver<0> {};
 module Foo:ver<1> {};
-say Foo.^ver; OUTPUT: «1␤»
+say Foo.^ver; # OUTPUT: «1␤»
 =end code
 
 The syntax allows the declared package to use a version, but as a matter of
@@ -169,10 +169,10 @@ searched last.
 Use the C<MY> pseudopackage to limit the lookup to the current lexical scope,
 and C<OUR> to limit the scopes to the current package scope.
 
-In the same vein, class and method names can be interpolated too.
+In the same vein, class and method names can be interpolated too:
 
     role with-method {
-        method a-method { return "in-a-method of " ~ $?CLASS.^name  };
+        method a-method { return 'in-a-method of ' ~ $?CLASS.^name  };
     }
 
     class a-class does with-method {
@@ -181,16 +181,16 @@ In the same vein, class and method names can be interpolated too.
 
     class b-class does with-method {};
 
-    my $what-class='a-class';
+    my $what-class = 'a-class';
 
-    say ::($what-class).a-method;
+    say ::($what-class).a-method; # OUTPUT: «in-a-method of a-class␤»
     $what-class = 'b-class';
-    say ::($what-class).a-method;
+    say ::($what-class).a-method; # OUTPUT: «in-a-method of b-class␤»
 
-    my $what-method='a-method';
-    say a-class."$what-method"();
-    $what-method='another-method';
-    say a-class."$what-method"();
+    my $what-method = 'a-method';
+    say a-class."$what-method"(); # OUTPUT: «in-a-method of a-class␤»
+    $what-method = 'another-method';
+    say a-class."$what-method"(); # OUTPUT: «in-another-method␤»
 
 X<|::($c).m>
 X<|A."$m"()>
@@ -203,7 +203,7 @@ package name as a hash:
 
 =for code :skip-test<showcasing syntaxes>
 Foo::Bar::{'&baz'}  # same as &Foo::Bar::baz
-PROCESS::<$IN>      # Same as $*IN
+PROCESS::<$IN>      # same as $*IN
 Foo::<::Bar><::Baz> # same as Foo::Bar::Baz
 
 Unlike C<::()> symbolic references, this does not parse the argument for


### PR DESCRIPTION
## The problem

No output was presented in the name interpolation example, requiring the reader to execute the code to see the output.

## Solution provided

Include the output in the form of OUTPUT comments.