### PR TITLE
Proofread several documents

### DIFF
--- a/doc/Language/glossary.pod6
+++ b/doc/Language/glossary.pod6
@@ -8,7 +8,7 @@ X<|Abstract Class>
 =head1 Abstract class
 
 The generic Computer Science term "abstract class" defines the
-L<interface|#Interface> or L<API|#API> of a class.  In Perl 6, this is
+L<interface|#Interface> or L<API|#API> of a class. In Perl 6, this is
 implemented using L<roles|#Roles> with L<stubbed|#Stub> methods.
 
     role Canine {
@@ -29,7 +29,7 @@ L<https://perl6advent.wordpress.com>.
 =head1 Adverb
 X<|Adverb>
 
-Generically, an adverb is a named argument to a function.  There are
+Generically, an adverb is a named argument to a function. There are
 also some specific syntax forms that allow adverbs to be tucked into
 some convenient places:
 
@@ -44,7 +44,7 @@ reason colon pair notation is also known as the adverbial pair form:
     :a(4)          # Same as "a" => 4
 
 Some other forms that use a colon in ways that have adverb-like
-semantics are called adverbial forms.  One special form starts with an
+semantics are called adverbial forms. One special form starts with an
 integer value, followed by a name (for the key):
 
     :20seconds     # same as seconds => 20
@@ -54,8 +54,8 @@ Also see L<#Colon pair and colon list>.
 X<|Adverbial Pair>
 =head1 Adverbial pair
 
-A generalized form of C<pair notation>.  They all start with the colon,
-like:
+A generalized form of C<pair notation>. They all start with the colon,
+as shown in the following examples:
 
 =begin table
   adverbial pair  | pair notation
@@ -139,7 +139,7 @@ X<|API>
 
 Application Programming Interface. Ideally, someone using your system or
 library should be able to do so with knowledge only of the API, but not
-necessarily knowing anything about the internals or implementation.
+necessarily knowing anything about the internals or the implementation details.
 
 See also L<#Abstract class>.
 
@@ -147,8 +147,8 @@ X<|Apocalypse>
 =head1 Apocalypse
 
 A document originally written by L<#TimToady>, in which he processed the
-initial barrage of RFCs that came out of the Perl community.  Now only kept
-as a historical document for reference.  See also L<#Exegesis> and
+initial barrage of RFCs that came out of the Perl community. Now only kept
+as a historical document for reference. See also L<#Exegesis> and
 L<#Synopsis>.
 
 X<|Arity>
@@ -157,12 +157,12 @@ X<|Arity>
 The number of L<positional|/type/Positional> operands expected by an
 L<operator|#Operator>, subroutine, method or callable block.
 
-    =begin code :preamble<class Foo {}>
-    sub infix:<+>(Foo $a, Foo $b) { $a.Int + $b.Int }  # arity of "+" is 2
-    sub frobnicate($x) { ... }                         # arity of 1
-    sub the-answer() { 42 }                            # arity of 0
-    -> $key, $value { ... }                     # arity of 2
-    =end code
+=begin code :preamble<class Foo {}>
+sub infix:<+>(Foo $a, Foo $b) { $a.Int + $b.Int }  # arity of "+" is 2
+sub frobnicate($x) { ... }                         # arity of 1
+sub the-answer() { 42 }                            # arity of 0
+-> $key, $value { ... }                            # arity of 2
+=end code
 
 The arity of a C<Callable> is one of the main selectors in
 L<multi-dispatch|#Multi-dispatch>.
@@ -178,7 +178,7 @@ Remove the link when “Texas” goes completely out of use.
 The ASCII variant of a non-ASCII Unicode L<operator|#Operator> or
 L<symbol|#Symbol>.
 For instance, C<(elem)> corresponds to the C<∈> ("Is this an element of
-that set?") operator that comes from set theory.  ASCII operators are a
+that set?") operator that comes from set theory. ASCII operators are a
 workaround to the problem that people don't know how to type Unicode yet.
 Culturally, while we encourage people to use the Unicode symbols in a
 vague sort of way, we do not disparage the use of the
@@ -189,19 +189,19 @@ Well, maybe just a little...
 X<|Autothreading>
 
 Autothreading is what happens if you pass a L<Junction|/type/Junction> to
-a subroutine that expects a parameter of type L<Any|/type/Any> or a subtype thereof
-(such as anything L<Cool|/type/Cool>). The call is then executed for each
-value of the junction. The result of these calls is assembled in a new
+a subroutine that expects a parameter of type L<Any|/type/Any> or a subtype
+thereof (such as anything L<Cool|/type/Cool>). The call is then executed for
+each value of the junction. The result of these calls is assembled in a new
 junction of the same type as the original junction.
 
     sub f($x) { 2 * $x };
     say f(1|2|3) == 4;    # OUTPUT: «any(False, True, False)␤»
 
 Here C<f()> is a sub with one parameter, and since it has no explicit type,
-it is implicitly typed as C<Any>.  The C<Junction> argument causes the
+it is implicitly typed as C<Any>. The C<Junction> argument causes the
 C<f(1|2|3)> call to be internally executed as C<f(1)|f(2)|f(3)>, and the
-resulting junction is C<2|4|6>.  These are then all compared to C<4>,
-resulting in a junction C<False|True|False>.  This process of separating
+resulting junction is C<2|4|6>. These are then all compared to C<4>,
+resulting in a junction C<False|True|False>. This process of separating
 junction arguments into multiple calls to a function is called
 I<autothreading>.
 
@@ -222,7 +222,8 @@ Backtracking is the default way a regexp is matched. The engine
 is allowed to explore several ways moving backward in the string
 characters in order to allow every piece of a regexp
 to match something.
-For more information see L<Regexp Backtracking section|/language/regexes#Backtracking>.
+For more information, see
+L<Regexp Backtracking section|/language/regexes#Backtracking>.
 
 =head1 binder
 
@@ -234,7 +235,9 @@ I<binder>.
 =head1 block
 X<|block>
 
-L<Blocks|/type/Block> are code object with its own lexical scope, which allows them to define variables without interfering with other in the containing block.
+L<Blocks|/type/Block> are code object with its own lexical scope, which
+allows them to define variables without interfering with other in the
+containing block.
 
 =head1 bytecode
 X<|bytecode>
@@ -256,14 +259,16 @@ A butterfly image intended primarily to represent Perl 6, The Language.
 X<|Colon Pair> X<|Colon List>
 
 A colon pair is a shorthand syntax used to create or visually present
-a L<Pair|/type/Pair> object.  The two most common forms are:
+a L<Pair|/type/Pair> object. The two most common forms are:
 
     :a(4)          # Same as "a" => 4,   same as Pair.new("a", 4)
     :a<4>          # Same as "a" => "4", same as Pair.new("a", val("4"))
 
-This is also known as the adverbial pair form.  Note: when the part after
-the colon and before the balanced delimiters is not a legal identifier, other
-semantics apply, not all of which produce Pair objects.
+This is also known as the adverbial pair form.
+
+B<Note>: when the part after the colon and before the balanced delimiters is
+not a legal identifier, other semantics apply, not all of which produce
+C<Pair> objects.
 
 Two other common forms are:
 
@@ -306,20 +311,21 @@ X<|decont>
 
 Short for "decontainerize", meaning to remove an item
 L<from its C«Scalar» container|/language/containers>, often to obtain
-L<a different behavior|https://perl6advent.wordpress.com/2017/12/02/#theoneandonly> for items that have it.
+L<a different behavior|https://perl6advent.wordpress.com/2017/12/02/#theoneandonly>
+for items that have it.
 
 =head1 diffy
 X<|diffy>
 
 See L<operator|#Operator>. It means the type of the operator result is
-sufficiently different from its arguments that op= makes little sense
+sufficiently different from its arguments that op= makes little sense.
 
 =head1 Exegesis
 X<|Exegesis>
 
 A document originally written by L<#TheDamian>, in which he tried to explain
-the L<Apocalypses|#Apocalypse> to the common (wo)man.  Now only kept as an
-historical document for reference.  See also L<#Synopsis>.
+the L<Apocalypses|#Apocalypse> to the common (wo)man. Now only kept as an
+historical document for reference. See also L<#Synopsis>.
 
 =head1 fiddly
 X<|fiddly>
@@ -330,8 +336,8 @@ Too complicated to apply a meta-op to. See L<operator|#Operator>.
 
 A handle is a data structure used to store information about some
 input/output operation such as file or socket reading or writing. Perl 6
-uses L<IO::Handle|/type/IO::Handle> as a base class for filehandles, and L<IO::Socket|/type/IO::Socket>
-for sockets.
+uses L<IO::Handle|/type/IO::Handle> as a base class for filehandles,
+and L<IO::Socket|/type/IO::Socket> for sockets.
 
 =head1 Huffmanize
 
@@ -343,22 +349,25 @@ is necessary to easily be reminded of what the rarely-used feature does.
 
 For example, printing output is a common task, while performing
 thread-safe atomic addition on native atomicity-safe integers is much less so.
-There's a need to "huffmanize" the task printing and that's why you can do it by
-just typing three letters L<put|/routine/put>. But there's no need to "huffmanize" the
-rarely-needed atomic operators, which is why you type the lengthier
-names, such as L<atomic-inc-fetch|/routine/atomic-inc-fetch>. L<put|/routine/put> is a bit of a vague name, but because
-it's commonly used, it's easy to learn what it does. L<atomic-inc-fetch|/routine/atomic-inc-fetch>,
-on the other hand is rarer, and the more descriptive name helps recall
-its purpose better.
+There's a need to "huffmanize" the task printing and that's why you can do it
+by just typing three letters L<put|/routine/put>. But there's no need to
+"huffmanize" the rarely-needed atomic operators, which is why you type the
+lengthier names, such as L<atomic-inc-fetch|/routine/atomic-inc-fetch>. The
+name L<put|/routine/put> is a bit vague, but because
+it's commonly used, it's easy to learn what it does. On the other hand,
+the name L<atomic-inc-fetch|/routine/atomic-inc-fetch> is rarer,
+and the more descriptive name helps recall its purpose better.
 
 X<|iffy>
 =head1 iffy
 
-Often used as a boolean value. See L<operator|#Operator>. Made via the L<C<use> keyword|/language/5to6-nutshell#index-entry-import>.
+Often used as a boolean value. See L<operator|#Operator>. Made via
+the L<C<use> keyword|/language/modules#index-entry-use>.
 
 =head1 import
 
 Include functions from a module in the current namespace.
+
 X<|instance>
 =head1 Instance
 
@@ -403,7 +412,7 @@ latter refers to the I<scope>.
 =head1 IRC
 X<|IRC>
 
-Internet Relay Chat.  Perl 6 developers and users usually hang out on
+Internet Relay Chat. Perl 6 developers and users usually hang out on
 the C<#perl6> channel of C<irc.freenode.org>. This channel is also
 populated by a host of friendly bots that allow you to interact with
 Perl 6 and its codebase, as well as send delayed messages and other
@@ -429,7 +438,7 @@ know, and I don't care."
 X<|backlog>
 =head2 backlog
 
-That part of a discussion on an L<#IRC> channel that you've missed.  If it is
+That part of a discussion on an L<#IRC> channel that you've missed. If it is
 not or no longer available in your IRC client, you can go to sites such as
 L<http://colabti.org/irclogger/irclogger_logs/perl6> to see what has been logged
 for you.
@@ -446,14 +455,15 @@ X<|compunit (glossary)>
 X<|compilation unit>
 =head2 Compilation unit or I<compunit>
 
-A compunit is L<a piece of Perl 6 code that is analyzed and compiled as a single unit|https://github.com/rakudo/rakudo/blob/master/docs/module_management.md>.
+A compunit is L<a piece of Perl 6 code that is analyzed and compiled as a
+single unit|https://github.com/rakudo/rakudo/blob/master/docs/module_management.md>.
 Typically, this piece of code will be contained in a single file, but code
 inside an L<EVAL|/routine/EVAL> is also considered a compunit.
 
 =head2 DWIM
 X<|DWIM>
 
-I<Do What I Mean>.  A programming language designer motto.
+I<Do What I Mean>. A programming language designer motto.
 The opposite of a DWIM is a L<#WAT>.
 
 =head2 flap
@@ -483,7 +493,7 @@ X<|gradual typing>
 
 You don't have to specify types of variables and parameters, but if you do,
 it helps in early determination of impossible dispatches and better
-optimization.  See also L<https://en.wikipedia.org/wiki/Gradual_typing>.
+optimization. See also L<https://en.wikipedia.org/wiki/Gradual_typing>.
 
 =head2 IIRC
 X<|IIRC>
@@ -503,7 +513,7 @@ It Would Be Nice
 =head2 LHF
 X<|LHF>
 
-Low Hanging Fruit.  Usually used in the context of a (relatively) simple
+Low Hanging Fruit. Usually used in the context of a (relatively) simple
 task to be performed by a (relative) newbie.
 
 =head2 LGTM
@@ -514,7 +524,7 @@ Looks Good To Me
 =head2 LTA
 X<|LTA>
 
-Less Than Awesome.  Usually used in the context of an error message that
+Less Than Awesome. Usually used in the context of an error message that
 is rather non-descriptive or unrelated to the actual error.
 
 =head2 NST
@@ -531,7 +541,7 @@ L<spesh|#Spesh> or JIT.
 =head2 PB
 X<|PB>
 
-Short for "problem".  As in "that's not the pb".
+Short for "problem". As in "that's not the pb".
 
 =head2 PR
 X<|PR>
@@ -556,8 +566,8 @@ Real Soon Now.
 =head2 RT
 X<|RT>
 
-Request Tracker (L<https://rt.perl.org/>).  The place where all the bugs
-related to L<#Rakudo> used to live.  Nowadays, the Github issue tracker of
+Request Tracker (L<https://rt.perl.org/>). The place where all the bugs
+related to L<#Rakudo> used to live. Nowadays, the Github issue tracker of
 the rakudo/rakudo repository is used for that.
 
 =head2 TIMTOWTDI
@@ -599,7 +609,7 @@ Wikipedia
 =head2 WW
 X<|WW>
 
-Short for C<wrong window>.  When on L<#IRC>, someone types something in
+Short for C<wrong window>. When on L<#IRC>, someone types something in
 a channel that was intended for another channel, or for a private
 message.
 
@@ -611,8 +621,8 @@ See also L<https://en.wikipedia.org/wiki/Larry_Wall>.
 =head1 Lexing
 X<|Lexing>
 
-Performing L<lexical analysis|https://en.wikipedia.org/wiki/Lexical_analysis>, a
-step which usually precedes parsing.
+Performing L<lexical analysis|https://en.wikipedia.org/wiki/Lexical_analysis>,
+a step which usually precedes parsing.
 
 =head1 Literal
 X<|Literal>
@@ -624,7 +634,8 @@ object and also refers to the object itself.
     say $x;         # $x is not a literal, but a variable
     my $s = "Foo";  # the "Foo" is a literal, the $s is a variable
 
-Different types of literals are described in L<the syntax document|/language/syntax#Literals>.
+Different types of literals are described in
+L<the syntax document|/language/syntax#Literals>.
 
 X<|LHS>
 =head1 LHS
@@ -639,7 +650,7 @@ something behaves as a LHS it means that it can be read and written to.
 X<|Value>
 
 An I<lvalue>, or a I<left value>, is anything that can appear on the
-left-hand side of the assignment operator C<=>.  It is anything you
+left-hand side of the assignment operator C<=>. It is anything you
 can assign to.
 
 Typical lvalues are variables, private and C<is rw> attributes, lists of
@@ -682,25 +693,25 @@ sub f {
 f();          # in mainline again
 
 You can also have the mainline of any package-like declarator, such as
-class, L<module|/language/modules>, L<grammar|/language/grammars>, etc.  These are
-typically run just after the class/module/grammar have been compiled (or
-when loaded from a precompiled file).
+class, L<module|/language/modules>, L<grammar|/language/grammars>, etc.
+These are typically run just after the class/module/grammar have been compiled
+(or when loaded from a precompiled file).
 
 X<|Mayspec>
 =head1 Mayspec
 
 Stands for "Maybe Specification". Usually refers to existing tests in the
 L<language specification|https://github.com/perl6/roast/>. The speaker
-is indicating they did not check whether the test is a spectest or a propspec test;
-i.e. whether the test is included in a released language specification or is a
-new test, proposed for the next version of the spec.
+is indicating they did not check whether the test is a spectest or a propspec
+test; i.e. whether the test is included in a released language specification
+or is a new test, proposed for the next version of the spec.
 
 =head1 MoarVM
 X<|MoarVM>
 
 MoarVM is short for Metamodel On A Runtime Virtual Machine.
-It's a virtual machine designed specifically for L<#NQP> and its L<MOP|/language/mop>:
-L<#6model>.  A document about
+It's a virtual machine designed specifically for L<#NQP> and
+its L<MOP|/language/mop>: L<#6model>. A document about
 L<the purpose of MoarVM|https://github.com/MoarVM/MoarVM/blob/master/docs/reveal.md>.
 MoarVM has some similarities with the Hotspot VM so you may peruse its
 L<glossary|http://openjdk.java.net/groups/hotspot/docs/HotSpotGlossary.html>
@@ -709,10 +720,11 @@ for entries missing from the present one.
 X<|Multi-Dispatch>X<|MMD>
 =head1 Multi-dispatch
 
-The process of picking a candidate for calling of a set of L<methods|/type/Method> or L<subs|/type/Sub> that
-come by the same name but with different arguments. The most narrow candidate
-wins. In case of an ambiguity, a routine with C<is default> trait will be
-chosen if one exists, otherwise an exception is thrown.
+The process of picking a candidate for calling of a set
+of L<methods|/type/Method> or L<subs|/type/Sub> that
+come by the same name but with different arguments. The most narrow
+candidate wins. In case of an ambiguity, a routine with C<is default> trait
+will be chosen if one exists, otherwise an exception is thrown.
 
 =head1 multi-method
 X<|multi-method>
@@ -730,7 +742,7 @@ and an explanation of how NFG works in L<this IRC log|https://colabti.org/irclog
 =head1 Niecza
 X<|Niecza>
 
-An implementation of Perl 6 targeting the .NET platform.  No longer actively
+An implementation of Perl 6 targeting the .NET platform. No longer actively
 maintained.
 
 =head1 Not Quite Perl
@@ -742,9 +754,9 @@ See L<#NQP>.
 X<|Not Quite Perl>
 
 NQP is a primitive language for writing subroutines and methods using a
-subset of the Perl 6 syntax.  It's not intended to be a full-fledged
+subset of the Perl 6 syntax. It's not intended to be a full-fledged
 programming language, nor does it provide a runtime environment beyond
-the basic VM primitives.  Compilers (such as L<#Rakudo>) typically use
+the basic VM primitives. Compilers (such as L<#Rakudo>) typically use
 NQP to compile action methods that convert a parse tree
 into its equivalent abstract syntax tree representation.
 
@@ -756,7 +768,10 @@ Not Yet Implemented
 =head1 opcode
 X<|opcode>
 
-An opcode, or operation code, is a bytecode operation, that is, a command of the language actually used on the virtual machine. They are not usually intended for human consumption, but they are usually specified somewhere, like L<this document for MoarVM|https://github.com/MoarVM/MoarVM/blob/master/docs/bytecode.markdown>.
+An opcode, or operation code, is a bytecode operation, that is, a command of
+the language actually used on the virtual machine. They are not usually
+intended for human consumption, but they are usually specified somewhere,
+like L<this document for MoarVM|https://github.com/MoarVM/MoarVM/blob/master/docs/bytecode.markdown>.
 
 =head1 Operator
 X<|Operator>
@@ -767,15 +782,15 @@ Operators are an alternative syntax for a L<#multi-method>. With that
 syntax, what would be the arguments of the function are named
 operands instead. Operators are classified into
 L<categories|https://design.perl6.org/S02.html#Grammatical_Categories> of
-categories.  A category has a precedence, an arity, and can be L<#fiddly>,
-L<#iffy>, L<#diffy>.  Perl 6 is very creative as to what is an operator, so
-there are many categories.  Operators are made of many tokens, possibly with
-a subexpression.  For example, C<@a[0]> belongs to the postcircumfix
+categories. A category has a precedence, an arity, and can be L<#fiddly>,
+L<#iffy>, L<#diffy>. Perl 6 is very creative as to what is an operator, so
+there are many categories. Operators are made of many tokens, possibly with
+a subexpression. For example, C<@a[0]> belongs to the postcircumfix
 category, is broken into the operand C<@a> and the postcircumfix operator
 C<[0]> where C<0> is the postcircumfixed subexpression.
 
 The C<< <O(I<...>)>  >> construction gives information about an operator
-that completes the information provided by its category.  Below
+that completes the information provided by its category. Below
 C<%conditional> is the category, C<< :reducecheck<ternary> >>, which
 specifies calling C<.ternary> to post-process the L<parse subtree|#Parse_tree>
 and C<< :pasttype<if> >> specifies the NQP L<#opcode> generated in the
@@ -787,7 +802,10 @@ AST from the parse subtree.
 =head1 Parse tree
 X<|Parse Tree>
 
-A L<parse tree|https://en.wikipedia.org/wiki/Parse_tree> represents the structure of a string or sentence according to a grammar. L<Grammar|/type/Grammar>s in Perl 6 output parse trees when they successfully match a string.
+A L<parse tree|https://en.wikipedia.org/wiki/Parse_tree> represents the
+structure of a string or sentence according to a grammar.
+L<Grammar|/type/Grammar>s in Perl 6 output parse trees when they successfully
+match a string.
 
 =head1 Parameter
 X<|Parameter>
@@ -804,7 +822,7 @@ subroutine/method/callable block.
 X<|Parrot>
 
 A L<virtual machine|#Virtual_machine> designed to run Perl 6 and other
-dynamic languages.  No longer actively maintained.
+dynamic languages. No longer actively maintained.
 
 =head1 PAST
 X<|PAST>
@@ -865,14 +883,17 @@ character.
 X<|pugs>
 =head1 pugs
 
-L<pugs|https://en.wikipedia.org/wiki/Pugs> was one of the first interpreters/compilers written for Perl 6. It was written in Haskell by Audrey Tang.
+L<pugs|https://en.wikipedia.org/wiki/Pugs> was one of the first
+interpreters/compilers written for Perl 6. It was written in Haskell
+by Audrey Tang.
 
 X<|p6y>
 =head1 p6y
 
 Retronym for the "Perl 6 way" of doing things, as in idiomatic
 expressions or definitions. First known use with this meaning by
-L<C<sorear> in the C<#perl6> IRC channel in 2010|https://colabti.org/irclogger/irclogger_log/perl6?date=2010-03-12#l177>.
+L<C<sorear> in the C<#perl6> IRC channel in
+2010|https://colabti.org/irclogger/irclogger_log/perl6?date=2010-03-12#l177>.
 
 X<|QAST>
 =head1 QAST
@@ -889,8 +910,8 @@ X<|Rakudo>
 =head1 Rakudo
 
 Rakudo is the name of a Perl 6 implementation that runs on L<#MoarVM> and
-the JVM.  It is an abbreviation of C<Rakuda-do>, which, when translated
-from Japanese, means "The Way of the Camel".  Also, in Japanese, "Rakudo"
+the JVM. It is an abbreviation of C<Rakuda-do>, which, when translated
+from Japanese, means "The Way of the Camel". Also, in Japanese, "Rakudo"
 means "Paradise."
 
 X<|Reify>
@@ -930,8 +951,8 @@ X<|roast>
 =head1 roast
 
 The Perl 6 L<specification tests|#test suite>, which live here:
-L<https://github.com/perl6/roast/>.  Originally developed for L<#pugs>,
-it now serves all Perl 6 implementations.  Why roast? It's the
+L<https://github.com/perl6/roast/>. Originally developed for L<#pugs>,
+it now serves all Perl 6 implementations. Why roast? It's the
 B<r>epository B<o>f B<a>ll B<s>pec B<t>ests.
 
 X<|role>
@@ -956,7 +977,7 @@ X<|rule>
 =head1 rvalue
 X<|rvalue>
 
-A value that can be used on the right-hand side of an assignment.  See also
+A value that can be used on the right-hand side of an assignment. See also
 L<#lvalue>.
 
 =head1 X<SAP>
@@ -979,10 +1000,10 @@ C<@array[1][3][5]>.
 =head1 Sigil
 X<|Sigil>
 
-In Perl, the sigil is the first character of a variable name.  It must
+In Perl, the sigil is the first character of a variable name. It must
 be either $, @, %, or & respectively for a L<scalar|/type/Scalar>,
 L<array|/type/Array>, L<hash|/type/Hash>, or L<code|/type/Code>
-variable.  See also Twigil and role. Also sigiled variables allow short
+variable. See also Twigil and role. Also sigiled variables allow short
 conventions for L<variable interpolation|#Variable_interpolation> in a
 double quoted string, or even postcircumfix expressions starting with
 such a variable.
@@ -990,8 +1011,8 @@ such a variable.
 =head1 Sigilless variable
 X<|Sigilless Variable>
 
-L<Sigilless variables|/language/variables#index-entry-\_(sigilless_variables)> are
-actually aliases to the value it is assigned to them, since they are not
+L<Sigilless variables|/language/variables#index-entry-\_(sigilless_variables)>
+are actually aliases to the value it is assigned to them, since they are not
 containers. Once you assign a sigilless variable (using the escape
 C<\>), its value cannot be changed.
 
@@ -1029,14 +1050,14 @@ X<|Symbol>
 Fancy alternative way to denote a name. Generally used in the context of
 L<module|/language/modules>s linking, be it in the OS level, or at the
 Perl 6 L<#Virtual_machine> level for modules generated from languages
-targeting these VMs.  The set of imported or exported symbols is called
+targeting these VMs. The set of imported or exported symbols is called
 the symbol table.
 
 =head1 Synopsis
 X<|Synopsis>
 
-The current human-readable description of the Perl 6 language.  Still in
-development.  Much more a community effort than the
+The current human-readable description of the Perl 6 language. Still in
+development. Much more a community effort than the
 L<Apocalypses|#Apocalypse> and L<Exegeses|#Exegesis> were. The current
 state of the language is reflected by L<#roast>, its L<#test suite>, not
 the synopses where speculative material is not always so flagged or more
@@ -1069,7 +1090,7 @@ the pronunciation of L<#TIMTOWTDI> as a word.
 
 In this context, a L<C<token>|/syntax/token> is a regex that does not backtrack.
 In general, L<tokens|https://en.wikipedia.org/wiki/Lexical_analysis> are
-extracted from the source program while L<#Lexing>.
+extracted from the source program while L<lexing|#Lexing>.
 
 =head1 Thunk
 X<|Thunk>
@@ -1098,7 +1119,7 @@ operators used in an expression.
 X<|twine>
 
 A data structure used to hold a POD string with embedded formatting
-codes.  For example:
+codes. For example:
 
 =begin code
 =begin pod
@@ -1125,15 +1146,15 @@ one simple string.>
 A
 L<type object|/language/classtut#index-entry-type_object>
 is an object that is used to represent a type or a class. Since in
-object oriented programming everything is an object, classes are objects
-too, which inherit from the ur-class which, in our case, is L<Mu|/type/Mu>.
+object oriented programming everything is an object, classes are
+objects too, and they inherit from L<Mu|/type/Mu>.
 
 =head1 value
 X<|value>
 
 A value is what is actually contained in a container such as a variable.
-Used in expressions such as L<lvalue|/language/glossary#lvalue>, to indicate that that particular
-container can be assigned to.
+Used in expressions such as L<lvalue|/language/glossary#lvalue>, to
+indicate that that particular container can be assigned to.
 
 =head1 UB
 X<|UB>
@@ -1211,8 +1232,8 @@ L<double q|/language/quoting#Interpolation:_qq> quoting constructs.
 X<|Virtual Machine>
 
 A virtual machine is the Perl compiler entity that executes the
-L<bytecode|#bytecode>.  It can optimize the bytecode or generate machine code
-Just in Time.  Examples are L<#MoarVM>, L<#Parrot> (who are intended to run
+L<bytecode|#bytecode>. It can optimize the bytecode or generate machine code
+Just in Time. Examples are L<#MoarVM>, L<#Parrot> (who are intended to run
 Perl 6) and more generic virtual machines such as JVM and Javascript.
 
 =head2 WAT
@@ -1231,10 +1252,9 @@ example is the space character « ».
 =head1 6model
 X<|6model>
 
-C<6model> is used in the L<MoarVM|/language/glossary#MoarVM>, and provides primitives used to
-create an object system. It is described in
-L<this presentation by Jonathan Worthington|https://jnthn.net/papers/2013-yapceu-moarvm.pdf>
-and implemented
+C<6model> is used in the L<MoarVM|/language/glossary#MoarVM>, and provides
+primitives used to create an object system. It is described in
+L<this presentation by Jonathan Worthington|https://jnthn.net/papers/2013-yapceu-moarvm.pdf> and implemented
 L<here in MoarVM|https://github.com/MoarVM/MoarVM/tree/master/src/6model>.
 
 =end pod

--- a/doc/Language/newline.pod6
+++ b/doc/Language/newline.pod6
@@ -42,9 +42,10 @@ C<:nl-out> attribute when you create that handle.
     $crlf-out.say: 1; #OUTPUT: «1\␤␍»
 
 In this example, where we are replicating standard output to a new handle by
-using L<IO::Special|/type/IO::Special>, we are appending a C<\> to the end of the string, followed
-by a newline C<␤> and a carriage return C<␍>; everything we print to that handle
-will get those characters at the end of the line, as shown.
+using L<IO::Special|/type/IO::Special>, we are appending a C<\> to the end of
+the string, followed by a newline C<␤> and a carriage return C<␍>; everything
+we print to that handle will get those characters at the end of the line,
+as shown.
 
 In regular expressions,
 L<C<\n>|/language/regexes#index-entry-regex_\n-regex_\N-\n_and_\N> is defined in

--- a/doc/Language/quoting.pod6
+++ b/doc/Language/quoting.pod6
@@ -21,7 +21,7 @@ B<Q ^>Almost any non-word character can be a delimiter!B<^>
 B<Q ｢｢>Delimiters can be repeated/nested if they are adjacent.B<｣｣>
 
 Delimiters can be nested, but in the plain C<Q> form, backslash escapes
-aren't allowed.  In other words, basic C<Q> strings are as literal as
+aren't allowed. In other words, basic C<Q> strings are as literal as
 possible.
 
 Some delimiters are not allowed immediately after C<Q>, C<q>, or C<qq>. Any
@@ -48,12 +48,12 @@ Q{This is still a closing curly brace → B<\>}
 
 These examples produce:
 
-    =begin code :solo
-    this is fine, because of space after Q
-    and so is this
-    Make sure you <match> opening and closing delimiters
-    This is still a closing curly brace → \
-    =end code
+=begin code :solo
+this is fine, because of space after Q
+and so is this
+Make sure you <match> opening and closing delimiters
+This is still a closing curly brace → \
+=end code
 
 X<|:x (quoting adverb)>X<|:exec (quoting adverb)>X<|:w (quoting adverb)>X<|:words (quoting adverb)>X<|:ww (quoting adverb)>X<|:quotewords (quoting adverb)>X<|:q (quoting adverb)>X<|:single (quoting adverb)>X<|:qq (quoting adverb)>X<|:double (quoting adverb)>X<|:s (quoting adverb)>X<|:scalar (quoting adverb)>X<|:a (quoting adverb)>X<|:array (quoting adverb)>X<|:h (quoting adverb)>X<|:hash (quoting adverb)>X<|:f (quoting adverb)>X<|:function (quoting adverb)>X<|:c (quoting adverb)>X<|:closure (quoting adverb)>X<|:b (quoting adverb)>X<|:backslash (quoting adverb)>X<|:to (quoting adverb)>X<|:heredoc (quoting adverb)>X<|:v (quoting adverb)>X<|:val (quoting adverb)>
 
@@ -184,7 +184,7 @@ say "@neighborsB<[]> and I try our best to coexist peacefully."
 Felix Danielle Lucinda and I try our best to coexist peacefully.
 =end code
 
-Often a method call is more appropriate.  These are allowed within C<qq>
+Often a method call is more appropriate. These are allowed within C<qq>
 quotes as long as they have parentheses after the call. Thus the following
 code will work:
 
@@ -198,7 +198,7 @@ Felix, Danielle, Lucinda and I try our best to coexist peacefully.
 
 However, C<"@example.com"> produces C<@example.com>.
 
-To call a subroutine use the C<&>-sigil.
+To call a subroutine, use the C<&>-sigil.
 X<|& (interpolation)>
 
     say "abc&uc("def")ghi";
@@ -210,7 +210,7 @@ interpolated as well.
     my %h = :1st; say "abc%h<st>ghi";
     # OUTPUT: «abc1ghi␤»
 
-To enter unicode sequences use C<\x> or C<\x[]> with the hex-code of the
+To enter unicode sequences, use C<\x> or C<\x[]> with the hex-code of the
 character or a list of characters.
 
     my $s = "I \x2665 Perl 6!";
@@ -221,7 +221,8 @@ character or a list of characters.
     say $s;
     # OUTPUT: «I really ♡♥❤💕 Perl 6!␤»
 
-You can also use L«unicode names|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences»
+You can also use
+L«unicode names|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences»
 , L<named sequences|/language/unicode#Named_sequences>
 and L<name aliases|/language/unicode#Name_aliases> with L«\c[]|/language/unicode#Entering_unicode_codepoints_and_codepoint_sequences».
 
@@ -233,13 +234,13 @@ Interpolation of undefined values will raise a control exception that can be
 caught in the current block with
 L<CONTROL|/language/phasers#CONTROL>.
 
-    =begin code
-    sub niler {Nil};
-    my Str $a = niler;
-    say("$a.html", "sometext");
-    say "alive"; # this line is dead code
-    CONTROL { .die };
-    =end code
+=begin code
+sub niler {Nil};
+my Str $a = niler;
+say("$a.html", "sometext");
+say "alive"; # this line is dead code
+CONTROL { .die };
+=end code
 
 =head2 Word quoting: qw
 X<|qw word quote>
@@ -250,7 +251,7 @@ B<q:w {> [ ] \{ \} B<}> eqv ('[', ']', '{', '}');
 B<Q:w |> [ ] { } B<|> eqv ('[', ']', '{', '}');
 
 The C<:w> form, usually written as C<qw>, splits the string into
-"words".  In this context, words are defined as sequences of non-whitespace
+"words". In this context, words are defined as sequences of non-whitespace
 characters separated by whitespace. The C<q:w> and C<qw> forms inherit the
 interpolation and escape semantics of the C<q> and single quote string
 delimiters, whereas C<Qw> and C<Q:w> inherit the non-escaping semantics of
@@ -292,22 +293,22 @@ angle brackets around the number, without any extra spaces:
 Compared to C<42/10> and C<1+42i>, there's no division (or addition) operation
 involved. This is useful for literals in routine signatures, for example:
 
-    =begin code
-    sub close-enough-π (<355/113>) {
-        say "Your π is close enough!"
-    }
-    close-enough-π 710/226; # OUTPUT: «Your π is close enough!␤»
-    =end code
+=begin code
+sub close-enough-π (<355/113>) {
+    say "Your π is close enough!"
+}
+close-enough-π 710/226; # OUTPUT: «Your π is close enough!␤»
+=end code
 
-    =begin code :skip-test<illustrates error>
-    # WRONG: can't do this, since it's a division operation
-    sub compilation-failure (355/113) {}
-    =end code
+=begin code :skip-test<illustrates error>
+# WRONG: can't do this, since it's a division operation
+sub compilation-failure (355/113) {}
+=end code
 
 =head2 X<Word quoting with quote protection: qww|quote,qww>
 
-The C<qw> form of word quoting will treat quote characters literally, leaving them in the
-resulting words:
+The C<qw> form of word quoting will treat quote characters literally, leaving
+them in the resulting words:
 
     say qw{"a b" c}.perl; # OUTPUT: «("\"a", "b\"", "c")␤»
 
@@ -337,18 +338,19 @@ Note that variable interpolation happens before word splitting:
 
 =head2 X<<<Word quoting with interpolation and quote protection: qqww|quote,qqww;>>>
 
-The C<qqw> form of word quoting will treat quote characters literally, leaving them in the
-resulting words:
+The C<qqw> form of word quoting will treat quote characters literally,
+leaving them in the resulting words:
 
     my $a = 42; say qqw{"$a b" c}.perl;  # OUTPUT: «("\"42", "b\"", "c")␤»
 
-Thus, if you wish to preserve quoted sub-strings as single items in the resulting words
-you need to use the C<qqww> variant:
+Thus, if you wish to preserve quoted sub-strings as single items in the
+resulting words you need to use the C<qqww> variant:
 
     my $a = 42; say qqww{"$a b" c}.perl; # OUTPUT: «("42 b", "c")␤»
 
-Quote protection happens before interpolation, and interpolation happens before word splitting,
-so quotes coming from inside interpolated variables are just literal quote characters:
+Quote protection happens before interpolation, and interpolation happens
+before word splitting, so quotes coming from inside interpolated variables are
+just literal quote characters:
 
     my $a = "1 2";
     say qqww{"$a" $a}.perl; # OUTPUT: «("1 2", "1", "2")␤»
@@ -380,14 +382,14 @@ I<don't> interpolate variables. Thus
     my $world = "there";
     say qx{echo "hello $world"}
 
-prints simply C<hello>.  Nevertheless, if you have declared an environment
+prints simply C<hello>. Nevertheless, if you have declared an environment
 variable before calling C<perl6>, this will be available within C<qx>, for
 instance
 
-    =begin code :skip-test<REPL>
-    WORLD="there" perl6
-    > say qx{echo "hello $WORLD"}
-    =end code
+=begin code :skip-test<REPL>
+WORLD="there" perl6
+> say qx{echo "hello $WORLD"}
+=end code
 
 will now print C<hello there>.
 
@@ -397,8 +399,8 @@ to a variable for later use:
     my $output = qx{echo "hello!"};
     say $output;    # OUTPUT: «hello!␤»
 
-See also L<shell|/routine/shell>, L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
-other ways to execute external commands.
+See also L<shell|/routine/shell>, L<run|/routine/run> and
+L<Proc::Async|/type/Proc::Async> for other ways to execute external commands.
 
 =head2 X<Shell quoting with interpolation: qqx|quote,qqx>
 
@@ -417,8 +419,8 @@ Again, the output of the external command can be kept in a variable:
     # runs the command: grep -i cool /usr/share/dict/words
     say $output;      # OUTPUT: «Cooley␤Cooley's␤Coolidge␤Coolidge's␤cool␤...»
 
-See also L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for better ways to
-execute external commands.
+See also L<run|/routine/run> and L<Proc::Async|/type/Proc::Async> for
+better ways to execute external commands.
 
 =head2 X<Heredocs: :to|quote,heredocs :to>
 
@@ -444,7 +446,7 @@ TERMINATOR
 =end code
 
 If the terminator is indented, that amount of indention is removed from the
-string literals.  Therefore this heredoc
+string literals. Therefore this heredoc
 
 =begin code
 say q:to/END/;
@@ -466,8 +468,9 @@ some multi line
 
 Heredocs include the newline from before the terminator.
 
-To allow interpolation of variables use the C<qq> form, but you will then have to escape meta characters
-C<{\> as well as C<$> if it is not the sigil for a defined variable.  For example:
+To allow interpolation of variables use the C<qq> form, but you will then have
+to escape meta characters C<{\> as well as C<$> if it is not the sigil for a
+defined variable. For example:
 
   my $f = 'db.7.3.8';
   my $s = qq:to/END/;
@@ -501,17 +504,20 @@ my ($first, $second) = qq:to/END1/, qq:to/END2/;
 
 =head2 Unquoting
 
-Literal strings permit interpolation of embedded quoting constructs by using the escape sequences such as these:
+Literal strings permit interpolation of embedded quoting constructs by using the
+escape sequences such as these:
 
     my $animal="quaggas";
     say 'These animals look like \qq[$animal]'; # OUTPUT: «These animals look like quaggas␤»
     say 'These animals are \qqw[$animal or zebras]'; # OUTPUT: «These animals are quaggas or zebras␤»
 
-In this example, C<\qq> will do double-quoting interpolation, and C<\qqw> word quoting with interpolation. Escaping any other quoting construct as above will act in the same way, allowing interpolation in literal strings.
+In this example, C<\qq> will do double-quoting interpolation, and C<\qqw> word
+quoting with interpolation. Escaping any other quoting construct as above will
+act in the same way, allowing interpolation in literal strings.
 
 =head1 Regexes
 
-For information about quoting as applied in regexes see the L<regular
+For information about quoting as applied in regexes, see the L<regular
 expression documentation|/language/regexes>.
 
 =end pod

--- a/doc/Language/syntax.pod6
+++ b/doc/Language/syntax.pod6
@@ -198,9 +198,9 @@ That says why we do what we do below.
 say "No more";
 =end code
 
-Curly braces inside the comment can be nested, so in C<#`{ a { b } c }>, the comment
-goes until the very end of the string. You may also use multiple curly
-braces, such as C<#`{{ double-curly-brace }}>, which might help
+Curly braces inside the comment can be nested, so in C<#`{ a { b } c }>,
+the comment goes until the very end of the string. You may also use multiple
+curly braces, such as C<#`{{ double-curly-brace }}>, which might help
 disambiguate from nested delimiters. You can embed these comments in
 expressions, as long as you don't insert them in the middle of keywords or
 identifiers.
@@ -717,7 +717,7 @@ inside:
 
 If the constructor is given a single L<Iterable|/type/Iterable>, it'll
 clone and flatten it. If you want an C<Array> with just 1 element that
-is that C<Iterable>, ensure to use a comma after it:
+is an C<Iterable>, ensure to use a comma after it:
 
     my @a = 1, 2;
     say [@a].perl;  # OUTPUT: «[1, 2]␤»
@@ -753,7 +753,7 @@ often this is used with simple arrow pairs.
     say %(a => 73, foo => "fish").keys.join(" ");   # OUTPUT: «a foo␤»
     #   ^^^^^^^^^^^^^^^^^^^^^^^^^ Hash constructor
 
-When assigning to a C<%> sigiled variable on the left-hand side, the
+When assigning to a C<%>-sigiled variable on the left-hand side, the
 sigil and parenthesis surrounding the right-hand side C<Pairs> are
 optional.
 
@@ -879,9 +879,10 @@ rules.
 
     grammar G { }
 
-Several packages may be declared in a single file. However, you can declare a C<unit> package
-at the start of the file (preceded only by comments or C<use> statements), and the
-rest of the file will be taken as being the body of the package. In this case, the curly braces are not required.
+Several packages may be declared in a single file. However, you can declare
+a C<unit> package at the start of the file (preceded only by comments or C<use>
+statements), and the rest of the file will be taken as being the body of the
+package. In this case, the curly braces are not required.
 
 =begin code :solo
 unit module M;
@@ -939,7 +940,7 @@ set-name-age($person: 'jane', 98);  # Invocant marker
 set-name-age $person: 'jane', 98;   # Indirect invocation
 =end code
 
-For more information see L<functions|/language/functions>.
+For more information, see L<functions|/language/functions>.
 
 =head2 Precedence drop
 
@@ -986,11 +987,11 @@ Operators can be composed. A common example of this is combining an
 infix (binary) operator with assignment. You can combine assignment with
 any binary operator.
 
-    =begin code :skip-test<showcasing syntaxes>
-    $x += 5     # Adds 5 to $x, same as $x = $x + 5
-    $x min= 3   # Sets $x to the smaller of $x and 3, same as $x = $x min 3
-    $x .= child # Equivalent to $x = $x.child
-    =end code
+=begin code :skip-test<showcasing syntaxes>
+$x += 5     # Adds 5 to $x, same as $x = $x + 5
+$x min= 3   # Sets $x to the smaller of $x and 3, same as $x = $x min 3
+$x .= child # Equivalent to $x = $x.child
+=end code
 
 Wrap an infix operator in C<[ ]> to create a new reduction operator that works
 on a single list of inputs, resulting in a single value.
@@ -1003,14 +1004,15 @@ new hyper operator that works pairwise on two lists.
 
     say <1 2 3> «+» <4 5 6> # OUTPUT: «(5 7 9)␤»
 
-The direction of the arrows indicates what to do when the lists are not the same size.
+The direction of the arrows indicates what to do when the lists are not the same
+size.
 
-    =begin code :skip-test<showcasing syntaxes>
-    @a «+« @b # Result is the size of @b, elements from @a will be re-used
-    @a »+» @b # Result is the size of @a, elements from @b will be re-used
-    @a «+» @b # Result is the size of the biggest input, the smaller one is re-used
-    @a »+« @b # Exception if @a and @b are different sizes
-    =end code
+=begin code :skip-test<showcasing syntaxes>
+@a «+« @b # Result is the size of @b, elements from @a will be re-used
+@a »+» @b # Result is the size of @a, elements from @b will be re-used
+@a «+» @b # Result is the size of the biggest input, the smaller one is re-used
+@a »+« @b # Exception if @a and @b are different sizes
+=end code
 
 You can also wrap a unary operator with a hyper operator.
 


### PR DESCRIPTION
glossary.pod6, newline.pod6, quoting.pod6 and syntax.pod6

Changes include minor wording, text reflow, whitespace, unindenting `=code`-wrapped code samples, etc.

<!--
## The problem


## Solution provided



    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
