### PR TITLE
update to show opener characters correctly

### DIFF
--- a/doc/Language/opener-chars.pod6
+++ b/doc/Language/opener-chars.pod6
@@ -12,7 +12,7 @@ can be seen.
 The source for the table is the I<token opener> defined in the I<role STD>
 in the I<Rakudo grammar>.
 
-=begin table
+=begin table :caption<Opener Graphemes>
 Char | Hex | Char | Hex | Char | Hex | Char | Hex
 =====+=====+======+=====+======+=====+======+====
 
@@ -118,3 +118,5 @@ Char | Hex | Char | Hex | Char | Hex | Char | Hex
 =end table
 
 =end pod
+
+# vim: expandtab softtabstop=4 shiftwidth=4 ft=perl6


### PR DESCRIPTION
## The problem

Need to show the valid opener chars for user reference.

## Solution provided

A new doc page with a table of chars.
