### PR TITLE
Add missing 'the' and fix example's output

### DIFF
--- a/doc/Language/functions.pod6
+++ b/doc/Language/functions.pod6
@@ -970,7 +970,7 @@ a 1;        # OUTPUT: «Int 1␤Any 2␤»
 X<|dispatch,samewith>
 
 C<samewith> calls current candidate again with arguments provided by users
-and returns return value of the new instance of current candidate.
+and returns the return value of the new instance of current candidate.
 
 =begin code
 proto a(|) {*}
@@ -980,7 +980,7 @@ multi a(Int $x) {
   return $x * samewith($x-1);
 }
 
-say (a 10); # OUTPUT: «36288002␤»
+say (a 10); # OUTPUT: «36288000␤»
 =end code
 
 X<|dispatch,nextcallee>


### PR DESCRIPTION
## The problem

I think a 'the' is missing in samewith's description and also fix its example output.
