### PR TITLE
Fix doc bug related to how to explicitly capture whitespace using <ws>.

### DIFF
--- a/doc/Language/grammars.pod6
+++ b/doc/Language/grammars.pod6
@@ -247,12 +247,14 @@ You can also redefine the default C<ws> token:
         token ws { \h*   }
     }.parse: "4   \n\n 5"; # Fails
 
-And even capture it, but you need to use it explicitly:
+And even capture it, but you need to use it explicitly. Notice that in the
+next example we use C<token> instead of C<rule>, as the latter would cause
+whitespace to be consumed by the implicit non-capturing C<.ws>.
 
 =for code
-grammar Foo { rule TOP {\d <ws> \d} };
+grammar Foo { token TOP {\d <ws> \d} };
 my $parsed = Foo.parse: "3 3";
-say $parsed<ws>; # OUTPUT: «｢｣␤»
+say $parsed<ws>; # OUTPUT: «｢ ｣␤»
 
 
 =head3 X«C<sym>|<sym>»


### PR DESCRIPTION
## The problem

This pull request should close the following issue:

https://github.com/perl6/doc/issues/3085


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
