### PR TITLE
Highlight Community, add IRC bot list

### DIFF
--- a/doc/HomePage.pod6
+++ b/doc/HomePage.pod6
@@ -42,8 +42,11 @@ by reporting issues or sending patches.
 <dt><a href="/language/faq">FAQs (Frequently Asked Questions)</a></dt>
 <dd>
     A collection of questions that have cropped up often, along with answers.
-</dl>
-
+</dd>
+<dt><a href="/language/community">Community</a></dt>
+<dd>
+    Information about the Raku development community, email lists, IRC and IRC bots, and blogs
+</dd>
 <hr/>
 
 
@@ -51,8 +54,7 @@ by reporting issues or sending patches.
 comprehensive list of Raku resources</a>, including tutorials, and how-tos.</p>
 
 <p>You may be interested in the <a href="https://perl6.org/community/">Community</a> page on the
-main perl6 website. You can find how to get in touch with Raku developers and users through instant
-chat or mailing lists.</p>
+main perl6 website.</p>
 
 <p>
 Perl&nbsp;6 compiler developers may also be interested in

--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -20,10 +20,169 @@ No, they pour new wine into new wineskins, and both are preserved.'
 
 =head2 Online communities
 
-There is a large presence on the L<C<#perl6>|https://perl6.org/community/irc> channel on C<freenode.net>, who are happy to provide support and answer questions, or just use as a friendly place to hang out.
+The C<#raku> channel was created in October 2019, and will become more active as it becomes the default channel. Eventually, connections
+to the C<#perl6> will be redirected to C<#raku>, but the historical logs will remain on the C<#perl6> channel.
+The L<C<#perl6>|https://perl6.org/community/irc> channel on C<freenode.net> has always had a large presence with many developers,
+ who are happy to provide support and answer questions, or just use it as a friendly place to hang out.
 Check out this L<IRC lingo|http://www.ircbeginner.com/ircinfo/abbreviations.html> resource for the abbreviations frequently used there.
 L<StackOverflow|https://stackoverflow.com/questions/tagged/perl6> is also a great resource for asking questions and helping others with their Raku problems and challenges.
 More resources can be found in the L<perl6.org community page|https://perl6.org/community/>.
