### PR TITLE
Added comment syntax on 101 page.

### DIFF
--- a/doc/Language/101-basics.pod6
+++ b/doc/Language/101-basics.pod6
@@ -29,12 +29,19 @@ Here's one way to solve that problem in Perl 6:
 =begin code :solo
 use v6;
 
-my $file  = open 'scores.txt';
+# Single line comments like this one start with '#'.
+my $file  = open 'scores.txt'; # Comments can also follow code on a line.
 my @names = $file.get.words;
 
 my %matches;
 my %sets;
 
+#`(  Multiple line comments
+     are denoted by a #, then `, then one of {,[, or (
+     and closed by the corresponding },], and ).
+     Nested pairs of brackets and braces are matched, so
+     something like this () will not end the comment.
+     In this case, closed by: )
 for $file.lines -> $line {
     next unless $line; # ignore any empty lines
 
@@ -52,6 +59,9 @@ for $file.lines -> $line {
     }
 }
 
+#`[
+  This is another multi-line comment. ]
+#`{ So is this, though it's not actually multi-line. }
 my @sorted = @names.sort({ %sets{$_} }).sort({ %matches{$_} }).reverse;
 
 for @sorted -> $n {


### PR DESCRIPTION
I think it's handy to make that easier to find in the
documentation.

## The problem
It's not as easy as it should be to find out how to put comments into Perl6 code from the official documentation.

## Solution provided

Examples are included right in the first example on the 101 page.

I may also revisit in other places.