### PR TITLE
code example error, add file name

### DIFF
--- a/doc/Language/create-cli.pod6
+++ b/doc/Language/create-cli.pod6
@@ -117,7 +117,7 @@ sub MAIN(
 
 With C<file.dat> present, this will work this way:
 =begin code :lang<shell>
-$ perl6 frobnicate.p6
+$ perl6 frobnicate.p6 file.dat
 24
 file.dat
 Verbosity off
@@ -126,7 +126,7 @@ Verbosity off
 Or this way with C<--verbose>:
 
 =begin code :lang<shell>
-$ perl6 frobnicate.p6 --verbose
+$ perl6 frobnicate.p6 --verbose file.dat
 24
 file.dat
 Verbosity on


### PR DESCRIPTION
## The problem
Following example seems incorrect
`With file.dat present, this will work this way:

$ perl6 frobnicate.p6
24
file.dat
Verbosity off
Or this way with --verbose:

$ perl6 frobnicate.p6 --verbose
24
file.dat
Verbosity on`

## Solution provided
Add file.dat to command line argument
`$ perl6 frobnicate.p6 file.dat
24
file.dat
Verbosity off
Or this way with --verbose:

$ perl6 frobnicate.p6 --verbose file.dat
24
file.dat
Verbosity on`
