### PR TITLE
Update several documents

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE A basic introductory example of a Perl 6 program
 
-Suppose that you host a table tennis tournament.  The referees tell you
+Suppose that you host a table tennis tournament. The referees tell you
 the results of each game in the format C<Player1 Player2 | 3:2>, which
 means that C<Player1> won against C<Player2> by 3 to 2 sets. You need a
 script that sums up how many matches and sets each player has won to
@@ -21,7 +21,7 @@ Dave Charlie | 3:0
 Ana Charlie | 3:1
 Beth Dave | 0:3
 
-The first line is the list of players.  Every subsequent line records a result
+The first line is the list of players. Every subsequent line records a result
 of a match.
 
 Here's one way to solve that problem in Perl 6:
@@ -55,7 +55,9 @@ for $file.lines -> $line {
 my @sorted = @names.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;
 
 for @sorted -> $n {
-    say "$n has won %matches{$n} matches and %sets{$n} sets";
+    my $match-noun = %matches{$n} == 1 ?? 'match' !! 'matches';
+    my $set-noun   = %sets{$n} == 1 ?? 'set' !! 'sets';
+    say "$n has won %matches{$n} $match-noun and %sets{$n} $set-noun";
 }
 =end code
 
@@ -64,15 +66,15 @@ This produces the output:
 =for code :lang<text>
 Ana has won 2 matches and 8 sets
 Dave has won 2 matches and 6 sets
-Charlie has won 1 matches and 4 sets
-Beth has won 1 matches and 4 sets
+Charlie has won 1 match and 4 sets
+Beth has won 1 match and 4 sets
 
 =head3 X<C<v6>|v6 (Basics)>
 
 Every Perl 6 program should begin with a line similar to C<use v6;>. This line
-tells the compiler which version of Perl the program expects. Should you
-accidentally run the file with Perl 5, you'll get a helpful error message.  6.c
-is an example of a Perl 6 version.
+tells the compiler which version of Perl 6 the program expects. For instance,
+6.c is an example of a Perl 6 version. Should you accidentally run the file
+with Perl 5, you'll get a helpful error message.
 
 =head3 X<C<statement>|statement (Basics)>
 
@@ -94,7 +96,7 @@ between curly braces C<{ }>.
 =head3 X<C<sigil>> and X<C<identifier>|identifier (Basics)>
 
 A variable name begins with a I<sigil>, which is a non-alpha-numeric
-symbol such as C<$>, C<@>, C<%>, or C<&>--or occasionally the double
+symbol such as C<$>, C<@>, C<%>, or C<&> E<mdash> or occasionally the double
 colon C<::>. Sigils indicate the structural interface for the variable,
 such as whether it should be treated as a single value, a compound value,
 a subroutine, etc. After the sigil comes an I<identifier>, which may
@@ -115,10 +117,10 @@ values (as with an C<Array> or C<Hash>).
 
 =head3 X<C<filehandle>> and X<C<assignment>>
 
-The built-in function C<open> opens a file, here named C<scores>, and returns a
-I<filehandle>--an object representing that file. The equality sign C<=>
-I<assigns> that filehandle to the variable on the left, which means that
-C<$file> now stores the filehandle.
+The built-in function C<open> opens a file, here named C<scores.txt>,
+and returns a I<filehandle> E<mdash> an object representing that file. The
+equality sign C<=> I<assigns> that filehandle to the variable on the left,
+which means that C<$file> now stores the filehandle.
 
 =head3 X<C<string literal>>
 
@@ -132,18 +134,19 @@ my @names = $file.get.words;
 
 =head3 X<C<array>>, X<C<method>|method (Basics)> and X<C<invocant>|invocant (Basics)>
 
-The right-hand side calls a I<method> --a named group of behavior-- named C<get>
-on the filehandle stored in C<$file>.  The C<get> method reads and returns
-one line from the file, removing the line ending.  If you print the contents of C<$file>
-after calling C<get>, you will see that the first line is no longer in there. C<words> is also a method,
-called on the string returned from C<get>. C<words> decomposes its
-I<invocant>--the string on which it operates--into a list of words, which
-here means strings separated by whitespace.
-It turns the single string C<'Beth Ana Charlie Dave'> into the list of
-strings C<'Beth', 'Ana', 'Charlie', 'Dave'>.
+The right-hand side calls a I<method> E<mdash> a named group of
+behavior E<mdash> named C<get> on the filehandle stored in C<$file>. The C<get>
+method reads and returns one line from the file, removing the line ending. If
+you print the contents of C<$file> after calling C<get>, you will see that the
+first line is no longer in there. C<words> is also a method, called on the
+string returned from C<get>. C<words> decomposes its I<invocant> E<mdash>
+the string on which it operates E<mdash> into a list of words, which here means
+strings separated by whitespace. It turns the single string C<'Beth Ana Charlie
+Dave'> into the list of strings C<'Beth', 'Ana', 'Charlie', 'Dave'>.
 
-Finally, this list gets stored in the L<Array|/type/Array> C<@names>.  The C<@> sigil marks
-the declared variable as an C<Array>.  Arrays store ordered lists.
+Finally, this list gets stored in the L<Array|/type/Array> C<@names>.
+The C<@> sigil marks the declared variable as an C<Array>.
+Arrays store ordered lists.
 
 =begin code
 my %matches;
@@ -152,14 +155,14 @@ my %sets;
 
 =head3 X<C<hash>>
 
-These two lines of code declare two hashes.  The C<%> sigil marks each variable
-as a C<Hash>.  A C<Hash> is an unordered collection of key-value pairs.  Other
-programming languages call that a I<hash table>, I<dictionary>, or I<map>.  You
-can query a hash table for the value that corresponds to a certain C<$key> with
-C<%hash{$key}>.
+These two lines of code declare two hashes. The C<%> sigil marks each variable
+as a C<Hash>. A C<Hash> is an unordered collection of key-value pairs. Other
+programming languages call that a I<hash table>, I<dictionary>, or I<map>.
+You can query a hash table for the value that corresponds to a certain
+C<$key> with C<%hash{$key}>.
 
 In the score counting program, C<%matches> stores the number of matches each
-player has won.  C<%sets> stores the number of sets each player has won. Both
+player has won. C<%sets> stores the number of sets each player has won. Both
 of these hashes are indexed by the player's name.
 
 =begin code :preamble<my $file>
@@ -172,9 +175,10 @@ for $file.lines -> $line {
 
 C<for> produces a loop that runs the I<block> delimited by curly braces
 once for each item of the list, setting the variable C<$line>
-to the current value of each iteration. C<$file.lines> produces a list of the
-lines read from the file C<scores.txt>, starting with the second line of the file
-since we already called C<$file.get> once, and going all the way to the end of the file.
+to the current value of each iteration. C<$file.lines> produces a list of
+the lines read from the file C<scores.txt>, starting with the second line
+of the file since we already called C<$file.get> once, and going all the way
+to the end of the file.
 
 During the first iteration, C<$line> will contain the string C<Ana Dave |
 3:0>; during the second, C<Charlie Beth | 3:1>, and so on.
@@ -187,15 +191,13 @@ C<my> can declare multiple variables simultaneously. The right-hand side of the
 assignment is a call to a method named C<split>, passing along the string
 C<' | '> as an argument.
 
-C<split> decomposes its invocant into a
-list of strings, so that joining the list items with the separator C<' | '>
-produces the original string.
+C<split> decomposes its invocant into a list of strings, so that joining the
+list items with the separator C<' | '> produces the original string.
 
-C<$pairing> gets the first item of the returned list, and
-C<$result> the second.
+C<$pairing> gets the first item of the returned list, and C<$result> the second.
 
 After processing the first line, C<$pairing> will hold the string C<Ana Dave>
-and C<$result> C<3:0>.
+and C<$result> will hold C<3:0>.
 
 The next two lines follow the same pattern:
 
@@ -205,11 +207,10 @@ my ($r1, $r2) = $result.split(':');
 =end code
 
 The first extracts and stores the names of the two players in the variables
-C<$p1> and C<$p2>.  The second extracts the results for each player and stores
+C<$p1> and C<$p2>. The second extracts the results for each player and stores
 them in C<$r1> and C<$r2>.
 
 After processing the first line of the file, the variables contain the values:
-cell C<'0'>
 =begin table
     Variable    Contents
     $line       'Ana Dave \| 3:0'
@@ -238,7 +239,7 @@ The C<+=> assignment operator is a shortcut for:
 
 =head3 X<C<Any>| Any (Basics)> and X<C<+=>>
 
-C<+= $r1> means I<increase the value in the variable on the left by $r1>.  In
+C<+= $r1> means I<increase the value in the variable on the left by $r1>. In
 the first iteration C<%sets{$p1}> is not yet set, so it defaults to a special
 value called C<Any>. The addition and incrementing operators treat C<Any> as a
 number with the value of zero; the strings get automatically converted to
@@ -246,11 +247,12 @@ numbers, as addition is a numeric operation.
 
 =head3 X<C<fat arrow>>,  X<C<pair>> and X<C<autovivification>>
 
-Before these two lines execute, C<%sets> is empty. Adding to an entry that is not in
-the hash yet will cause that entry to spring into existence just-in-time, with a
-value starting at zero. (This is I<autovivification>). After these two lines
-have run for the first time, C<%sets> contains C<< 'Ana' => 3, 'Dave' => 0 >>.
-(The fat arrow C<< => >> separates key and value in a C<Pair>.)
+Before these two lines execute, C<%sets> is empty. Adding to an entry that is
+not in the hash yet will cause that entry to spring into existence
+just-in-time, with a value starting at zero. (This is I<autovivification>).
+After these two lines have run for the first time, C<%sets> contains C<< 'Ana'
+=> 3, 'Dave' => 0 >>. (The fat arrow C<< => >> separates the key and the value
+in a C<Pair>.)
 
 =begin code :preamble<my $r1;my $r2;my $p1;my $p2;my %matches;>
 if $r1 > $r2 {
@@ -280,17 +282,17 @@ my @sorted = @names.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;
 =head3 X<C<variables, $_>>
 
 This line consists of three individually simple steps. An array's C<sort>
-method returns a sorted version of the array's contents.  However, the default
-sort on an array sorts by its contents.  To print player names in winner-first
+method returns a sorted version of the array's contents. However, the default
+sort on an array sorts by its contents. To print player names in winner-first
 order, the code must sort the array by the I<scores> of the players, not their
-names.  The C<sort> method's argument is a I<block> used to transform the array
-elements (the names of players) to the data by which to sort.  The array items
+names. The C<sort> method's argument is a I<block> used to transform the array
+elements (the names of players) to the data by which to sort. The array items
 are passed in through the I<topic variable> C<$_>.
 
 =head3 X<C<block>|block (Basics)>
 
 You have seen blocks before: both the C<for> loop C<< -> $line { ... } >> and
-the C<if> statement worked on blocks.  A block is a self-contained piece of
+the C<if> statement worked on blocks. A block is a self-contained piece of
 Perl 6 code with an optional signature (the C<< -> $line >> part).
 
 The simplest way to sort the players by score would be C<@names.sort({
@@ -302,34 +304,44 @@ tournament.
 =head3 X<C<stable sort>>
 
 When two array items have the same value, C<sort> leaves them in the same order
-as it found them.  Computer scientists call this a I<stable sort>. The program
+as it found them. Computer scientists call this a I<stable sort>. The program
 takes advantage of this property of Perl 6's C<sort> to achieve the goal by
 sorting twice: first by the number of sets won (the secondary criterion), then
 by the number of matches won.
 
 After the first sorting step, the names are in the order C<Beth Charlie Dave
-Ana>.  After the second sorting step, it's still the same, because no one has
+Ana>. After the second sorting step, it's still the same, because no one has
 won fewer matches but more sets than someone else. Such a situation is entirely
 possible, especially at larger tournaments.
 
-C<sort> sorts in ascending order, from smallest to largest.  This is the
+C<sort> sorts in ascending order, from smallest to largest. This is the
 opposite of the desired order. Therefore, the code calls the C<.reverse> method
 on the result of the second sort, and stores the final list in C<@sorted>.
 
 =begin code :preamble<my @sorted;my %matches;my %sets>
 for @sorted -> $n {
-    say "$n has won %matches{$n} matches and %sets{$n} sets";
+    my $match-noun = %matches{$n} == 1 ?? 'match' !! 'matches';
+    my $set-noun   = %sets{$n} == 1 ?? 'set' !! 'sets';
+    say "$n has won %matches{$n} $match-noun and %sets{$n} $set-noun";
 }
 =end code
 
 =head3 X<C<say>| say (Basics)>, X<C<print>| say (Basics)> and X<C<put>|put (Basics)>
 
 To print out the players and their scores, the code loops over C<@sorted>,
-setting C<$n> to the name of each player in turn.  Read this code as "For each
+setting C<$n> to the name of each player in turn. Read this code as "For each
 element of sorted, set C<$n> to the element, then execute the contents of the
-following block."  C<say> prints its arguments to the standard output (the
-screen, normally), followed by a newline.  (Use C<print> if you don't want the
-newline at the end.)
+following block." The variable C<$match-noun> will store either the string
+I<match> if the player has won a single match or I<matches> if the player
+has won zero or more matches. In order to do this, the I<ternary>
+operator (C<?? !!>) is used. If C<%matches{$n} == 1> evaluates to C<True>,
+then I<match> is returned. Otherwise, I<matches> is returned. Either way,
+the returned value is stored in C<$match-noun>. The same approach applies
+to <$set-noun>.
+
+The statement C<say> prints its arguments to the standard output
+(the screen, normally), followed by a newline. (Use C<print> if you don't
+want the newline at the end.)
 
 Note that C<say> will truncate certain data structures by calling the C<.gist>
 method so C<put> is safer if you want exact output.
@@ -337,11 +349,11 @@ method so C<put> is safer if you want exact output.
 =head3 X<C<interpolation>>
 
 When you run the program, you'll see that C<say> doesn't print the contents of
-that string verbatim.  In place of C<$n> it prints the contents of the variable
-C<$n>-- the names of players stored in C<$n>.  This automatic substitution of
-code with its contents is I<interpolation>. This interpolation happens only in
-strings delimited by double quotes C<"...">. Single quoted strings C<'...'> do
-not interpolate:
+that string verbatim. In place of C<$n> it prints the contents of the variable
+C<$n> E<mdash> the names of players stored in C<$n>. This automatic substitution
+of code with its contents is I<interpolation>. This interpolation happens only
+in strings delimited by double quotes C<"...">. Single quoted strings C<'...'>
+do not interpolate:
 
 =head3 X<C<double-quoted strings>> and X<C<single-quoted strings>>
 
@@ -358,22 +370,28 @@ interpolated by placing them within curly braces.
 
 Arrays within curly braces are interpolated with a single space character
 between each item. Hashes within curly braces are interpolated as a series of
-lines. Each line will contain a key, followed by a tab character, then the value
-associated with that key, and finally a newline.
+lines. Each line will contain a key, followed by a tab character, then the
+value associated with that key, and finally a newline.
 
 Let's see an example of this now.
 
 In this example, you will see some special syntax that makes it easier
-to make a list of strings. This is the C<< <...> >> L<quote-words|/language/operators#index-entry-qw-quote-words-quote-words> construct.
-When you put words in between the < and > they are all assumed to be strings,
-so you do not need to wrap them each in double quotes C<< "..." >>.
+to make a list of strings. This is the
+C«<...>» L<quote-words|/language/operators#index-entry-qw-quote-words-quote-words>
+construct. When you put words in between the < and > they are all assumed
+to be strings, so you do not need to wrap them each in double quotes
+C«"..."».
 
 =begin code :preamble<my %sets>
-say "Math: { 1 + 2 }";                  # OUTPUT: «Math: 3␤»
-my @people = <Luke Matthew Mark>;
-say "The synoptics are: {@people}";     # OUTPUT: «The synoptics are: Luke Matthew Mark␤»
+say "Math: { 1 + 2 }";
+# OUTPUT: «Math: 3␤»
 
-say "{%sets}␤";                         # From the table tennis tournament
+my @people = <Luke Matthew Mark>;
+say "The synoptics are: {@people}";
+# OUTPUT: «The synoptics are: Luke Matthew Mark␤»
+
+say "{%sets}␤";
+# OUTPUT (From the table tennis tournament):
 
 # Charlie 4
 # Dave    6
@@ -381,10 +399,9 @@ say "{%sets}␤";                         # From the table tennis tournament
 # Beth    4
 =end code
 
-
 When array and hash variables appear directly in a double-quoted string (and
 not inside curly braces), they are only interpolated if their name is
-followed by a postcircumfix -- a bracketing pair that follows a
+followed by a postcircumfix E<mdash> a bracketing pair that follows a
 statement. It's also ok to have a method call between the variable name and
 the postcircumfix.
 
@@ -403,7 +420,7 @@ say "we have @flavors.sort()";    # OUTPUT: «we have peach vanilla␤»
 
 # chained method calls:
 say "we have @flavors.sort.join(', ')";
-                                # OUTPUT: «we have peach, vanilla␤»
+                                  # OUTPUT: «we have peach, vanilla␤»
 =end code
 
 
@@ -429,15 +446,16 @@ my @sorted = @names.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;
 my @sorted = %sets.keys.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;
 =end code
 
-B<2.> Instead of deleting the redundant C<@names> variable, you can also use it to warn if a
-player appears that wasn't mentioned in the first line, for example due to a
-typo. How would you modify your program to achieve that?
+B<2.> Instead of deleting the redundant C<@names> variable, you can also use it
+to warn if a player appears that wasn't mentioned in the first line, for
+example due to a typo. How would you modify your program to achieve that?
 
 Hint: Try using L<membership operators|/language/operators#infix_(elem),_infix_∈>.
 
-B<Answer:> Change C<@names> to C<@valid-players>. When looping through the lines of
-the file, check to see that C<$p1> and C<$p2> are in C<@valid-players>. Note that
-for membership operators you can also use C<(elem)> and C<!(elem)>.
+B<Answer:> Change C<@names> to C<@valid-players>. When looping through the
+lines of the file, check to see that C<$p1> and C<$p2> are in
+C<@valid-players>. Note that for membership operators you can also use C<(elem)>
+and C<!(elem)>.
 
 =begin code :preamble<my $file>
 ...;

--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -37,11 +37,15 @@ In the two classes, the default constructor is being used. This
 constructor will use named parameters in its invocation: C«Point.new(x =>
 0, y => 0)».
 
-You can also provide your own construction and C<BUILD> implementation. You need
-to do it in the case there are private attributes, like below:
+You can also provide your own constructor and C<BUILD> implementation.
+You need to do it for cases in which there are private attributes that
+might need to be populated during object construction, as in the
+example below:
 
 =begin code
-class Hero { #taken from https://medium.freecodecamp.org/a-short-overview-of-object-oriented-software-design-c7aa0a622c83
+# Example taken from
+# https://medium.freecodecamp.org/a-short-overview-of-object-oriented-software-design-c7aa0a622c83
+class Hero {
     has @!inventory;
     has Str $.name;
     submethod BUILD( :$name, :@inventory ) {
@@ -108,18 +112,18 @@ my $eat =
 $eat.perform();
 =end code
 
-In this case, C<BUILD> is needed since we have overridden the default new.
-C<bless> is eventually invoking it with the two named arguments that correspond
-to the two properties without a default value. With its signature, C<BUILD>
-converts the two positionals to the two attributes, C<&!callback> and
-C<@!dependencies>, and returns the object (or turns it in to the next phase,
-C<TWEAK>, if available).
+In this case, C<BUILD> is needed since we have overridden the default
+C<new> constructor. C<bless> is eventually invoking it with the two named
+arguments that correspond to the two properties without a default value. With
+its signature, C<BUILD> converts the two positionals to the two attributes,
+C<&!callback> and C<@!dependencies>, and returns the object (or turns it in to
+the next phase, C<TWEAK>, if available).
 
-Declaring C<new> as a C<method> and not a C<multi method> prevents us
+Declaring C<new> as a C<method> and not as a C<multi method> prevents us
 from using the default constructor; this implicit constructor uses the
-attributes as named parameters. That is one of the reasons why using
-C<new> is discouraged. If you need to declare it anyway, use C<multi
-method new> if you do not want to disable the default constructors.
+attributes as named parameters. This is one of the reasons why using
+C<new> as a method's name is discouraged. If you need to declare it anyway,
+use C<multi method new> if you do not want to disable the default constructor.
 
 C<TWEAK> is the last submethod to be called, and it has the
 advantage of having the object properties available without needing to
@@ -161,14 +165,12 @@ or supplies or delete temporary files that are no longer going to be used.
 =begin code
 my $in_destructor = 0;
 
-class Foo
-{
+class Foo {
     submethod DESTROY { $in_destructor++ }
 }
 
 my $foo;
-for 1 .. 6000
-{
+for 1 .. 6000 {
     $foo = Foo.new();
 }
 
@@ -191,9 +193,9 @@ X<|behavior>
 X<|classes,behavior>
 
 Perl 6, like many other languages, uses the C<class> keyword to define a
-class.  The block that follows may contain arbitrary code, just as with
+class. The block that follows may contain arbitrary code, just as with
 any other block, but classes commonly contain state and behavior
-declarations.  The example code includes attributes (state), introduced
+declarations. The example code includes attributes (state), introduced
 through the C<has> keyword, and behaviors, introduced through the C<method>
 keyword.
 
@@ -209,22 +211,26 @@ classes. The example above uses the class name C<Task> so that other code can
 refer to it later, such as to create class instances by calling the C<new>
 method.
 
-You can use C<.DEFINITE> method to find out if what you have is an instance
+You can use the C<.DEFINITE> method to find out if what you have is an instance
 or a type object:
 
-    say Int.DEFINITE; # OUTPUT: «False␤» (type object)
-    say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
+=begin code
+say Int.DEFINITE; # OUTPUT: «False␤» (type object)
+say 426.DEFINITE; # OUTPUT: «True␤»  (instance)
 
-    class Foo {};
-    say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
-    say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
+class Foo {};
+say Foo.DEFINITE;     # OUTPUT: «False␤» (type object)
+say Foo.new.DEFINITE; # OUTPUT: «True␤»  (instance)
+=end code
 
 You can also use type "smileys" to only accept instances or type objects:
 
-    multi foo (Int:U) { "It's a type object!" }
-    multi foo (Int:D) { "It's an instance!"   }
-    say foo Int; # OUTPUT: «It's a type object!␤»
-    say foo 42;  # OUTPUT: «It's an instance!␤»
+=begin code
+multi foo (Int:U) { "It's a type object!" }
+multi foo (Int:D) { "It's an instance!"   }
+say foo Int; # OUTPUT: «It's a type object!␤»
+say foo 42;  # OUTPUT: «It's an instance!␤»
+=end code
 
 X<|attributes>
 X<|classes,attributes>
@@ -232,14 +238,15 @@ X<|encapsulation>
 X<|classes,encapsulation>
 =head1 State
 
-The first three lines inside the class block all declare attributes (called
-I<fields> or I<instance storage> in other languages). Just as a C<my>
-variable cannot be accessed from outside its declared scope, attributes are
-not accessible outside of the class.  This I<encapsulation> is one of the
-key principles of object oriented design.
+In the C<Task> class, the first three lines inside the block all
+declare attributes (called I<fields> or I<instance storage> in other
+languages). Just as a C<my> variable cannot be accessed from outside its
+declared scope, attributes are not accessible outside of the class.
+This I<encapsulation> is one of the key principles of object oriented design.
 
-The first declaration specifies instance storage for a callback--a bit of
-code to invoke in order to perform the task that an object represents:
+The first declaration specifies instance storage for a callback (i.e.,
+a bit of code to invoke in order to perform the task that an object
+represents):
 
 =for code
 has &!callback;
@@ -249,18 +256,18 @@ X<|twigils>
 X<|twigils,!>
 
 The C<&> sigil indicates that this attribute represents something invocable.
-The C<!> character is a I<twigil>, or secondary sigil.  A twigil forms part
-of the name of the variable.  In this case, the C<!> twigil emphasizes that
+The C<!> character is a I<twigil>, or secondary sigil. A twigil forms part
+of the name of the variable. In this case, the C<!> twigil emphasizes that
 this attribute is private to the class.
 
 The second declaration also uses the private twigil:
 
-    =for code :preamble<class Task {}>
-    has Task @!dependencies;
+=for code :preamble<class Task {}>
+has Task @!dependencies;
 
 However, this attribute represents an array of items, so it requires the
 C<@> sigil. These items each specify a task that must be completed before
-the present one can complete. Furthermore, the type declaration on this
+the present one is completed. Furthermore, the type declaration on this
 attribute indicates that the array may only hold instances of the C<Task>
 class (or some subclass of it).
 
@@ -274,20 +281,24 @@ X<|twigils,accessors>
 X<|accessor methods>
 X<|classes,accessors>
 
-This scalar attribute (with the C<$> sigil) has a type of C<Bool>.  Instead
+This scalar attribute (with the C<$> sigil) has a type of C<Bool>. Instead
 of the C<!> twigil, the C<.> twigil is used. While Perl 6 does enforce
 encapsulation on attributes, it also saves you from writing accessor
-methods.  Replacing the C<!> with a C<.> both declares the attribute
-C<$!done> and an accessor method named C<done>. It's as if you had written:
+methods. Replacing the C<!> with a C<.> both declares a private attribute
+and an accessor method named after the attribute. In this case,
+both the attribute C<$!done> and the accessor method C<done> are declared.
+It's as if you had written:
 
-    has Bool $!done;
-    method done() { return $!done }
+=begin code
+has Bool $!done;
+method done() { return $!done }
+=end code
 
 Note that this is not like declaring a public attribute, as some languages
 allow; you really get I<both> a private attribute and a method,
 without having to write the method by hand. You are free instead to write
 your own accessor method, if at some future point you need to do something
-more complex than return the value.
+more complex than returning the value.
 
 X<|traits,is rw>
 Note that using the C<.> twigil has created a method that will provide
@@ -295,30 +306,34 @@ read-only access to the attribute. If instead the users of this object
 should be able to reset a task's completion state (perhaps to perform it
 again), you can change the attribute declaration:
 
-    has Bool $.done is rw;
+=for code
+has Bool $.done is rw;
 
 The C<is rw> trait causes the generated accessor method to return a container
-external code can modify to change the value of the attribute.
+so external code can modify the value of the attribute.
 
 You can also supply default values to attributes (which works equally for
 those with and without accessors):
 
-    has Bool $.done = False;
+=for code
+has Bool $.done = False;
 
 The assignment is carried out at object build time. The right-hand side is
 evaluated at that time, and can even reference earlier attributes:
 
-    =for code :preamble<class Task {}>
-    has Task @!dependencies;
-    has $.ready = not @!dependencies;
+=begin code :preamble<class Task {}>
+has Task @!dependencies;
+has $.ready = not @!dependencies;
+=end code
 
 Writable attributes are accessible through writable containers:
 
-=for code
+=begin code
 class a-class {
     has $.an-attribute is rw;
 }
 say (a-class.new.an-attribute = "hey"); # OUTPUT: «hey␤»
+=end code
 
 This attribute can also be accessed using the C<.an-attribute> or
 C<.an-attribute()> syntax. See also
@@ -326,9 +341,9 @@ L<the C<is rw> trait on classes|/language/typesystem#trait_is_rw> for examples
 on how this works on the whole class.
 
 X<|class variables>
-A class declaration can also include I<class variables>,
-which are variables whose value is shared by all instances, and can be used for
-things like counting the number of instantiations or any other shared state.
+A class declaration can also include I<class variables>, which are variables
+whose value is shared by all instances, and can be used for things like
+counting the number of instantiations or any other shared state.
 Class variables use the same syntax as the rest of the attributes, but are
 declared as C<my> or C<our>, depending on the scope; C<our> variables will be
 shared by subclasses, since they have package scope.
@@ -362,13 +377,14 @@ In this case, using C<new> might be the easiest way to initialize the C<$.ID>
 field and increment the value of the counter at the same time. C<new>, through
 C<bless>, will invoke the default C<BUILD>, assigning the values to their
 properties correctly. You can obtain the same effect using C<TWEAK>, which is
-considered a more I<p6y> way. Please check L<the section on
+considered a more I<p6y> way of achieving such effect. Please check L<the section on
 submethods|/language/classtut#index-entry-OOP> for an alternative example on how
 to do this. Since C<TWEAK> is called in every object instantiation, it's
 incremented twice when creating objects of class C<Str-with-ID-and-tag>; this is
 a I<class hierarchy> variable that is shared by all subclasses of
 C<Str-with-ID>. Additionally, class variables declared with package scope are
-visible via their FQN, while lexically scoped class variables are "private".
+visible via their fully qualified name (FQN), while lexically scoped class
+variables are "private".
 
 =head1 Static fields?
 
@@ -395,12 +411,12 @@ importing the class using the L<use|/syntax/use> keyword.
 
 =begin code :preamble<class Foo {}; sub some_complicated_subroutine {}>
 class HaveStaticAttr {
-      my Foo $.foo = some_complicated_subroutine;
+    my Foo $.foo = some_complicated_subroutine;
 }
 =end code
 
 Class attributes may also be declared with a secondary sigil – in a similar
-manner to object attributes – that will generate read-only accessors if the
+manner to instance attributes – that will generate read-only accessors if the
 attribute is to be public.
 
 =head1 Methods
@@ -408,16 +424,16 @@ attribute is to be public.
 X<|methods>
 X<|classes,methods>
 
-While attributes give objects state, methods give objects behaviors.  Let's
+While attributes give objects state, methods give objects behaviors. Let's
 ignore the C<new> method temporarily; it's a special type of method.
 Consider the second method, C<add-dependency>, which adds a new task to a
-task's dependency list.
+task's dependency list:
 
-    =begin code :skip-test<incomplete code>
-    method add-dependency(Task $dependency) {
-        push @!dependencies, $dependency;
-    }
-    =end code
+=begin code :skip-test<incomplete code>
+method add-dependency(Task $dependency) {
+    push @!dependencies, $dependency;
+}
+=end code
 
 X<|invocant>
 In many ways, this looks a lot like a C<sub> declaration. However, there are
@@ -432,68 +448,72 @@ attribute.
 
 The C<perform> method contains the main logic of the dependency handler:
 
-    =begin code :skip-test<incomplete code>
-    method perform() {
-        unless $!done {
-            .perform() for @!dependencies;
-            &!callback();
-            $!done = True;
-        }
+=begin code :skip-test<incomplete code>
+method perform() {
+    unless $!done {
+        .perform() for @!dependencies;
+        &!callback();
+        $!done = True;
     }
-    =end code
+}
+=end code
 
 It takes no parameters, working instead with the object's attributes. First,
 it checks if the task has already completed by checking the C<$!done>
-attribute.  If so, there's nothing to do.
+attribute. If so, there's nothing to do.
 
 X<|operators,.>
 Otherwise, the method performs all of the task's dependencies, using the
 C<for> construct to iterate over all of the items in the C<@!dependencies>
-attribute.  This iteration places each item – each a C<Task> object – into
-the topic variable, C<$_>.  Using the C<.> method call operator without
+attribute. This iteration places each item – each a C<Task> object – into
+the topic variable, C<$_>. Using the C<.> method call operator without
 specifying an explicit invocant uses the current topic as the invocant.
 Thus the iteration construct calls the C<.perform()> method on every C<Task>
 object in the C<@!dependencies> attribute of the current invocant.
 
 After all of the dependencies have completed, it's time to perform the
 current C<Task>'s task by invoking the C<&!callback> attribute directly;
-this is the purpose of the parentheses.  Finally, the method sets the
+this is the purpose of the parentheses. Finally, the method sets the
 C<$!done> attribute to C<True>, so that subsequent invocations of C<perform>
 on this object (if this C<Task> is a dependency of another C<Task>, for
 example) will not repeat the task.
 
 X<|! (private methods)>
+X<|FQN>
 =head2 Private methods
 
 Just like attributes, methods can also be private. Private methods are declared
-with a prefixed exclamation mark. They are called with C<self!> followed by the
-method's name. To call a private method of another class the calling class has
-to be trusted by the called class. A trust relationship is declared with
-C<trusts> and the class to be trusted must already be declared. Calling a
-private method of another class requires an instance of that class and the fully
-qualified name of the method.  Trust also allows access to private attributes.
+with a prefixed exclamation mark. They are called with C<self!>
+followed by the method's name. To call a private method of another class the
+calling class has to be trusted by the called class. A trust relationship is
+declared with C<trusts> and the class to be trusted must already be declared.
+Calling a private method of another class requires an instance of that class
+and the fully qualified name (FQN) of the method. Trust also allows access to
+private attributes.
 
-    class B {...}
+=begin code
+class B {...}
 
-    class C {
-        trusts B;
-        has $!hidden = 'invisible';
-        method !not-yours () { say 'hidden' }
-        method yours-to-use () {
-            say $!hidden;
-            self!not-yours();
-        }
+class C {
+    trusts B;
+    has $!hidden = 'invisible';
+    method !not-yours () { say 'hidden' }
+    method yours-to-use () {
+        say $!hidden;
+        self!not-yours();
     }
+}
 
-    class B {
-        method i-am-trusted () {
-            my C $c.=new;
-            $c!C::not-yours();
-        }
+class B {
+    method i-am-trusted () {
+        my C $c.=new;
+        $c!C::not-yours();
     }
+}
 
-    C.new.yours-to-use(); # the context of this call is GLOBAL, and not trusted by C
-    B.new.i-am-trusted();
+C.new.yours-to-use(); # the context of this call is GLOBAL, and not trusted by C
+B.new.i-am-trusted();
+=end code
 
 Trust relationships are not subject to inheritance. To trust the global
 namespace, the pseudo package C<GLOBAL> can be used.
@@ -502,29 +522,32 @@ X<|constructors>
 =head1 Constructors
 
 Perl 6 is rather more liberal than many languages in the area of
-constructors.  A constructor is anything that returns an instance of the
-class.  Furthermore, constructors are ordinary methods. You inherit a
+constructors. A constructor is anything that returns an instance of the
+class. Furthermore, constructors are ordinary methods. You inherit a
 default constructor named C<new> from the base class C<Mu>, but you are
 free to override C<new>, as this example does:
 
-    method new(&callback, *@dependencies) {
-        return self.bless(:&callback, :@dependencies);
-    }
+=begin code
+method new(&callback, *@dependencies) {
+    return self.bless(:&callback, :@dependencies);
+}
+=end code
 
 X<|objects,bless>
 X<|bless>
 
 The biggest difference between constructors in Perl 6 and constructors in
 languages such as C# and Java is that rather than setting up state on a
-somehow already magically created object, Perl 6 constructors
-create the object themselves. The easiest way to do this is by calling the
-L<bless|/routine/bless> method, also inherited from L<Mu|/type/Mu>. The C<bless> method expects a
-set of named parameters to provide the initial values for each attribute.
+somehow already magically created object, Perl 6 constructors create the
+object themselves. The easiest way to do this is by calling the
+L<bless|/routine/bless> method, also inherited from L<Mu|/type/Mu>.
+The C<bless> method expects a set of named parameters to provide the initial
+values for each attribute.
 
 The example's constructor turns positional arguments into named arguments,
 so that the class can provide a nice constructor for its users. The first
 parameter is the callback (the thing which will execute the task). The rest
-of the parameters are dependent C<Task> instances.  The constructor captures
+of the parameters are dependent C<Task> instances. The constructor captures
 these into the C<@dependencies> slurpy array and passes them as named
 parameters to C<bless> (note that C<:&callback> uses the name of the
 variable – minus the sigil – as the name of the parameter).
@@ -546,8 +569,8 @@ as the bind targets for C<BUILD>'s parameters. Zero-boilerplate
 initialization! See L<objects|/language/objects#Object_construction> for
 more information.
 
-The C<BUILD> method is responsible for initializing all attributes and must also
-handle default values:
+The C<BUILD> method is responsible for initializing all attributes and must
+also handle default values:
 
 =begin code
 has &!callback;
@@ -566,7 +589,7 @@ options to influence object construction and attribute initialization.
 
 =head1 Consuming our class
 
-After creating a class, you can create instances of the class.  Declaring a
+After creating a class, you can create instances of the class. Declaring a
 custom constructor provides a simple way of declaring tasks along with their
 dependencies. To create a single task with no dependencies, write:
 
@@ -574,29 +597,29 @@ dependencies. To create a single task with no dependencies, write:
 my $eat = Task.new({ say 'eating dinner. NOM!' });
 
 An earlier section explained that declaring the class C<Task> installed a
-type object in the namespace.  This type object is a kind of "empty
-instance" of the class, specifically an instance without any state.  You can
+type object in the namespace. This type object is a kind of "empty
+instance" of the class, specifically an instance without any state. You can
 call methods on that instance, as long as they do not try to access any
 state; C<new> is an example, as it creates a new object rather than
 modifying or accessing an existing object.
 
-Unfortunately, dinner never magically happens.  It has dependent tasks:
+Unfortunately, dinner never magically happens. It has dependent tasks:
 
-    =begin code :preamble<class Task {}>
-    my $eat =
-        Task.new({ say 'eating dinner. NOM!' },
-            Task.new({ say 'making dinner' },
-                Task.new({ say 'buying food' },
-                    Task.new({ say 'making some money' }),
-                    Task.new({ say 'going to the store' })
-                ),
-                Task.new({ say 'cleaning kitchen' })
-            )
-        );
-    =end code
+=begin code :preamble<class Task {}>
+my $eat =
+    Task.new({ say 'eating dinner. NOM!' },
+        Task.new({ say 'making dinner' },
+            Task.new({ say 'buying food' },
+                Task.new({ say 'making some money' }),
+                Task.new({ say 'going to the store' })
+            ),
+            Task.new({ say 'cleaning kitchen' })
+        )
+    );
+=end code
 
-Notice how the custom constructor and sensible use of whitespace makes task
-dependencies clear.
+Notice how the custom constructor and the sensible use of whitespace makes
+task dependencies clear.
 
 Finally, the C<perform> method call recursively calls the C<perform> method
 on the various other dependencies in order, giving the output:
@@ -615,123 +638,127 @@ eating dinner. NOM!
 X<|classes, inheritance>
 
 Object Oriented Programming provides the concept of inheritance as one of
-the mechanisms for code reuse.  Perl 6 supports the ability for one
-class to inherit from one or more classes.  When a class inherits from
+the mechanisms for code reuse. Perl 6 supports the ability for one
+class to inherit from one or more classes. When a class inherits from
 another class it informs the method dispatcher to follow the inheritance
-chain to look for a method to dispatch.  This happens both for standard
-methods defined via the method keyword and for methods generated through
+chain to look for a method to dispatch. This happens both for standard
+methods defined via the C<method> keyword and for methods generated through
 other means, such as attribute accessors.
 
-    =begin code
-    class Employee {
-        has $.salary;
-    }
+=begin code
+class Employee {
+    has $.salary;
+}
 
-    class Programmer is Employee {
-        has @.known_languages is rw;
-        has $.favorite_editor;
+class Programmer is Employee {
+    has @.known_languages is rw;
+    has $.favorite_editor;
 
-        method code_to_solve( $problem ) {
-            return "Solving $problem using $.favorite_editor in "
-            ~ $.known_languages[0];
-        }
+    method code_to_solve( $problem ) {
+        return "Solving $problem using $.favorite_editor in "
+        ~ $.known_languages[0];
     }
-    =end code
+}
+=end code
 
 Now, any object of type Programmer can make use of the methods and accessors
 defined in the Employee class as though they were from the Programmer class.
 
-    =begin code :preamble<class Programmer {}>
-    my $programmer = Programmer.new(
-        salary => 100_000,
-        known_languages => <Perl5 Perl6 Erlang C++>,
-        favorite_editor => 'vim'
-    );
+=begin code :preamble<class Programmer {}>
+my $programmer = Programmer.new(
+    salary => 100_000,
+    known_languages => <Perl5 Perl6 Erlang C++>,
+    favorite_editor => 'vim'
+);
 
-    say $programmer.code_to_solve('halting problem'), " will get ", $programmer.salary(), "\$";
-    #OUTPUT: «Solving halting problem using vim in Perl5 will get 100000$␤»
-    =end code
+say $programmer.code_to_solve('halting problem'),
+    " will get \$ {$programmer.salary()}";
+# OUTPUT: «Solving halting problem using vim in Perl5 will get $100000␤»
+=end code
 
 =head2 Overriding inherited methods
 
 Of course, classes can override methods and attributes defined by parent
-classes by defining their own.  The example below demonstrates the C<Baker>
+classes by defining their own. The example below demonstrates the C<Baker>
 class overriding the C<Cook>'s C<cook> method.
 
-    =begin code :preamble<class Employee {}>
-    class Cook is Employee {
-        has @.utensils  is rw;
-        has @.cookbooks is rw;
+=begin code :preamble<class Employee {}>
+class Cook is Employee {
+    has @.utensils  is rw;
+    has @.cookbooks is rw;
 
-        method cook( $food ) {
-            say "Cooking $food";
-        }
-
-        method clean_utensils {
-            say "Cleaning $_" for @.utensils;
-        }
+    method cook( $food ) {
+        say "Cooking $food";
     }
 
-    class Baker is Cook {
-        method cook( $confection ) {
-            say "Baking a tasty $confection";
-        }
+    method clean_utensils {
+        say "Cleaning $_" for @.utensils;
     }
+}
 
-    my $cook = Cook.new(
-        utensils => <spoon ladle knife pan>,
-        cookbooks => 'The Joy of Cooking',
-        salary => 40000);
+class Baker is Cook {
+    method cook( $confection ) {
+        say "Baking a tasty $confection";
+    }
+}
 
-    $cook.cook( 'pizza' );       # OUTPUT: «Cooking pizza␤»
-    say $cook.utensils.perl;     # OUTPUT: «["spoon", "ladle", "knife", "pan"]␤»
-    say $cook.cookbooks.perl;    # OUTPUT: «["The Joy of Cooking"]␤»
-    say $cook.salary;            # OUTPUT: «40000␤»
+my $cook = Cook.new(
+    utensils  => <spoon ladle knife pan>,
+    cookbooks => 'The Joy of Cooking',
+    salary    => 40000
+);
 
-    my $baker = Baker.new(
-        utensils => 'self cleaning oven',
-        cookbooks => "The Baker's Apprentice",
-        salary => 50000);
+$cook.cook( 'pizza' );       # OUTPUT: «Cooking pizza␤»
+say $cook.utensils.perl;     # OUTPUT: «["spoon", "ladle", "knife", "pan"]␤»
+say $cook.cookbooks.perl;    # OUTPUT: «["The Joy of Cooking"]␤»
+say $cook.salary;            # OUTPUT: «40000␤»
 
-    $baker.cook('brioche');      # OUTPUT: «Baking a tasty brioche␤»
-    say $baker.utensils.perl;    # OUTPUT: «["self cleaning oven"]␤»
-    say $baker.cookbooks.perl;   # OUTPUT: «["The Baker's Apprentice"]␤»
-    say $baker.salary;           # OUTPUT: «50000␤»
-    =end code
+my $baker = Baker.new(
+    utensils  => 'self cleaning oven',
+    cookbooks => "The Baker's Apprentice",
+    salary    => 50000
+);
+
+$baker.cook('brioche');      # OUTPUT: «Baking a tasty brioche␤»
+say $baker.utensils.perl;    # OUTPUT: «["self cleaning oven"]␤»
+say $baker.cookbooks.perl;   # OUTPUT: «["The Baker's Apprentice"]␤»
+say $baker.salary;           # OUTPUT: «50000␤»
+=end code
 
 Because the dispatcher will see the C<cook> method on C<Baker> before it
 moves up to the parent class the C<Baker>'s C<cook> method will be called.
 
-To access methods in the inheritance chain use
+To access methods in the inheritance chain, use
 L<re-dispatch|/language/functions#Re-dispatching> or the
 L<MOP|/type/Metamodel::ClassHOW#method_can>.
 
 =head2 Multiple inheritance
 
-As mentioned before, a class can inherit from multiple classes.  When a
+As mentioned before, a class can inherit from multiple classes. When a
 class inherits from multiple classes the dispatcher knows to look at both
-classes when looking up a method to search for.  Perl 6 uses the L<C3 algorithm|https://en.wikipedia.org/wiki/C3_linearization> to linearize
+classes when looking up a method to search for. Perl 6 uses the
+L<C3 algorithm|https://en.wikipedia.org/wiki/C3_linearization> to linearize
 multiple inheritance hierarchies, which is better than depth-first search
 for handling multiple inheritance.
 
-    =begin code :preamble<class Programmer {}; class Cook {}>
-    class GeekCook is Programmer is Cook {
-        method new( *%params ) {
-            push( %params<cookbooks>, "Cooking for Geeks" );
-            return self.bless(|%params);
-        }
+=begin code :preamble<class Programmer {}; class Cook {}>
+class GeekCook is Programmer is Cook {
+    method new( *%params ) {
+        push( %params<cookbooks>, "Cooking for Geeks" );
+        return self.bless(|%params);
     }
+}
 
-    my $geek = GeekCook.new(
-        books           => 'Learning Perl 6',
-        utensils        => ('stainless steel pot', 'knife', 'calibrated oven'),
-        favorite_editor => 'MacVim',
-        known_languages => <Perl6>
-    );
+my $geek = GeekCook.new(
+    books           => 'Learning Perl 6',
+    utensils        => ('stainless steel pot', 'knife', 'calibrated oven'),
+    favorite_editor => 'MacVim',
+    known_languages => <Perl6>
+);
 
-    $geek.cook('pizza');
-    $geek.code_to_solve('P =? NP');
-    =end code
+$geek.cook('pizza');
+$geek.code_to_solve('P =? NP');
+=end code
 
 Now all the methods made available to the Programmer and the Cook classes
 are available from the GeekCook class.
@@ -741,7 +768,8 @@ it is important to understand that there are more useful OOP concepts.  When
 reaching for multiple inheritance it is good practice to consider whether
 the design wouldn't be better realized by using roles, which are generally
 safer because they force the class author to explicitly resolve conflicting
-method names.  For more information on roles see L<Roles|/language/objects#Roles>.
+method names. For more information on roles, see
+L<Roles|/language/objects#Roles>.
 
 =head2 The X<C<also>|also declarator> declarator
 
@@ -749,17 +777,21 @@ Classes to be inherited from can be listed in the class declaration body by
 prefixing the C<is> trait with C<also>. This also works for the role
 composition trait C<does>.
 
-    =begin code :preamble<class Programmer {}; class Cook {}>
-    class GeekCook {
-        also is Programmer;
-        also is Cook;
-        # ...
-    }
+=begin code :preamble<class Programmer {}; class Cook {}>
+class GeekCook {
+    also is Programmer;
+    also is Cook;
+    # ...
+}
 
-    role A {};
-    role B {};
-    class C { also does A; also does B }
-    =end code
+role A {};
+role B {};
+class C {
+    also does A;
+    also does B;
+    # ...
+}
+=end code
 
 =head1 Introspection
 
@@ -770,24 +802,27 @@ a controlling object) for some properties, such as its type.
 Given an object C<$o> and the class definitions from the previous sections,
 we can ask it a few questions:
 
-    =begin code :preamble<my $o; class Employee {}; class GeekCook {}>
-    if $o ~~ Employee { say "It's an employee" };
-    if $o ~~ GeekCook { say "It's a geeky cook" };
-    say $o.perl;
-    say $o.^methods(:local)».name.join(', ');
-    say $o.^name;
-    =end code
+=begin code :preamble<my $o; class Employee {}; class GeekCook {}>
+my Programmer $o .= new;
+if $o ~~ Employee { say "It's an employee" };
+say $o ~~ GeekCook ?? "It's a geeky cook" !! "Not a geeky cook";
+say $o.WHAT;
+say $o.perl;
+say $o.^methods(:local)».name.join(', ');
+say $o.^name;
+=end code
 
-The output can look like this:
+The output might look like this:
 
-    =begin code :lang<output>
-    It's an employee
-    (Programmer)
-    Programmer.new(known_languages => ["Perl", "Python", "Pascal"],
-            favorite_editor => "gvim", salary => "too small")
-    code_to_solve, known_languages, favorite_editor
-    Programmer
-    =end code
+=begin code :lang<output>
+It's an employee
+Not a geeky cook
+(Programmer)
+Programmer.new(known_languages => ["Perl", "Python", "Pascal"],
+        favorite_editor => "gvim", salary => "too small")
+code_to_solve, known_languages, favorite_editor
+Programmer
+=end code
 
 The first two tests each smartmatch against a class name. If the object is
 of that class, or of an inheriting class, it returns true. So the object in
@@ -800,7 +835,7 @@ C<$o>, which tells us the exact type of C<$o>: in this case C<Programmer>.
 C<$o.perl> returns a string that can be executed as Perl code, and
 reproduces the original object C<$o>. While this does not work perfectly in
 all cases, it is very useful for debugging simple objects.
-N<For example closures cannot easily be reproduced this way; if you
+N<For example, closures cannot easily be reproduced this way; if you
 don't know what a closure is don't worry. Also current implementations have
 problems with dumping cyclic data structures this way, but they are expected
 to be handled correctly by C<.perl> at some point.>
@@ -823,13 +858,13 @@ unsurprisingly returns the class name.
 
 Introspection is very useful for debugging and for learning the language
 and new libraries. When a function or method returns an object you don't
-know about, finding its type with C<.WHAT>, seeing a construction recipe for
-it with C<.perl>, and so on, you'll get a good idea of what its return value
-is. With C<.^methods> you can learn what you can do with the class.
+know about, by finding its type with C<.WHAT>, seeing a construction recipe
+for it with C<.perl>, and so on, you'll get a good idea of what its return
+value is. With C<.^methods>, you can learn what you can do with the class.
 
-But there are other applications too: a routine that serializes objects to a
-bunch of bytes needs to know the attributes of that object, which it can
-find out via introspection.
+But there are other applications too. For instance, a routine that serializes
+objects to a bunch of bytes needs to know the attributes of that object,
+which it can find out via introspection.
 
 =head2 X<Overriding default gist method>
 
@@ -837,7 +872,8 @@ Some classes might need its own version of C<gist>, which overrides the terse
 way it is printed when called to provide a default representation of the class.
 For instance, L<exceptions|/language/exceptions#Uncaught_exceptions> might want
 to write just the C<payload> and not the full object so that it is clearer what
-has happened. But you can do that with every class:
+to see what's happened. However, this isn't limited to exceptions; you can
+do that with every class:
 
 =begin code
 class Cook {

--- a/doc/Language/intro.pod6
+++ b/doc/Language/intro.pod6
@@ -13,10 +13,10 @@ For a quick hands-on introduction, there is a short
 L<C<annotated programming example>|/language/101-basics>.
 
 For programmers with experience in other languages, there are a number of
-B<Migration> guides that compare and contrast the features of Perl6 with other
+B<Migration> guides that compare and contrast the features of Perl 6 with other
 languages.
 
-A number of B<Tutorials> cover several areas in which Perl6 is particularly
+A number of B<Tutorials> cover several areas in which Perl 6 is particularly
 innovative. The section headers should help navigate the remaining documents.
 
 There are a number of L<C<useful resources>|https://perl6.org/resources> listed
@@ -40,7 +40,7 @@ L<C<Containers>|/language/containers> - variables, which are like the nouns of
 a computer language, are containers in which information is stored. The first
 letter in the formal name of a container, such as the '$' of $my-variable, or
 '@' of @an-array-of-things, or '%' of %the-scores-in-the-competition, conveys
-information about the container. However, Perl6 is more abstract than other
+information about the container. However, Perl 6 is more abstract than other
 languages about what can be stored in a container. So, for example, a $scalar
 container can contain an object that is in fact an array.
 =end item
@@ -53,14 +53,14 @@ programs can be written as if Perl 6 was purely procedural in nature. However,
 complex software, such as the Rakudo compiler of Perl 6, is made much simpler
 by writing in object-oriented idioms, which is why the Perl 6 documentation is
 more easily understood by reviewing what a class is and what a role is. Without
-understanding about Classes and Roles, it would be difficult to understand
-Types, to which a whole section of the documentation is devoted.
+understanding about classes and roles, it would be difficult to understand
+types, to which a whole section of the documentation is devoted.
 =end item
 
 =begin item
 L<C<Traps to Avoid>|/language/traps> - Several common assumptions lead to code
-that does not work as the programmer intended. This section identifies some. It
-is worth reviewing when something doesn't quite work out.
+that does not work as the programmer intended. This section identifies some
+of them. It is worth reviewing when something doesn't quite work out.
 =end item
 
 =end pod

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -133,13 +133,15 @@ if $type ~~ Real {
 Classes are declared using the C<class> keyword, typically followed by a
 name.
 
-    class Journey { }
+=for code
+class Journey { }
 
 This declaration results in a type object being created and installed in the
 current package and current lexical scope under the name C<Journey>. You
 can also declare classes lexically:
 
-    my class Journey { }
+=for code
+my class Journey { }
 
 This restricts their visibility to the current lexical scope, which can be
 useful if the class is an implementation detail nested inside a module or
@@ -151,38 +153,44 @@ X<|Attribute> X<|Property> X<|Member> X<|Slot>
 Attributes are variables that exist per instance of a class; when instantiated
 to a value, the association between the variable and its value is called a
 property. They are where the state of an object is stored. In Perl 6, all
-attributes are I<private>, that means they can be accessed directly only by
+attributes are I<private>, which means they can be accessed directly only by
 the class instance itself. They are typically declared using the C<has>
 declarator and the C<!> twigil.
 
-    class Journey {
-        has $!origin;
-        has $!destination;
-        has @!travelers;
-        has $!notes;
-    }
+=begin code
+class Journey {
+    has $!origin;
+    has $!destination;
+    has @!travelers;
+    has $!notes;
+}
+=end code
 
 While there is no such thing as a public (or even protected) attribute,
 there is a way to have accessor methods generated automatically: replace the
 C<!> twigil with the C<.> twigil (the C<.> should remind you of a method
 call).
 
-    class Journey {
-        has $.origin;
-        has $.destination;
-        has @!travelers;
-        has $.notes;
-    }
+=begin code
+class Journey {
+    has $.origin;
+    has $.destination;
+    has @!travelers;
+    has $.notes;
+}
+=end code
 
 This defaults to providing a read-only accessor. In order to allow changes
 to the attribute, add the L<is rw|/routine/is%20rw> trait:
 
-    class Journey {
-        has $.origin;
-        has $.destination;
-        has @!travelers;
-        has $.notes is rw;
-    }
+=begin code
+class Journey {
+    has $.origin;
+    has $.destination;
+    has @!travelers;
+    has $.notes is rw;
+}
+=end code
 
 Now, after a C<Journey> object is created, its C<.origin>, C<.destination>,
 and C<.notes> will all be accessible from outside the class, but only
@@ -193,33 +201,35 @@ destination, we may not get the desired result. To prevent this, provide
 default values or make sure that an attribute is set on object creation
 by marking an attribute with an L<is required|/routine/is%20required> trait.
 
-    class Journey {
-        # error if origin is not provided
-        has $.origin is required;
-        # set the destination to Orlando as default (unless that is the origin!)
-        has $.destination = self.origin eq 'Orlando' ?? 'Kampala' !! 'Orlando';
-        has @!travelers;
-        has $.notes is rw;
-    }
+=begin code
+class Journey {
+    # error if origin is not provided
+    has $.origin is required;
+    # set the destination to Orlando as default (unless that is the origin!)
+    has $.destination = self.origin eq 'Orlando' ?? 'Kampala' !! 'Orlando';
+    has @!travelers;
+    has $.notes is rw;
+}
+=end code
 
 Since classes inherit a default constructor from C<Mu> and we have requested
 that some accessor methods are generated for us, our class is already
 somewhat functional.
 
-    =begin code :preamble<class Journey {};>
-    # Create a new instance of the class.
-    my $vacation = Journey.new(
-        origin      => 'Sweden',
-        destination => 'Switzerland',
-        notes       => 'Pack hiking gear!'
-    );
+=begin code :preamble<class Journey {};>
+# Create a new instance of the class.
+my $vacation = Journey.new(
+    origin      => 'Sweden',
+    destination => 'Switzerland',
+    notes       => 'Pack hiking gear!'
+);
 
-    # Use an accessor; this outputs Sweden.
-    say $vacation.origin;
+# Use an accessor; this outputs Sweden.
+say $vacation.origin;
 
-    # Use an rw accessor to change the value.
-    $vacation.notes = 'Pack hiking gear and sunglasses!';
-    =end code
+# Use an rw accessor to change the value.
+$vacation.notes = 'Pack hiking gear and sunglasses!';
+=end code
 
 Note that, although the default constructor can initialize read-only
 attributes, it will only set attributes that have an accessor method.
@@ -230,39 +240,38 @@ default constructor, the attribute C<@!travelers> is not initialized.
 
 Methods are declared with the C<method> keyword inside a class body.
 
-    =begin code
-    class Journey {
-        has $.origin;
-        has $.destination;
-        has @!travelers;
-        has $.notes is rw;
+=begin code
+class Journey {
+    has $.origin;
+    has $.destination;
+    has @!travelers;
+    has $.notes is rw;
 
-        method add-traveler($name) {
-            if $name ne any(@!travelers) {
-                push @!travelers, $name;
-            }
-            else {
-                warn "$name is already going on the journey!";
-            }
+    method add-traveler($name) {
+        if $name ne any(@!travelers) {
+            push @!travelers, $name;
         }
-
-        method describe() {
-            "From $!origin to $!destination"
+        else {
+            warn "$name is already going on the journey!";
         }
     }
-    =end code
+
+    method describe() {
+        "From $!origin to $!destination"
+    }
+}
+=end code
 
 A method can have a signature, just like a subroutine. Attributes can be
 used in methods and can always be used with the C<!> twigil, even if they
 are declared with the C<.> twigil. This is because the C<.> twigil
 declares a C<!> twigil and generates an accessor method.
 
-Looking at the code above,
-there is a subtle but important difference between using C<$!origin>
-and C<$.origin> in the method C<describe>.
-C<$!origin> is an inexpensive and obvious lookup of the attribute.
-C<$.origin> is a method call and thus may be overridden in a subclass.
-Only use C<$.origin> if you want to allow overriding.
+Looking at the code above, there is a subtle but important difference between
+using C<$!origin> and C<$.origin> in the method C<describe>. C<$!origin> 
+is an inexpensive and obvious lookup of the attribute. C<$.origin> is a
+method call and thus may be overridden in a subclass. Only use C<$.origin> if
+you want to allow overriding.
 
 Unlike subroutines, additional named arguments will not produce compile time or
 runtime errors. That allows chaining of methods via
@@ -271,32 +280,34 @@ L<Re-dispatching|/language/functions#Re-dispatching>.
 You may write your own accessors to override any or all of the autogenerated
 ones.
 
-    my $ⲧ = " " xx 4; # A tab-like thing
-    class Journey {
-        has $.origin;
-        has $.destination;
-        has @.travelers;
-        has Str $.notes is rw;
+=begin code
+my $ⲧ = " " xx 4; # A tab-like thing
+class Journey {
+    has $.origin;
+    has $.destination;
+    has @.travelers;
+    has Str $.notes is rw;
 
-        multi method notes() { "$!notes\n" };
-        multi method notes( Str $note ) { $!notes ~= "$note\n$ⲧ" };
+    multi method notes() { "$!notes\n" };
+    multi method notes( Str $note ) { $!notes ~= "$note\n$ⲧ" };
 
-        method Str { "⤷ $!origin\n$ⲧ" ~ self.notes() ~ "$!destination ⤶\n" };
-    }
+    method Str { "⤷ $!origin\n$ⲧ" ~ self.notes() ~ "$!destination ⤶\n" };
+}
 
-    my $trip = Journey.new( :origin<Here>, :destination<There>,
-                            travelers => <þor Freya> );
+my $trip = Journey.new( :origin<Here>, :destination<There>,
+                        travelers => <þor Freya> );
 
-    $trip.notes("First steps");
-    notes $trip: "Almost there";
-    print $trip;
+$trip.notes("First steps");
+notes $trip: "Almost there";
+print $trip;
 
-    # OUTPUT:
-    #⤷ Here
-    #       First steps
-    #       Almost there
-    #
-    #There ⤶
+# OUTPUT:
+#⤷ Here
+#       First steps
+#       Almost there
+#
+#There ⤶
+=end code
 
 The declared multi method C<notes> overrides the auto-generated
 methods implicit in the declaration of C<$.notes>, using a different
@@ -308,13 +319,14 @@ separated by a colon, the arguments: C<method invocant: arguments>. We can use
 this syntax whenever it feels more natural than the classical
 period-and-parentheses one. It works exactly in the same way.
 
-
 Method names can be resolved at runtime with the C<.""> operator.
 
-    class A { has $.b };
-    my $name = 'b';
-    A.new."$name"().say;
-    # OUTPUT: «(Any)␤»
+=begin code
+class A { has $.b };
+my $name = 'b';
+A.new."$name"().say;
+# OUTPUT: «(Any)␤»
+=end code
 
 The syntax used to update C<$.notes> changed in this section with respect
 to the previous L<#Attributes> section. Instead of an assignment:
@@ -340,16 +352,18 @@ L<weaker object oriented design|https://6guts.wordpress.com/2016/11/25/perl-6-is
 
 =head2 Class and instance methods
 
-A method's signature can have an I<invocant> as its first parameter
+A method's signature can have an I<explicit invocant> as its first parameter
 followed by a colon, which allows for the method to refer to the object
 it was called on.
 
-    class Foo {
-        method greet($me: $person) {
-            say "Hi, I am $me.^name(), nice to meet you, $person";
-        }
+=begin code
+class Foo {
+    method greet($me: $person) {
+        say "Hi, I am $me.^name(), nice to meet you, $person";
     }
-    Foo.new.greet("Bob");    # OUTPUT: «Hi, I am Foo, nice to meet you, Bob␤»
+}
+Foo.new.greet("Bob");    # OUTPUT: «Hi, I am Foo, nice to meet you, Bob␤»
+=end code
 
 Providing an invocant in the method signature also allows for defining
 the method as either as a class method, or as an object method, through
@@ -358,67 +372,75 @@ C<::?CLASS> variable can be used to provide the class name at compile
 time, combined with either C<:U> (for class methods) or C<:D> (for
 instance methods).
 
-    class Pizza {
-        has $!radius = 42;
-        has @.ingredients;
+=begin code
+class Pizza {
+    has $!radius = 42;
+    has @.ingredients;
 
-        # class method: construct from a list of ingredients
-        method from-ingredients(::?CLASS:U $pizza: @ingredients) {
-            $pizza.new( ingredients => @ingredients );
-        }
-
-        # instance method
-        method get-radius(::?CLASS:D:) { $!radius }
+    # class method: construct from a list of ingredients
+    method from-ingredients(::?CLASS:U $pizza: @ingredients) {
+        $pizza.new( ingredients => @ingredients );
     }
-    my $p = Pizza.from-ingredients: <cheese pepperoni vegetables>;
-    say $p.ingredients;     # OUTPUT: «[cheese pepperoni vegetables]␤»
-    say $p.get-radius;      # OUTPUT: «42␤»
-    say Pizza.get-radius;   # This will fail.
-    CATCH { default { put .^name ~ ":\n" ~ .Str } };
-    # OUTPUT: «X::Parameter::InvalidConcreteness:␤
-    #          Invocant of method 'get-radius' must be
-    #          an object instance of type 'Pizza',
-    #          not a type object of type 'Pizza'.
-    #          Did you forget a '.new'?»
+
+    # instance method
+    method get-radius(::?CLASS:D:) { $!radius }
+}
+my $p = Pizza.from-ingredients: <cheese pepperoni vegetables>;
+say $p.ingredients;     # OUTPUT: «[cheese pepperoni vegetables]␤»
+say $p.get-radius;      # OUTPUT: «42␤»
+say Pizza.get-radius;   # This will fail.
+CATCH { default { put .^name ~ ":\n" ~ .Str } };
+# OUTPUT: «X::Parameter::InvalidConcreteness:␤
+#          Invocant of method 'get-radius' must be
+#          an object instance of type 'Pizza',
+#          not a type object of type 'Pizza'.
+#          Did you forget a '.new'?»
+=end code
 
 A method can be both a class and object method by using the
 L<multi|/syntax/multi> declarator:
 
-    class C {
-        multi method f(::?CLASS:U:) { say "class method"  }
-        multi method f(::?CLASS:D:) { say "object method" }
-    }
-    C.f;       # OUTPUT: «class method␤»
-    C.new.f;   # OUTPUT: «object method␤»
+=begin code
+class C {
+    multi method f(::?CLASS:U:) { say "class method"  }
+    multi method f(::?CLASS:D:) { say "object method" }
+}
+C.f;       # OUTPUT: «class method␤»
+C.new.f;   # OUTPUT: «object method␤»
+=end code
 
 =head2 X<C<self>>
 
-Inside a method, the term C<self> is available and bound to the invocant object.
-C<self> can be used to call further methods on the invocant, including
-constructors:
+Inside a method, the term C<self> is available and bound to the invocant
+object. C<self> can be used to call further methods on the invocant,
+including constructors:
 
-    class Box {
-      has $.data;
+=begin code
+class Box {
+  has $.data;
 
-      method make-new-box-from() {
-          self.new: data => $!data;
-      }
-    }
+  method make-new-box-from() {
+      self.new: data => $!data;
+  }
+}
+=end code
 
 C<self> can be used in class or instance methods as well, though beware
 of trying to invoke one type of method from the other:
 
-    class C {
-        method g()            { 42     }
-        method f(::?CLASS:U:) { self.g }
-        method d(::?CLASS:D:) { self.f }
-    }
-    C.f;        # OUTPUT: «42␤»
-    C.new.d;    # This will fail.
-    CATCH { default { put .^name ~ ":\n" ~ .Str } };
-    # OUTPUT: «X::Parameter::InvalidConcreteness:␤
-    #          Invocant of method 'f' must be a type object of type 'C',
-    #          not an object instance of type 'C'.  Did you forget a 'multi'?»
+=begin code
+class C {
+    method g()            { 42     }
+    method f(::?CLASS:U:) { self.g }
+    method d(::?CLASS:D:) { self.f }
+}
+C.f;        # OUTPUT: «42␤»
+C.new.d;    # This will fail.
+CATCH { default { put .^name ~ ":\n" ~ .Str } };
+# OUTPUT: «X::Parameter::InvalidConcreteness:␤
+#          Invocant of method 'f' must be a type object of type 'C',
+#          not an object instance of type 'C'.  Did you forget a 'multi'?»
+=end code
 
 C<self> can also be used with attributes, as long as they have an accessor.
 C<self.a> will call the accessor for an attribute declared as C<has $.a>.
@@ -433,8 +455,8 @@ class A {
 A.new.b; # OUTPUT: «1␤2␤3␤(1 2 3)␤»
 =end code
 
-The colon-syntax for method
-arguments is only supported for method calls using C<self>, not the shortcut.
+The colon-syntax for method arguments is only supported for method calls
+using C<self>, not the shortcut.
 
 Note that if the relevant methods C<bless>, C<CREATE> of L<Mu|/type/Mu>
 are not overloaded, C<self> will point to the type object in those methods.
@@ -481,7 +503,7 @@ Private methods are not inherited by subclasses.
 X<|Submethods>
 =head2 Submethods
 
-Submethods are public methods that will  not be inherited by subclasses. The
+Submethods are public methods that will not be inherited by subclasses. The
 name stems from the fact that they are semantically similar to subroutines.
 
 Submethods are useful for object construction and destruction tasks, as well
@@ -491,32 +513,32 @@ certainly have to override them.
 For example, the L<default method new|/type/Mu#method_new> calls submethod
 C<BUILD> on each class in an L<inheritance|#Inheritance> chain:
 
-    =begin code
-    class Point2D {
-        has $.x;
-        has $.y;
+=begin code
+class Point2D {
+    has $.x;
+    has $.y;
 
-        submethod BUILD(:$!x, :$!y) {
-            say "Initializing Point2D";
-        }
+    submethod BUILD(:$!x, :$!y) {
+        say "Initializing Point2D";
     }
+}
 
-    class InvertiblePoint2D is Point2D {
-        submethod BUILD() {
-            say "Initializing InvertiblePoint2D";
-        }
-        method invert {
-            self.new(x => - $.x, y => - $.y);
-        }
+class InvertiblePoint2D is Point2D {
+    submethod BUILD() {
+        say "Initializing InvertiblePoint2D";
     }
+    method invert {
+        self.new(x => - $.x, y => - $.y);
+    }
+}
 
-    say InvertiblePoint2D.new(x => 1, y => 2);
-    # OUTPUT: «Initializing Point2D␤»
-    # OUTPUT: «Initializing InvertiblePoint2D␤»
-    # OUTPUT: «InvertiblePoint2D.new(x => 1, y => 2)␤»
-    =end code
+say InvertiblePoint2D.new(x => 1, y => 2);
+# OUTPUT: «Initializing Point2D␤»
+# OUTPUT: «Initializing InvertiblePoint2D␤»
+# OUTPUT: «InvertiblePoint2D.new(x => 1, y => 2)␤»
+=end code
 
-See also: L<#Object_construction>.
+See also: L<Object construction|#Object_construction>.
 
 =head2 Inheritance
 
@@ -532,34 +554,35 @@ consulted is called the I<method resolution order> (MRO). Perl 6 uses the
 L<C3 method resolution order|https://en.wikipedia.org/wiki/C3_linearization>.
 You can ask a type for its MRO through a call to its meta class:
 
-    say List.^mro;      # ((List) (Cool) (Any) (Mu))
+=for code
+say List.^mro;      # ((List) (Cool) (Any) (Mu))
 
-If a class does not specify a parent class, L<Any|/type/Any> is assumed by default.
-All classes directly or indirectly derive from L<Mu|/type/Mu>, the root of the type
-hierarchy.
+If a class does not specify a parent class, L<Any|/type/Any> is assumed
+by default. All classes directly or indirectly derive from L<Mu|/type/Mu>,
+the root of the type hierarchy.
 
 All calls to public methods are "virtual" in the C++ sense, which means that
 the actual type of an object determines which method to call, not the
 declared type:
 
-    =begin code
-    class Parent {
-        method frob {
-            say "the parent class frobs"
-        }
+=begin code
+class Parent {
+    method frob {
+        say "the parent class frobs"
     }
+}
 
-    class Child is Parent {
-        method frob {
-            say "the child's somewhat more fancy frob is called"
-        }
+class Child is Parent {
+    method frob {
+        say "the child's somewhat more fancy frob is called"
     }
+}
 
-    my Parent $test;
-    $test = Child.new;
-    $test.frob;          # calls the frob method of Child rather than Parent
-    # OUTPUT: «the child's somewhat more fancy frob is called␤»
-    =end code
+my Parent $test;
+$test = Child.new;
+$test.frob;          # calls the frob method of Child rather than Parent
+# OUTPUT: «the child's somewhat more fancy frob is called␤»
+=end code
 
 X<|new (method)>
 =head2 Object construction
@@ -567,23 +590,26 @@ X<|new (method)>
 Objects are generally created through method calls, either on the type
 object or on another object of the same type.
 
-Class L<Mu|/type/Mu> provides a constructor method called L<new|/routine/new>, which takes named
+Class L<Mu|/type/Mu> provides a constructor method called
+L<new|/routine/new>, which takes named
 L<arguments|/language/functions#Arguments> and uses them to initialize public
 attributes.
 
-    class Point {
-        has $.x;
-        has $.y;
-    }
-    my $p = Point.new( x => 5, y => 2);
-    #             ^^^ inherited from class Mu
-    say "x: ", $p.x;
-    say "y: ", $p.y;
-    # OUTPUT: «x: 5␤»
-    # OUTPUT: «y: 2␤»
+=begin code
+class Point {
+    has $.x;
+    has $.y;
+}
+my $p = Point.new( x => 5, y => 2);
+#             ^^^ inherited from class Mu
+say "x: ", $p.x;
+say "y: ", $p.y;
+# OUTPUT: «x: 5␤»
+# OUTPUT: «y: 2␤»
+=end code
 
-C<Mu.new> calls method L<bless|/routine/bless> on its invocant, passing all the named
-L<arguments|/language/functions#Arguments>. C<bless> creates the new
+C<Mu.new> calls method L<bless|/routine/bless> on its invocant, passing all
+the named L<arguments|/language/functions#Arguments>. C<bless> creates the new
 object, and then walks all subclasses in reverse method resolution order
 (i.e. from L<Mu|/type/Mu> to most derived classes) and in each class checks for
 the existence of a method named C<BUILD>. If the method exists, the
@@ -615,31 +641,31 @@ C<BUILD> submethods can be used to run custom code at object construction
 time. They can also be used for creating aliases for attribute
 initialization:
 
-    =begin code
-    class EncodedBuffer {
-        has $.enc;
-        has $.data;
+=begin code
+class EncodedBuffer {
+    has $.enc;
+    has $.data;
 
-        submethod BUILD(:encoding(:$enc), :$data) {
-            $!enc  :=  $enc;
-            $!data := $data;
-        }
+    submethod BUILD(:encoding(:$enc), :$data) {
+        $!enc  :=  $enc;
+        $!data := $data;
     }
-    my $b1 = EncodedBuffer.new( encoding => 'UTF-8', data => [64, 65] );
-    my $b2 = EncodedBuffer.new( enc      => 'UTF-8', data => [64, 65] );
-    #  both enc and encoding are allowed now
-    =end code
+}
+my $b1 = EncodedBuffer.new( encoding => 'UTF-8', data => [64, 65] );
+my $b2 = EncodedBuffer.new( enc      => 'UTF-8', data => [64, 65] );
+#  both enc and encoding are allowed now
+=end code
 
 Since passing arguments to a routine binds the arguments to the parameters,
 a separate binding step is unnecessary if the attribute is used as a
 parameter. Hence the example above could also have been written as:
 
-    =begin code :preamble<has $!enc; has $!data>
-    submethod BUILD(:encoding(:$!enc), :$!data) {
-        # nothing to do here anymore, the signature binding
-        # does all the work for us.
-    }
-    =end code
+=begin code :preamble<has $!enc; has $!data>
+submethod BUILD(:encoding(:$!enc), :$!data) {
+    # nothing to do here anymore, the signature binding
+    # does all the work for us.
+}
+=end code
 
 However, be careful when using this auto-binding of attributes
 when the attribute may have special type requirements, such as an C<:$!id>
@@ -650,13 +676,15 @@ default value will be C<Any>, which would cause a type error.
 The third implication is that if you want a constructor that accepts
 positional arguments, you must write your own C<new> method:
 
-    class Point {
-        has $.x;
-        has $.y;
-        method new($x, $y) {
-            self.bless(:$x, :$y);
-        }
+=begin code
+class Point {
+    has $.x;
+    has $.y;
+    method new($x, $y) {
+        self.bless(:$x, :$y);
     }
+}
+=end code
 
 However this is considered poor practice, because it makes correct
 initialization of objects from subclasses harder.
@@ -688,17 +716,17 @@ The cloning is done using the L<clone|/routine/clone> method available on all
 objects, which shallow-clones both public and private attributes. New values for
 I<public> attributes can be supplied as named arguments.
 
-    =begin code
-    class Foo {
-        has $.foo = 42;
-        has $.bar = 100;
-    }
+=begin code
+class Foo {
+    has $.foo = 42;
+    has $.bar = 100;
+}
 
-    my $o1 = Foo.new;
-    my $o2 = $o1.clone: :bar(5000);
-    say $o1; # Foo.new(foo => 42, bar => 100)
-    say $o2; # Foo.new(foo => 42, bar => 5000)
-    =end code
+my $o1 = Foo.new;
+my $o2 = $o1.clone: :bar(5000);
+say $o1; # Foo.new(foo => 42, bar => 100)
+say $o2; # Foo.new(foo => 42, bar => 5000)
+=end code
 
 See document for L<clone|/routine/clone> for details on how non-scalar
 attributes get cloned, as well as examples of implementing your own custom clone
@@ -707,15 +735,15 @@ methods.
 =head1 X<Roles|declarator,role>
 
 Roles are a collection of attributes and methods; however, unlike classes, roles
-are meant for describing only parts of an object's behavior; this why, in
+are meant for describing only parts of an object's behavior; this is why, in
 general, roles are intended to be I<mixed in> classes and objects. In general,
 classes are meant for managing objects and roles are meant for managing behavior
 and code reuse within objects.
 
 X<|does>
 Roles use the keyword C<role> preceding the name of the role that is
-declared. Roles are mixed in using the C<does> keyword preceding the name of the
-Role that is mixed in.
+declared. Roles are mixed in using the C<does> keyword preceding the name
+of the role that is mixed in.
 
 =begin code
 constant ⲧ = " " xx 4; #Just a ⲧab
@@ -749,8 +777,8 @@ print $trip;
 #There ⤶
 =end code
 
-Roles are immutable as soon as the compiler parses the closing curly brace of
-the role declaration.
+Roles are immutable as soon as the compiler parses the closing curly brace
+of the role declaration.
 
 =head2 Applying roles
 
@@ -770,85 +798,91 @@ trying to market it as a new form of popular transportation, you might have
 a class C<Bull>, for all the bulls you keep around the house, and a class
 C<Automobile>, for things that you can drive.
 
-    class Bull {
-        has Bool $.castrated = False;
-        method steer {
-            # Turn your bull into a steer
-            $!castrated = True;
-            return self;
-        }
+=begin code
+class Bull {
+    has Bool $.castrated = False;
+    method steer {
+        # Turn your bull into a steer
+        $!castrated = True;
+        return self;
     }
-    class Automobile {
-        has $.direction;
-        method steer($!direction) { }
-    }
-    class Taurus is Bull is Automobile { }
+}
+class Automobile {
+    has $.direction;
+    method steer($!direction) { }
+}
+class Taurus is Bull is Automobile { }
 
-    my $t = Taurus.new;
-    say $t.steer;
-    # OUTPUT: «Taurus.new(castrated => Bool::True, direction => Any)␤»
+my $t = Taurus.new;
+say $t.steer;
+# OUTPUT: «Taurus.new(castrated => Bool::True, direction => Any)␤»
+=end code
 
 With this setup, your poor customers will find themselves unable to turn
 their Taurus and you won't be able to make more of your product! In this
 case, it may have been better to use roles:
 
-    =begin code :skip-test<illustrates error>
-    role Bull-Like {
-        has Bool $.castrated = False;
-        method steer {
-            # Turn your bull into a steer
-            $!castrated = True;
-            return self;
-        }
+=begin code :skip-test<illustrates error>
+role Bull-Like {
+    has Bool $.castrated = False;
+    method steer {
+        # Turn your bull into a steer
+        $!castrated = True;
+        return self;
     }
-    role Steerable {
-        has Real $.direction;
-        method steer(Real $d = 0) {
-            $!direction += $d;
-        }
+}
+role Steerable {
+    has Real $.direction;
+    method steer(Real $d = 0) {
+        $!direction += $d;
     }
-    class Taurus does Bull-Like does Steerable { }
-    =end code
+}
+class Taurus does Bull-Like does Steerable { }
+=end code
 
 This code will die with something like:
 
-    =begin code :lang<text>
-    ===SORRY!===
-    Method 'steer' must be resolved by class Taurus because it exists in
-    multiple roles (Steerable, Bull-Like)
-    =end code
+=begin code :lang<text>
+===SORRY!===
+Method 'steer' must be resolved by class Taurus because it exists in
+multiple roles (Steerable, Bull-Like)
+=end code
 
 This check will save you a lot of headaches:
 
-    =begin code :preamble<role Bull-Like{}; role Steerable{};>
-    class Taurus does Bull-Like does Steerable {
-        method steer($direction?) {
-            self.Steerable::steer($direction)
-        }
+=begin code :preamble<role Bull-Like{}; role Steerable{};>
+class Taurus does Bull-Like does Steerable {
+    method steer($direction?) {
+        self.Steerable::steer($direction)
     }
-    =end code
+}
+=end code
 
 When a role is applied to a second role, the actual application is delayed
 until the second role is applied to a class, at which point both roles are
 applied to the class. Thus
 
-    role R1 {
-        # methods here
-    }
-    role R2 does R1 {
-        # methods here
-    }
-    class C does R2 { }
+=begin code
+role R1 {
+    # methods here
+}
+role R2 does R1 {
+    # methods here
+}
+class C does R2 { }
+=end code
 
 produces the same class C<C> as
 
-    role R1 {
-        # methods here
-    }
-    role R2 {
-        # methods here
-    }
-    class C does R1 does R2 { }
+=begin code
+role R1 {
+    # methods here
+}
+role R2 {
+    # methods here
+}
+class C does R1 does R2 { }
+=end code
 
 =head2 Stubs
 
@@ -857,28 +891,28 @@ a non-stubbed version of a method of the same name must be supplied
 at the time the role is applied to a class. This allows you to
 create roles that act as abstract interfaces.
 
-    =begin code :skip-test<illustrates error>
-    role AbstractSerializable {
-        method serialize() { ... }        # literal ... here marks the
-                                          # method as a stub
-    }
+=begin code :skip-test<illustrates error>
+role AbstractSerializable {
+    method serialize() { ... }        # literal ... here marks the
+                                      # method as a stub
+}
 
-    # the following is a compile time error, for example
-    #        Method 'serialize' must be implemented by Point because
-    #        it's required by a role
+# the following is a compile time error, for example
+#        Method 'serialize' must be implemented by Point because
+#        it's required by a role
 
-    class APoint does AbstractSerializable {
-        has $.x;
-        has $.y;
-    }
+class APoint does AbstractSerializable {
+    has $.x;
+    has $.y;
+}
 
-    # this works:
-    class SPoint does AbstractSerializable {
-        has $.x;
-        has $.y;
-        method serialize() { "p($.x, $.y)" }
-    }
-    =end code
+# this works:
+class SPoint does AbstractSerializable {
+    has $.x;
+    has $.y;
+    method serialize() { "p($.x, $.y)" }
+}
+=end code
 
 The implementation of the stubbed method may also be provided by another
 role.
@@ -889,11 +923,11 @@ Roles cannot inherit from classes, but they may I<carry> classes, causing
 any class which does that role to inherit from the carried classes.
 So if you write:
 
-    =begin code
-    role A is Exception { }
-    class X::Ouch does A { }
-    X::Ouch.^parents.say # OUTPUT: «((Exception))␤»
-    =end code
+=begin code
+role A is Exception { }
+class X::Ouch does A { }
+X::Ouch.^parents.say # OUTPUT: «((Exception))␤»
+=end code
 
 then C<X::Ouch> will inherit directly from Exception, as we can see above
 by listing its parents.
@@ -904,18 +938,18 @@ instead, which uses C<transitive> as flag for including all levels or just the
 first one. Despite this, a class or instance may still be tested with
 smartmatches or type constraints to see if it does a role.
 
-    =begin code
-    role F { }
-    class G does F { }
-    G.^roles.say;                    # OUTPUT: «((F))␤»
-    role Ur {}
-    role Ar does Ur {}
-    class Whim does Ar {}; Whim.^roles(:!transitive).say;   # OUTPUT: «((Ar))␤»
-    say G ~~ F;                      # OUTPUT: «True␤»
-    multi a (F $a) { "F".say }
-    multi a ($a)   { "not F".say }
-    a(G);                            # OUTPUT: «F␤»
-    =end code
+=begin code
+role F { }
+class G does F { }
+G.^roles.say;                    # OUTPUT: «((F))␤»
+role Ur {}
+role Ar does Ur {}
+class Whim does Ar {}; Whim.^roles(:!transitive).say;   # OUTPUT: «((Ar))␤»
+say G ~~ F;                      # OUTPUT: «True␤»
+multi a (F $a) { "F".say }
+multi a ($a)   { "not F".say }
+a(G);                            # OUTPUT: «F␤»
+=end code
 
 =head2 Pecking order
 
@@ -925,22 +959,24 @@ from roles override methods inherited from classes. This happens both when
 said class was brought in by a role, and also when said class was inherited
 directly.
 
-    role M {
-      method f { say "I am in role M" }
-    }
+=begin code
+role M {
+  method f { say "I am in role M" }
+}
 
-    class A {
-      method f { say "I am in class A" }
-    }
+class A {
+  method f { say "I am in class A" }
+}
 
-    class B is A does M {
-      method f { say "I am in class B" }
-    }
+class B is A does M {
+  method f { say "I am in class B" }
+}
 
-    class C is A does M { }
+class C is A does M { }
 
-    B.new.f; # OUTPUT «I am in class B␤»
-    C.new.f; # OUTPUT «I am in role M␤»
+B.new.f; # OUTPUT «I am in class B␤»
+C.new.f; # OUTPUT «I am in role M␤»
+=end code
 
 Note that each candidate for a multi-method is its own method. In this case,
 the above only applies if two such candidates have the same signature.
@@ -953,16 +989,16 @@ Any attempt to directly instantiate a role or use it as a type object
 will automatically create a class with the same name as the role,
 making it possible to transparently use a role as if it were a class.
 
-    =begin code
-    role Point {
-        has $.x;
-        has $.y;
-        method abs { sqrt($.x * $.x + $.y * $.y) }
-        method dimensions { 2 }
-    }
-    say Point.new(x => 6, y => 8).abs; # OUTPUT «10␤»
-    say Point.dimensions;              # OUTPUT «2␤»
-    =end code
+=begin code
+role Point {
+    has $.x;
+    has $.y;
+    method abs { sqrt($.x * $.x + $.y * $.y) }
+    method dimensions { 2 }
+}
+say Point.new(x => 6, y => 8).abs; # OUTPUT «10␤»
+say Point.dimensions;              # OUTPUT «2␤»
+=end code
 
 We call this automatic creation of classes I<punning>, and the generated class
 a I<pun>.
@@ -973,58 +1009,57 @@ however, as those are sometimes used to work directly with roles.
 X<|Parameterized Roles>
 =head2 Parameterized roles
 
-
 Roles can be parameterized, by giving them a signature in square brackets:
 
-    =begin code
-    role BinaryTree[::Type] {
-        has BinaryTree[Type] $.left;
-        has BinaryTree[Type] $.right;
-        has Type $.node;
+=begin code
+role BinaryTree[::Type] {
+    has BinaryTree[Type] $.left;
+    has BinaryTree[Type] $.right;
+    has Type $.node;
 
-        method visit-preorder(&cb) {
-            cb $.node;
-            for $.left, $.right -> $branch {
-                $branch.visit-preorder(&cb) if defined $branch;
-            }
-        }
-        method visit-postorder(&cb) {
-            for $.left, $.right -> $branch {
-                $branch.visit-postorder(&cb) if defined $branch;
-            }
-            cb $.node;
-        }
-        method new-from-list(::?CLASS:U: *@el) {
-            my $middle-index = @el.elems div 2;
-            my @left         = @el[0 .. $middle-index - 1];
-            my $middle       = @el[$middle-index];
-            my @right        = @el[$middle-index + 1 .. *];
-            self.new(
-                node    => $middle,
-                left    => @left  ?? self.new-from-list(@left)  !! self,
-                right   => @right ?? self.new-from-list(@right) !! self,
-            );
+    method visit-preorder(&cb) {
+        cb $.node;
+        for $.left, $.right -> $branch {
+            $branch.visit-preorder(&cb) if defined $branch;
         }
     }
+    method visit-postorder(&cb) {
+        for $.left, $.right -> $branch {
+            $branch.visit-postorder(&cb) if defined $branch;
+        }
+        cb $.node;
+    }
+    method new-from-list(::?CLASS:U: *@el) {
+        my $middle-index = @el.elems div 2;
+        my @left         = @el[0 .. $middle-index - 1];
+        my $middle       = @el[$middle-index];
+        my @right        = @el[$middle-index + 1 .. *];
+        self.new(
+            node    => $middle,
+            left    => @left  ?? self.new-from-list(@left)  !! self,
+            right   => @right ?? self.new-from-list(@right) !! self,
+        );
+    }
+}
 
-    my $t = BinaryTree[Int].new-from-list(4, 5, 6);
-    $t.visit-preorder(&say);    # OUTPUT: «5␤4␤6␤»
-    $t.visit-postorder(&say);   # OUTPUT: «4␤6␤5␤»
-    =end code
+my $t = BinaryTree[Int].new-from-list(4, 5, 6);
+$t.visit-preorder(&say);    # OUTPUT: «5␤4␤6␤»
+$t.visit-postorder(&say);   # OUTPUT: «4␤6␤5␤»
+=end code
 
 Here the signature consists only of a type capture, but any signature will do:
 
-    =begin code
-    enum Severity <debug info warn error critical>;
+=begin code
+enum Severity <debug info warn error critical>;
 
-    role Logging[$filehandle = $*ERR] {
-        method log(Severity $sev, $message) {
-            $filehandle.print("[{uc $sev}] $message\n");
-        }
+role Logging[$filehandle = $*ERR] {
+    method log(Severity $sev, $message) {
+        $filehandle.print("[{uc $sev}] $message\n");
     }
+}
 
-    Logging[$*OUT].log(debug, 'here we go'); # OUTPUT: «[DEBUG] here we go␤»
-    =end code
+Logging[$*OUT].log(debug, 'here we go'); # OUTPUT: «[DEBUG] here we go␤»
+=end code
 
 You can have multiple roles of the same name, but with different signatures;
 the normal rules of multi dispatch apply for choosing multi candidates.
@@ -1036,12 +1071,14 @@ Roles can be mixed into objects. A role's given attributes and methods will be
 added to the methods and attributes the object already has. Multiple mixins and
 anonymous roles are supported.
 
-    role R { method Str() {'hidden!'} };
-    my $i = 2 but R;
-    sub f(\bound){ put bound };
-    f($i); # OUTPUT: «hidden!␤»
-    my @positional := <a b> but R;
-    say @positional.^name; # OUTPUT: «List+{R}␤»
+=begin code
+role R { method Str() {'hidden!'} };
+my $i = 2 but R;
+sub f(\bound){ put bound };
+f($i); # OUTPUT: «hidden!␤»
+my @positional := <a b> but R;
+say @positional.^name; # OUTPUT: «List+{R}␤»
+=end code
 
 Note that the object got the role mixed in, not the object's class or the
 container. Thus, @-sigiled containers will require binding to make the role
@@ -1050,9 +1087,11 @@ a new value, which effectively strips the mixin from the result. That is why it
 might be more clear to mix in the role in the declaration of the variable using
 C<does>:
 
-    role R {};
-    my @positional does R = <a b>;
-    say @positional.^name; # OUTPUT: «Array+{R}␤»
+=begin code
+role R {};
+my @positional does R = <a b>;
+say @positional.^name; # OUTPUT: «Array+{R}␤»
+=end code
 
 The operator C<infix:<but>> is narrower than the list constructor. When
 providing a list of roles to mix in, always use parentheses.
@@ -1069,30 +1108,34 @@ say $all-roles.^name; # OUTPUT: «Int+{R1,R2}␤»
 
 Mixins can be used at any point in your object's life.
 
-    # A counter for Table of Contents
-    role TOC-Counter {
-        has Int @!counters is default(0);
-        method Str() { @!counters.join: '.' }
-        method inc($level) {
-            @!counters[$level - 1]++;
-            @!counters.splice($level);
-            self
-        }
+=begin code
+# A counter for Table of Contents
+role TOC-Counter {
+    has Int @!counters is default(0);
+    method Str() { @!counters.join: '.' }
+    method inc($level) {
+        @!counters[$level - 1]++;
+        @!counters.splice($level);
+        self
     }
+}
 
-    my Num $toc-counter = NaN;     # don't do math with Not A Number
-    say $toc-counter;              # OUTPUT: «NaN␤»
-    $toc-counter does TOC-Counter; # now we mix the role in
-    $toc-counter.inc(1).inc(2).inc(2).inc(1).inc(2).inc(2).inc(3).inc(3);
-    put $toc-counter / 1;          # OUTPUT: «NaN␤» (because that's numerical context)
-    put $toc-counter;              # OUTPUT: «2.2.2␤» (put will call TOC-Counter::Str)
+my Num $toc-counter = NaN;     # don't do math with Not A Number
+say $toc-counter;              # OUTPUT: «NaN␤»
+$toc-counter does TOC-Counter; # now we mix the role in
+$toc-counter.inc(1).inc(2).inc(2).inc(1).inc(2).inc(2).inc(3).inc(3);
+put $toc-counter / 1;          # OUTPUT: «NaN␤» (because that's numerical context)
+put $toc-counter;              # OUTPUT: «2.2.2␤» (put will call TOC-Counter::Str)
+=end code
 
 Roles can be anonymous.
 
-    my %seen of Int is default(0 but role :: { method Str() {'NULL'} });
-    say %seen<not-there>;          # OUTPUT: «NULL␤»
-    say %seen<not-there>.defined;  # OUTPUT: «True␤» (0 may be False but is well defined)
-    say Int.new(%seen<not-there>); # OUTPUT: «0␤»
+=begin code
+my %seen of Int is default(0 but role :: { method Str() {'NULL'} });
+say %seen<not-there>;          # OUTPUT: «NULL␤»
+say %seen<not-there>.defined;  # OUTPUT: «True␤» (0 may be False but is well defined)
+say Int.new(%seen<not-there>); # OUTPUT: «0␤»
+=end code
 
 =head1 Meta-object programming and introspection
 
@@ -1108,11 +1151,13 @@ Note that although this looks like a method call, it works more like a macro.
 So, what can you do with the meta object? For one you can check if two
 objects have the same meta class by comparing them for equality:
 
-    say 1.HOW ===   2.HOW;      # OUTPUT: «True␤»
-    say 1.HOW === Int.HOW;      # OUTPUT: «True␤»
-    say 1.HOW === Num.HOW;      # OUTPUT: «False␤»
+=begin code
+say 1.HOW ===   2.HOW;      # OUTPUT: «True␤»
+say 1.HOW === Int.HOW;      # OUTPUT: «True␤»
+say 1.HOW === Num.HOW;      # OUTPUT: «False␤»
+=end code
 
-Perl 6 uses the word I<HOW>, Higher Order Workings, to refer to the meta
+Perl 6 uses the word I<HOW> (Higher Order Workings) to refer to the meta
 object system. Thus it should be no surprise that in Rakudo, the class name
 of the meta class that controls class behavior is called
 C<Perl6::Metamodel::ClassHOW>. For each class there is one instance of
@@ -1124,12 +1169,14 @@ meta objects is to call the method on the meta object and pass in the object
 of interest as first argument to the object. So to get the name of the class
 of an object, you could write:
 
-    my $object = 1;
-    my $metaobject = 1.HOW;
-    say $metaobject.name($object);      # OUTPUT: «Int␤»
+=begin code
+my $object = 1;
+my $metaobject = 1.HOW;
+say $metaobject.name($object);      # OUTPUT: «Int␤»
 
-    # or shorter:
-    say 1.HOW.name(1);                  # OUTPUT: «Int␤»
+# or shorter:
+say 1.HOW.name(1);                  # OUTPUT: «Int␤»
+=end code
 
 (The motivation is that Perl 6 also wants to allow a more prototype-based
 object system, where it's not necessary to create a new meta object for
@@ -1137,9 +1184,11 @@ every type).
 
 There's a shortcut to keep from using the same object twice:
 
-    say 1.^name;                        # OUTPUT: «Int␤»
-    # same as
-    say 1.HOW.name(1);                  # OUTPUT: «Int␤»
+=begin code
+say 1.^name;                        # OUTPUT: «Int␤»
+# same as
+say 1.HOW.name(1);                  # OUTPUT: «Int␤»
+=end code
 
 See L<Metamodel::ClassHOW|/type/Metamodel::ClassHOW> for documentation on
 the meta class of C<class> and also the L<general documentation on the meta

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -274,10 +274,10 @@ Code blocks can also be explicitly defined by enclosing them in C<=begin code>
 and C<=end code>
 
 =begin code :lang<pod6>
-=begin code
-my $name = 'John Doe';
-say $name;
-=end code
+    =begin code
+    my $name = 'John Doe';
+    say $name;
+    =end code
 =end code
 
 =head2 I/O blocks

--- a/doc/Language/pod.pod6
+++ b/doc/Language/pod.pod6
@@ -61,14 +61,14 @@ Perl6-ish option pairs. That is, any of:
 =end table
 
 Where '$e1, $e2, ...' are list elements of type String, Int, Number, or
-Boolean.  Lists may have mixed element types. Note that one-element
+Boolean. Lists may have mixed element types. Note that one-element
 lists are converted to the type of their element (String, Int, Number, or
 Boolean). Also note that "bigints" can be used if required.
 
 For hashes, '$k1, $k2, ...' are keys of type Str and '$v1, $v2, ...'
 are values of type String, Int, Number, or Boolean.
 
-Strings are delimited by single or double quotes.  Whitespace is not significant
+Strings are delimited by single or double quotes. Whitespace is not significant
 outside of strings. Hash keys need not be quote-delimited unless they contain
 significant whitespace. Strings entered inside angle brackets become lists if
 any whitespace is used inside the angle brackets.
@@ -117,8 +117,8 @@ instead they are attached to some source code.
 Declarator blocks are introduced by a special comment: either C<#|> or C<#=>,
 which must be immediately followed by either a space or an opening curly brace.
 If followed by a space, the block is terminated by the end of line;
-if followed by one or more opening curly braces, the block is terminated by the matching
-sequence of closing curly braces.
+if followed by one or more opening curly braces, the block is terminated by
+the matching sequence of closing curly braces.
 
 Blocks starting with C<#|> are attached to the code after them,
 and blocks starting with C<#=> are attached to the code before them.
@@ -220,7 +220,8 @@ previous directive
 
 Ordinary paragraphs do not require an explicit marker or delimiters.
 
-Alternatively, there is also an explicit C<=para> marker that can be used to explicitly mark a paragraph.
+Alternatively, there is also an explicit C<=para> marker that can be used
+to explicitly mark a paragraph.
 
 =begin code :lang<pod6>
 =para
@@ -245,18 +246,20 @@ which continues until an...
 =end para
 =end code
 
-As demonstrated by the previous example, within a delimited C<=begin para> and C<=end para> block, any blank lines are preserved.
+As demonstrated by the previous example, within a delimited C<=begin para> and
+C<=end para> block, any blank lines are preserved.
 
 =head2 Code blocks
 
-Code blocks are used to specify  source code, which should be rendered without re-justification,
-without whitespace-squeezing, and without recognizing any inline formatting codes.
-Typically these blocks are used to show examples of code, mark-up,
-or other textual specifications, and are rendered using a fixed-width font.
+Code blocks are used to specify  source code, which should be rendered without
+re-justification, without whitespace-squeezing, and without recognizing any
+inline formatting codes. Typically these blocks are used to show examples of
+code, mark-up, or other textual specifications, and are rendered using a
+fixed-width font.
 
 A code block may be implicitly specified as one or more lines of text,
-each of which starts with a whitespace character.
-The implicit code block is then terminated by a blank line.
+each of which starts with a whitespace character. The implicit code block
+is then terminated by a blank line.
 
 For example:
 
@@ -267,15 +270,15 @@ This ordinary paragraph introduces a code block:
     say $name;
 =end code
 
-Code blocks can also be explicitly defined by enclosing them in C<=begin code> and C<=end code>
+Code blocks can also be explicitly defined by enclosing them in C<=begin code>
+and C<=end code>
 
 =begin code :lang<pod6>
-    =begin code
-    my $name = 'John Doe';
-    say $name;
-    =end code
+=begin code
+my $name = 'John Doe';
+say $name;
 =end code
-
+=end code
 
 =head2 I/O blocks
 
@@ -311,7 +314,8 @@ The three suspects are:
 
 =head3 Definition lists
 
-Lists that define terms or commands use C<=defn>, equivalent to the C<DL> lists in HTML
+Lists that define terms or commands use C<=defn>, equivalent to the C<DL> lists
+in HTML
 
 =begin code :lang<pod6>
 =defn Happy
@@ -331,7 +335,8 @@ When you're not happy.
 
 =head3 Multi-level lists
 
-Lists may be multi-level, with items at each level specified using the C<=item1>, C<=item2>, C<=item3>, etc. blocks.
+Lists may be multi-level, with items at each level specified using the
+C<=item1>, C<=item2>, C<=item3>, etc. blocks.
 
 Note that C<=item> is just an abbreviation for C<=item1>.
 
@@ -413,13 +418,14 @@ Z<Eventually copy everything from tables.pod6 and put it here>
 
 Pod comments are comments that Pod renderers ignore.
 
-Comments are useful for meta-documentation (documenting the documentation). Single-line comments use the C<comment> keyword:
+Comments are useful for meta-documentation (documenting the documentation).
+Single-line comments use the C<=comment> marker:
 
 =begin code :lang<pod6>
 =comment Add more here about the algorithm
 =end code
 
-For multi-line comments use a delimited C<comment> block:
+For multi-line comments, use a delimited C<comment> block:
 
 =begin code :lang<pod6>
 =begin comment
@@ -430,8 +436,8 @@ multi-line.
 
 =head2 Semantic blocks
 
-All uppercase block typenames are reserved for specifying standard documentation,
-publishing, source components, or meta-information.
+All uppercase block typenames are reserved for specifying standard
+documentation, publishing, source components, or meta-information.
 
 =begin code :lang<pod6>
 =NAME
@@ -451,8 +457,8 @@ be used.
 
 Formatting codes may nest other formatting codes.
 
-The following codes are available: B<B>, B<C>, B<E>, B<I>, B<K>, B<L>, B<N>, B<P>,
-B<R>, B<T>, B<U>, B<V>, B<X>, and B<Z>.
+The following codes are available: B<B>, B<C>, B<E>, B<I>, B<K>, B<L>, B<N>,
+B<P>, B<R>, B<T>, B<U>, B<V>, B<X>, and B<Z>.
 
 =head2 Bold
 
@@ -480,7 +486,7 @@ Z<If used will bust Pod::To::BigPage>
 
 =head2 Code
 
-To flag text as Code and treat it verbatim enclose it in C<C< >>
+To flag text as code and treat it verbatim enclose it in C<C< >>
 =for code :lang<pod6>
 C<my $var = 1; say $var;>
 
@@ -492,8 +498,9 @@ To create a link enclose it in C<L< >>
 
 A vertical bar (optional) separates label and target.
 
-The target location can be an URL (first example) or a local POD document (second example).
-Local file names are relative to the base of the project, not the current document.
+The target location can be an URL (first example) or a local POD document
+(second example). Local file names are relative to the base of the project, not
+the current document.
 
 =for code :lang<pod6>
 Perl 6 homepage L<https://perl6.org>
@@ -522,7 +529,8 @@ L<Comments|#Comments>
 
 =head2 Placement links
 
-This code is not implemented in C<Pod::To::HTML>, but is partially implemented in C<Pod::To::BigPage>.
+This code is not implemented in C<Pod::To::HTML>, but is partially implemented
+in C<Pod::To::BigPage>.
 
 A second kind of link E<mdash> the C<P<>> or B<placement link> E<mdash> works
 in the opposite direction. Instead of directing focus out to another
@@ -536,6 +544,7 @@ code itself.
 C<P<>> codes are handy for breaking out standard elements of
 your documentation set into reusable components that can then be
 incorporated directly into multiple documents. For example:
+
 =begin code :lang<pod6>
 =COPYRIGHT
 P<file:/shared/docs/std_copyright.pod>
@@ -543,6 +552,7 @@ P<file:/shared/docs/std_copyright.pod>
 =DISCLAIMER
 P<http://www.MegaGigaTeraPetaCorp.com/std/disclaimer.txt>
 =end code
+
 might produce:
 
 =begin nested
@@ -618,12 +628,12 @@ The basic C<ln> command is: C<ln> R<source_file> R<target_file>
 or:
 
 =begin code :allow<R> :lang<pod6>
-    Then enter your details at the prompt:
+Then enter your details at the prompt:
 
-    =for input
-        Name: R<your surname>
-          ID: R<your employee number>
-        Pass: R<your 36-letter password>
+=for input
+    Name: R<your surname>
+      ID: R<your employee number>
+    Pass: R<your 36-letter password>
 =end code
 
 =head2 Terminal output
@@ -636,10 +646,13 @@ Z<If used will bust Pod::To::BigPage>
 
 =head2 Unicode
 
-To include Unicode code points or HTML5 character references in a Pod document, enclose them in  C<E< >>
+To include Unicode code points or HTML5 character references in a Pod document,
+enclose them in  C<E< >>
 
-C<E< >> can enclose a number, that number is treated as the decimal Unicode value for the desired code point.
-It can also enclose explicit binary, octal, decimal, or hexadecimal numbers using the Perl 6 notations for explicitly based numbers.
+C<E< >> can enclose a number, which is treated as the decimal Unicode
+value for the desired code point. It can also enclose explicit binary, octal,
+decimal, or hexadecimal numbers using the Perl 6 notations for explicitly based
+numbers.
 
 =begin code :lang<pod6>
 Perl 6 makes considerable use of the E<171> and E<187> characters.
@@ -659,21 +672,22 @@ Perl 6 makes considerable use of the « and » characters.
 
 =head2 Verbatim text
 
-This code is not implemented by C<Pod::To::HTML>, but is implemented in C<Pod::To::BigPage>.
+This code is not implemented by C<Pod::To::HTML>, but is implemented in
+C<Pod::To::BigPage>.
 
 The C<V<>> formatting code treats its entire contents as being B<verbatim>,
 disregarding every apparent formatting code within it. For example:
 
 =for code :lang<pod6>
-    The B<V< V<> >> formatting code disarms other codes
-    such as V< I<>, C<>, B<>, and M<> >.
+The B<V< V<> >> formatting code disarms other codes
+such as V< I<>, C<>, B<>, and M<> >.
 
 Note, however that the C<V<>> code only changes the way its
 contents are parsed, I<not> the way they are rendered. That is, the
 contents are still wrapped and formatted like plain text, and the
 effects of any formatting codes surrounding the C<V<>> code
 are still applied to its contents. For example the previous example
-is rendered:
+is rendered as:
 
 =nested
 The B<V< V<> >> formatting code disarms other codes
@@ -686,18 +700,18 @@ of the code are both formatted into the document and used as the
 (case-insensitive) index entry:
 
 =begin code :allow<B> :lang<pod6>
-    An B<X<array>> is an ordered list of scalars indexed by number,
-    starting with 0. A B<X<hash>> is an unordered collection of scalar
-    values indexed by their associated string key.
+An B<X<array>> is an ordered list of scalars indexed by number,
+starting with 0. A B<X<hash>> is an unordered collection of scalar
+values indexed by their associated string key.
 =end code
 
 You can specify an index entry in which the indexed text and the index
 entry are different, by separating the two with a vertical bar:
 
 =begin code :allow<B> :lang<pod6>
-    An B<X<array|arrays>> is an ordered list of scalars indexed by number,
-    starting with 0. A B<X<hash|hashes>> is an unordered collection of
-    scalar values indexed by their associated string key.
+An B<X<array|arrays>> is an ordered list of scalars indexed by number,
+starting with 0. A B<X<hash|hashes>> is an unordered collection of
+scalar values indexed by their associated string key.
 =end code
 
 In the two-part form, the index entry comes after the bar and is
@@ -707,50 +721,52 @@ You can specify hierarchical index entries by separating indexing levels
 with commas:
 
 =begin code :allow<B> :lang<pod6>
-    An X<array|B<arrays, definition of>> is an ordered list of scalars
-    indexed by number, starting with 0. A X<hash|B<hashes, definition of>>
-    is an unordered collection of scalar values indexed by their
-    associated string key.
+An X<array|B<arrays, definition of>> is an ordered list of scalars
+indexed by number, starting with 0. A X<hash|B<hashes, definition of>>
+is an unordered collection of scalar values indexed by their
+associated string key.
 =end code
 
 You can specify two or more entries for a single indexed text, by separating
 the entries with semicolons:
 
 =begin code :allow<B> :lang<pod6>
-    A X<hash|B<hashes, definition of; associative arrays>>
-    is an unordered collection of scalar values indexed by their
-    associated string key.
+A X<hash|B<hashes, definition of; associative arrays>>
+is an unordered collection of scalar values indexed by their
+associated string key.
 =end code
 
 The indexed text can be empty, creating a "zero-width" index entry:
 
 =begin code :allow<B> :lang<pod6>
-    B<X<|puns, deliberate>>This is called the "Orcish Maneuver"
-    because you "OR" the "cache".
+B<X<|puns, deliberate>>This is called the "Orcish Maneuver"
+because you "OR" the "cache".
 =end code
 
 =head1 Rendering Pod
 
 =head2 HTML
 
-In order to generate HTML from Pod, you need the L<Pod::To::HTML module|https://github.com/perl6/Pod-To-HTML>.
+In order to generate HTML from Pod, you need the
+L<Pod::To::HTML module|https://github.com/perl6/Pod-To-HTML>.
 
 If it is not already installed, install it by running the following command:
 C<zef install Pod::To::HTML>
 
-Using the terminal run the following command:
+Once installed, run the following command in the terminal:
 =begin code :lang<shell>
 perl6 --doc=HTML input.pod6 > output.html
 =end code
 
 =head2 Markdown
 
-In order to generate Markdown from Pod, you need the L<Pod::To::Markdown module|https://github.com/softmoth/perl6-pod-to-markdown>.
+In order to generate Markdown from Pod, you need
+the L<Pod::To::Markdown module|https://github.com/softmoth/perl6-pod-to-markdown>.
 
 If it is not already installed, install it by running the following command:
 C<zef install Pod::To::Markdown>
 
-Using the terminal run the following command:
+Once installed, run the following command in the terminal:
 =begin code :lang<shell>
 perl6 --doc=Markdown input.pod6 > output.md
 =end code
@@ -776,8 +792,7 @@ traditional Unix command line "--man" option to your program with a
 multi MAIN subroutine like this:
 
 =begin code
-multi MAIN(Bool :$man)
-{
+multi MAIN(Bool :$man) {
     run $*EXECUTABLE, '--doc', $*PROGRAM;
 }
 =end code
@@ -786,9 +801,9 @@ Now C<myprogram --man> will output your Pod rendered as a man page.
 
 =head1 Accessing Pod
 
-In order to access Pod documentation from within a Perl 6 program
-it is required to use the special C<=> twigil, as documented
-in the L<variables section|/language/variables#The_=_twigil>.
+In order to access Pod documentation from within a Perl 6 program the
+special C<=> twigil, as documented
+in the L<variables section|/language/variables#The_=_twigil>, must be used.
 
 The C<=> twigil provides the introspection over the Pod structure,
 providing a L<Pod::Block|/type/Pod::Block> tree root from which it is possible


### PR DESCRIPTION
101-basics.pod6, classtut.pod6, intro.pod6, objects.pod6 and pod.pod6

Changes include minor rewording, text reflow, move from indentation to sample codes wrapped with `=code` directives, etc.


<!--
## The problem


## Solution provided


    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