+
+=head2 IRC bots
+
+The IRC channel has some very interesting bots. This is a full list with the name of the bot, a link to more information
+and a short description.
+
+=defn benchable L<More detail|https://github.com/perl6/whateverable/wiki/Benchable>
+An IRC bot for benchmarking code at a given commit of Rakudo. It
+can be addressed by its full name ('benchable6') or its short name
+('bench'). It will run the given code five times and return the
+minimum amount of time taken.
+
+=defn bisectable L<More detail|https://github.com/perl6/whateverable/wiki/Bisectable>
+This bot is meant to help you find when something got broken. If
+you want to know if something has ever worked use Committable
+instead.
+
+=defn bloatable L<More detail|https://github.com/perl6/whateverable/wiki/Bloatable>
+An IRC bot for running bloaty on libmoar.so files of MoarVM. It can
+be addressed by its full name ('bloatable6') or its short name
+('bloat' or 'bloaty'). It will run bloaty and pass one or more
+libmoar.so files from different revisions of MoarVM.
+
+=defn buggable L<More detail|https://github.com/zoffixznet/perl6-buggable>
+RT queue search and utility bot.
+
+=defn camelia
+Perl 6 code evaluation bot. We use this for live testing of code
+that may be of interest to others; it chats back to the channel.
+C<perl6: my $a>
+will result in a test against the latest revisions of rakudo and niecza,
+C<nqp: say('foo')>
+will test nqp,
+C<std: my $a>
+will parse the expression using STD.pm6. For other compilers, try C<camelia: help>.
+
+=defn committable L<More detail|https://github.com/perl6/whateverable/wiki/Committable>
+An IRC bot for running code at a given commit of Rakudo. It can be
+addressed by its full name ('committable6') or its short names
+('commit', 'c').
+
+=defn coverable L<More detail|https://github.com/perl6/whateverable/wiki/Coverable>
+An IRC bot for creating a coverage report of the Rakudo (and NQP)
+source lines that were hit while running the code you give it. The
+first option is the commit, the second (optional) option is the
+filter for what lines of the MoarVM-generated coverage log you
+want, the third is the code to run.
+
+=defn Geth L<More detail|https://github.com/perl6/geth>
+Announces commits made to various projects relevant to Raku, such
+as implementations of Raku and some of the
+L<repositories owned by Raku|https://github.com/perl6/>.
+
+=defn evalable L<More detail|https://github.com/perl6/whateverable/wiki/Evalable>
+Evalable is just Committable that defaults to <code>HEAD</code>.
+
+=defn greppable L<More detail|https://github.com/perl6/whateverable/wiki/Greppable>
+An IRC bot for grepping through the module ecosystem. It can be
+addressed by its full name ('greppable6') or its short name
+('grep').
+
+=defn huggable L<More detail|https://github.com/zoffixznet/huggable>
+Let's you <code>.hug</code> people in the channel.
+
+=defn ilbot L<More detail|https://github.com/moritz/ilbot>
+IRC logging bot.
+
+=defn nativecallable L<More detail|https://github.com/perl6/whateverable/wiki/Nativecallable>
+an IRC bot for generating Perl 6 NativeCall code from C
+definitions. It can be addressed by its full name
+('nativecallable6') or its short name ('nativecall'). The bot is
+using C<App::GPTrixie> to do the conversion.
+
+=defn notable L<More detail|https://github.com/perl6/whateverable/wiki/Notable>
+an IRC bot for for noting things. It can be addressed by its full name ('notable6')
+or its short name ('note'). There is also a “weekly:” shortcut.
+
+=defn quotable L<More detail|https://github.com/perl6/whateverable/wiki/Quotable>
+ An IRC bot for searching messages in the IRC log. It can be
+ addressed by its full name ('quotable6') or its short name
+ ('quote').
+
+=defn releasable L<More detail|https://github.com/perl6/whateverable/wiki/Releasable>
+An IRC bot for getting information about the upcoming release. It
+can be addressed by its full name ('releasable6') or its short name
+('release').
+
+As a user, you are probably only interested in its only command
+“status”. It tells when the next release is going to happen and how
+many blockers are there.
+
+=defn reportable L<More detail|https://github.com/perl6/whateverable/wiki/Reportable>
+An IRC bot for generating reports of changes in rakudo RT and GitHub issue trackers
+(which issues were resolved, updated, rejected, etc.). It can be addressed by its full name
+('reportable6') or its short name ('report'). It takes snapshots of issue trackers
+periodically, and then you can ask it to generate a report for two given snapshots.
+
+See also: L<Weekly, Monthly and Yearly reports|https://github.com/rakudo/rakudo/wiki/Ticket-updates>
+
+=defn shareable L<More detail|https://github.com/perl6/whateverable/wiki/Shareable>
+ An IRC bot for making rakudo builds produced by Whateverable publicly available.
+ It can be addressed by its full name ('shareable6').
+
+ Note that the build will be located
+  in /tmp/whateverable/rakudo-moar/SOME-SHA/. Also, as of today these files are only
+  useful for you if you're on linux x86_64.
+
+=defn SourceBaby L<More detail|https://github.com/zoffixznet/perl6-sourceable>
+Core source code locator
+
+=defn squashable L<More detail|https://github.com/perl6/whateverable/wiki/Squashable>
+An IRC bot for the Monthly Bug Squash Day (a.k.a. Community Bug
+SQUASHathon). It can be addressed by its full name ('squashable6')
+or its short name ('squash'). It can tell you when the next even is
+going to happen and what's the current status of the active event.
+Also, it will also announce changes to the repo.
+
+=defn statisfiable L<More detail|https://github.com/perl6/whateverable/wiki/Statisfiable>
+An IRC bot that can gather stats across rakudo builds. It can be
+addressed by its full name ('statisfiable6') or its short name
+('stat'). For most commands it will reply with a gist that has a
+graph and the raw data. Note that stats are cached, but it takes
+some time for it to generate the graph, so be patient.
+
+=defn synopsebot6 L<More detail|https://github.com/perl6/synopsebot>
+Creates links to the synopses and turns mentions of RT ticket
+numbers into clickable RT links.
+
+=defn tellable L<More detail|https://github.com/perl6/whateverable/wiki/Tellable>
+An IRC bot for passing messages to users who are currently offline.
+You can also use it to see when was the last time somebody talked.
+
+=defn Undercover L<More detail|https://github.com/zoffixznet/undercover>
+Very similar to SourceBaby, except points to
+L<rakudo.party|https://wtf.rakudo.party/> indicating stresstest coverage of code.
+
+=defn undersightable L<More detail|https://github.com/perl6/whateverable/wiki/Undersightable>
+ An IRC bot for checking that important things are operating correctly (websites are up,
+ bots are online, released tarballs are correct, etc.). It can be addressed by its full name
+ ('undersightable6').
+
+=defn unicodable L<More detail|https://github.com/perl6/whateverable/wiki/Unicodable>
+An IRC bot for getting interesting information about Unicode
+characters. It can be addressed by its full name ('unicodable6') or
+its short name ('u').
+
+=defn PufferBot L<More detail|https://github.com/Kaiepi/p6-RakudoBot>
+An IRC bot for testing builds of Rakudo on OpenBSD. It can be
+addressed by its full name ('PufferBot'). Talks only in
+L<#perl6-dev|https://webchat.freenode.net/?channels=#perl6-dev>.
+
+=defn BeastieBot L<More detail|https://github.com/Kaiepi/p6-RakudoBot>
+An IRC bot for testing builds of Rakudo on FreeBSD. It can be
+addressed by its full name ('BeastieBot'). Talks only in
+L<#perl6-dev|https://webchat.freenode.net/?channels=#perl6-dev>.
+
 
 =head2 Offline communities
 


### PR DESCRIPTION
1 - Place the Community resources in HomePage (leaving the same link in the Language page)
2 - Add a list of bots (the text is taken from perl6.org/community/IRC) to the Community page.
3 - Some editing of Raku / Perl6
4 - Added channel #raku to resource list.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
