### PR TITLE
Fixexternallinks, close #2836, close #2657

### DIFF
--- a/template/footer.html
+++ b/template/footer.html
@@ -26,6 +26,6 @@
 <script type="text/javascript" src="/js/search.js?v=3"></script>
 <script type="text/javascript">
   $(document).ready(function() {
-    $('query').autofocus = true;
+    $('query').focus();
   });
 </script>

--- a/template/footer.html
+++ b/template/footer.html
@@ -26,6 +26,8 @@
 <script type="text/javascript" src="/js/search.js?v=3"></script>
 <script type="text/javascript">
   $(document).ready(function() {
-    $('query').focus();
+    if (!location.hash || location.hash === "#___top") {
+      $('query').focus();
+    } 
   });
 </script>

--- a/template/footer.html
+++ b/template/footer.html
@@ -24,3 +24,8 @@
 
 <script type="text/javascript" src="/js/app.js?v=1"></script>
 <script type="text/javascript" src="/js/search.js?v=3"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('query').autofocus = true;
+  });
+</script>

--- a/template/header.html
+++ b/template/header.html
@@ -1,20 +1,30 @@
 <div id="header" class="pretty-box green">
-    <a href="/"
-        ><img src="/images/Camelia.svg" alt="»ö«" id="logo" width=62 height=48
-        >&nbsp;Perl 6 Documentation</a
-    >
-    <div id="search" class="ui-widget">
-        <div class="green">
-            <input placeholder="Loading..." id="query"
-                accesskey="f" title="Enter term to search for (hit Esc to focus)" autofocus>
-        </div>
-        <p id="not-found-message">
-            Not in Index (<a href="" id="try-web-search">try site search</a>)
-        </p>
+  <a href="/"
+    ><img
+      src="/images/Camelia.svg"
+      alt="»ö«"
+      id="logo"
+      width="62"
+      height="48"
+    />&nbsp;Perl 6 Documentation</a
+  >
+  <div id="search" class="ui-widget">
+    <div class="green">
+      <input
+        placeholder="Loading..."
+        id="query"
+        accesskey="f"
+        title="Enter term to search for (hit Esc to focus)"
+      />
     </div>
-    <div class="menu">
-      MENU
-    </div>
+    <p id="not-found-message">
+      Not in Index (<a href="" id="try-web-search">try site search</a>)
+    </p>
+  </div>
+  <div class="menu">
+    MENU
+  </div>
 </div>
 <div id="content" class="pretty-box yellow CONTENT_CLASS">
-EDITURL
+  EDITURL
+</div>


### PR DESCRIPTION
## The problem

If the `autofocus` property is set since the beginning it blocks fragment links.

## Solution provided

Add the autofocus property when the page is totally loaded and ready.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
