### PR TITLE
Improve readability.  Adjust token `letter` indentation.

### DIFF
--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -162,8 +162,8 @@ simply take the C<.made> value from the C«$<calc-op>» match object. And the
 actions for individual alternations now follow the same naming pattern as in the
 grammar: C«method calc-op:sym<add>» and C«method calc-op:sym<sub>».
 
-The real beauty of this method can be seen when you subclass that grammar
-and actions class. Let's say we want to add a multiplication feature to the
+The real beauty of this method can be seen when you subclass the grammar
+and action classes. Let's say we want to add a multiplication feature to the
 calculator:
 
     =begin code :preamble<grammar Calculator {}; class Calculations {}>
@@ -180,7 +180,7 @@ calculator:
     # OUTPUT: «6␤»
     =end code
 
-All we had to add are additional rule and action to the C<calc-op> group and
+All we had to add are an additional rule and action to the C<calc-op> group and
 the thing works—all thanks to proto regexes.
 
 =head2 Special tokens
@@ -193,12 +193,12 @@ the thing works—all thanks to proto regexes.
     }
 
 The C<TOP> token is the default first token attempted to match
-when parsing with a grammar. Note that if you're parsing with
+when parsing with a grammar. Note that if you're parsing with the
 L<C<.parse>|/type/Grammar#method_parse> method, C<token TOP> is automatically
 anchored to the start and end of the string. If you don't want to parse the
 whole string, look up L<C<.subparse>|/type/Grammar#method_subparse>.
 
-Using C<rule TOP> or C<regex TOP> are also acceptable.
+Using C<rule TOP> or C<regex TOP> is also acceptable.
 
 A different token can be chosen to be matched first using the C<:rule> named
 argument to C<.parse>, C<.subparse>, or C<.parsefile>. These are all C<Grammar>
@@ -225,8 +225,8 @@ Please bear in mind that we're preceding C<ws> with a dot to avoid capturing,
 which we are not interested in. Since in general whitespace is a separator, this
 is how it's mostly found.
 
-When C<rule> instead of C<token> is used, C<:sigspace> is enabled by default and
-any whitespace after terms and closing parenthesis/brackets is turned into a
+When C<rule> is used instead of C<token>, C<:sigspace> is enabled by default and
+any whitespace after terms and closing parenthesis/brackets are turned into a
 non-capturing call to C<ws>, written as C«<.ws>» where C<.> means non-capturing.
 That is to say:
 
@@ -263,11 +263,11 @@ the C<:sym> adverb for that particular regex:
     grammar Foo {
         token TOP { <letter>+ }
         proto token letter {*}
-        token letter:sym<P> { <sym> }
-        token letter:sym<e> { <sym> }
-        token letter:sym<r> { <sym> }
-        token letter:sym<l> { <sym> }
-        token letter:sym<*> {   .   }
+              token letter:sym<P> { <sym> }
+              token letter:sym<e> { <sym> }
+              token letter:sym<r> { <sym> }
+              token letter:sym<l> { <sym> }
+              token letter:sym<*> {   .   }
     }.parse("I ♥ Perl", actions => class {
         method TOP($/) { make $<letter>.grep(*.<sym>).join }
     }).made.say; # OUTPUT: «Perl␤»
@@ -321,8 +321,8 @@ as they return a L<Match|/type/Match>:
         token num-basic { <[0..9]>+ }
     }
 
-The grammar above will attempt different matches depending on the arguments
-provided by parse methods:
+The grammar above will attempt different matches depending on the argument
+provided to the subparse methods:
 
     =begin code :preamble<grammar DigitMatcher{};>
     say +DigitMatcher.subparse: '12७१७९०९', args => \(:full-unicode);


### PR DESCRIPTION
## The problem
1) A few of the sentences on the page didn't read that well.
2) The token `letter` indentation was different than a previous example.

## Solution provided
1) Adjust a few words and phrases here and there.
2) Adjust token `letter` indentation to match previous example.
