### PR TITLE
Correct all methods' signatures in Metamodel::EnumHOW's page

### DIFF
--- a/doc/Type/Metamodel/EnumHOW.pod6
+++ b/doc/Type/Metamodel/EnumHOW.pod6
@@ -34,13 +34,13 @@ of the language specification.
 
 =head2 method add_enum_value
 
-    method add_enum_value(Metamodel::ClassHOW:D: $obj, $value)
+    method add_enum_value($obj, $value)
 
 Adds a value to this enum.
 
 =head2 method enum_values
 
-    method enum_values(Metamodel::ClassHOW:D: $obj)
+    method enum_values($obj)
 
 Returns the values for the enum.
 
@@ -49,7 +49,7 @@ Returns the values for the enum.
 
 =head2 method elems
 
-    method elems(Metamodel::ClassHOW:D: $obj)
+    method elems($obj)
 
 Returns the number of values.
 
@@ -58,7 +58,7 @@ Returns the number of values.
 
 =head2 method enum_from_value
 
-    method enum_from_value(Metamodel::ClassHOW:D: $obj, $value)
+    method enum_from_value($obj, $value)
 
 Given a value of the enum's base type, return the corresponding enum.
 
@@ -67,7 +67,7 @@ Given a value of the enum's base type, return the corresponding enum.
 
 =head2 method enum_value_list
 
-    method enum_value_list(Metamodel::ClassHOW:D: $obj)
+    method enum_value_list($obj)
 
 Returns a list of the enum values.
 


### PR DESCRIPTION
None of its methods actually specify what type the object the method is
called on must be.

I just want to make sure this matches how the rest of the docs' signatures are written before pushing.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
