### PR TITLE
Pursue .WHAT removal

### DIFF
--- a/doc/Language/classtut.pod6
+++ b/doc/Language/classtut.pod6
@@ -816,11 +816,10 @@ The output might look like this:
 =begin code :lang<output>
 It's an employee
 Not a geeky cook
-(Programmer)
+Programmer
 Programmer.new(known_languages => ["Perl", "Python", "Pascal"],
         favorite_editor => "gvim", salary => "too small")
 code_to_solve, known_languages, favorite_editor
-Programmer
 =end code
 
 The first two tests each smartmatch against a class name. If the object is
@@ -828,8 +827,7 @@ of that class, or of an inheriting class, it returns true. So the object in
 question is of class C<Employee> or one that inherits from it, but not
 C<GeekCook>.
 
-The C<.WHAT> method returns the type object associated with the object
-C<$o>, which tells us the exact type of C<$o>: in this case C<Programmer>.
+The call C<$o.^name> tells us the type of C<$o>: in this case C<Programmer>.
 
 C<$o.perl> returns a string that can be executed as Perl code, and
 reproduces the original object C<$o>. While this does not work perfectly in
@@ -857,7 +855,7 @@ unsurprisingly returns the class name.
 
 Introspection is very useful for debugging and for learning the language
 and new libraries. When a function or method returns an object you don't
-know about, by finding its type with C<.WHAT>, seeing a construction recipe
+know about, by finding its type with C<.^name>, seeing a construction recipe
 for it with C<.perl>, and so on, you'll get a good idea of what its return
 value is. With C<.^methods>, you can learn what you can do with the class.
 


### PR DESCRIPTION
- Sync output with code example
- Update code example description
- Advise .^name usage

## The problem
.WHAT was removed from an example in snippet in doc/Language/classtut.pod6 a year ago in favor of .^name: this is a followup