### PR TITLE
Update syntax.pod6

### DIFF
--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -177,8 +177,10 @@ if $age > 250 {     # catch obvious outliers
 
 Multi-line and embedded comments start with a hash character, followed by a
 backtick, and then some opening bracketing character, and end with the matching
-closing bracketing character. The content can not only span multiple lines, but
-can also be embedded inline.
+closing bracketing character. Only the paired characters (), {}, [], and <> are 
+valid for bounding comment blocks. (Unlike matches and substitutions, where pairs 
+such as !!, || or @ may be used.) The content can not only span multiple lines, 
+but can also be embedded inline.
 
 =begin code
 if #`( why would I ever write an inline comment here? ) True {


### PR DESCRIPTION
Explicitly specify legal bounding characters for multi-line comment blocks.

## The problem
Text open to misinterpretation - rakudo #3036

## Solution provided
Expanded text to state explicitly which characters are legal
