### PR TITLE
Add Raku to case exceptions in titles

### DIFF
--- a/xt/headings.t
+++ b/xt/headings.t
@@ -27,7 +27,7 @@ for @files -> $file {
             # proper names, macros, acronyms, and other exceptions
             $title ~~ s:g/ <|w> (
                 I
-                | Perl 6 | Pod 6 | P6 | C3 | NQP
+                | Raku | Perl 6 | Pod 6 | P6 | C3 | NQP
                 | AST | EVAL | PRE | POST | CLI | MOP
                 | TITLE | SUBTITLE | "MONKEY-TYPING"
                 | API | TCP | UDP | FAQ


### PR DESCRIPTION
## The problem

'Raku' should be a case exception in titles.
