### PR TITLE
Document elems on Seq

### DIFF
--- a/doc/Type/Seq.pod6
+++ b/doc/Type/Seq.pod6
@@ -75,6 +75,14 @@ Returns the underlying iterator, and marks the invocant as consumed.
 If called on an already consumed sequence, throws an error of type
 L<X::Seq::Consumed|/type/X::Seq::Consumed>.
 
+=head2 method elems
+
+    method elems(Seq:D:)
+
+If the caller C<Seq> is not lazy, consumes and caches its values,
+returning their length. Otherwise, throws an error of type
+L<X::Cannot::Lazy|/type/X::Cannot::Lazy>.
+
 =head2 method is-lazy
 
     method is-lazy(Seq:D: --> Bool:D)


### PR DESCRIPTION
## The problem

`elems` method on Seq is not documented... Based on implementation at https://github.com/rakudo/rakudo/blob/master/src/core.c/Seq.pm6#L51-L61

## Solution provided

Document it.