### PR TITLE
Roles can also be mixed in using 'is'.

### DIFF
--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -742,8 +742,8 @@ and code reuse within objects.
 
 X<|does>
 Roles use the keyword C<role> preceding the name of the role that is
-declared. Roles are mixed in using the C<does> keyword preceding the name
-of the role that is mixed in.
+declared. Roles are mixed in using the C<is> or C<does> keyword preceding the
+name of the role that is mixed in.
 
 =begin code
 constant ⲧ = " " xx 4; #Just a ⲧab

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -742,8 +742,13 @@ and code reuse within objects.
 
 X<|does>
 Roles use the keyword C<role> preceding the name of the role that is
-declared. Roles are mixed in using the C<is> or C<does> keyword preceding the
-name of the role that is mixed in.
+declared. Roles are mixed in using the C<does> keyword preceding the name of
+the role that is mixed in.
+
+Roles can also be mixed into a class using C<is>. However, the semantics of
+C<is> with a role are quite different from those offered by C<does>. With C<is>,
+a class is punned from the role, and then inherited from. Thus, there is no
+flattening composition, and none of the safeties C<does> provides.
 
 =begin code
 constant ⲧ = " " xx 4; #Just a ⲧab

--- a/doc/Language/objects.pod6
+++ b/doc/Language/objects.pod6
@@ -748,7 +748,7 @@ the role that is mixed in.
 Roles can also be mixed into a class using C<is>. However, the semantics of
 C<is> with a role are quite different from those offered by C<does>. With C<is>,
 a class is punned from the role, and then inherited from. Thus, there is no
-flattening composition, and none of the safeties C<does> provides.
+flattening composition, and none of the safeties which C<does> provides.
 
 =begin code
 constant ⲧ = " " xx 4; #Just a ⲧab


### PR DESCRIPTION
## The problem
The docs say a Role can be mixed into a class using "does" but fails to mention that "is" also works.

## Solution provided

Update the docs to clarify how "is" also works to mix a Role into a class.