### PR TITLE
Clarify join

### DIFF
--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -913,9 +913,10 @@ Defined as
 
     method join($separator = '') is nodal
 
-Converts the object to a list, and applies
-L<C<list.join>|/type/List#routine_join> to it. Can take a separator, which is an
-empty string by default.
+Converts the object to a list by calling
+L<C<self.list>|/type/Any#routine_list>,
+and calls L<C<.join>|/type/List#routine_join> on the list.
+Can take a separator, which is an empty string by default.
 
     (1..3).join.say ;      # OUTPUT: «123␤»
     <a b c>.join("❧").put; # OUTPUT: «a❧b❧c␤»

--- a/doc/Type/Any.pod6
+++ b/doc/Type/Any.pod6
@@ -918,7 +918,7 @@ L<C<self.list>|/type/Any#routine_list>,
 and calls L<C<.join>|/type/List#routine_join> on the list.
 Can take a separator, which is an empty string by default.
 
-    (1..3).join.say ;      # OUTPUT: «123␤»
+    (1..3).join.say;       # OUTPUT: «123␤»
     <a b c>.join("❧").put; # OUTPUT: «a❧b❧c␤»
 
 =head2 method categorize

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -235,9 +235,10 @@ Defined as:
     sub    join($separator, *@list)
     method join(List:D: $separator = "")
 
-Treats the elements of the list as strings, interleaves them with
-C<$separator> and concatenates everything into a single string.  Note that
-you can omit the C<$separator> if you use the method syntax.
+Treats the elements of the list as strings by calling
+L<C<.Str>|/type/Any#routine_Str> on each of them, interleaves them with
+C<$separator> and concatenates everything into a single string. Note that you
+can omit the C<$separator> if you use the method syntax.
 
 Example:
 

--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -256,7 +256,7 @@ But it behaves slurpily, flattening all arguments after the first into a single
 list:
 
     say join('|', 3, 'þ', 1+4i);    # OUTPUT: «3|þ|1+4i␤»
-    say join ', ', <a b c>, 'd', 'e' , 'f'; OUTPUT: «a, b, c, d, e, f␤»
+    say join ', ', <a b c>, 'd', 'e' , 'f'; # OUTPUT: «a, b, c, d, e, f␤»
 
 In this case, the first list C«<a b c» is I<slurped> and flattened, unlike what
 happens when C<join> is invoked as a method.


### PR DESCRIPTION
## The problem

Somebody on IRC asked how to customize the way join treats the elements. The documentation merely stated that the elements were treated as strings, but not how this happens.

## Solution provided

This patch clarifies that .Str is called. Also clarify how Any.join calls self.list first.
