### PR TITLE
Change link for Math::Constants to point to the top of the repo.

### DIFF
--- a/doc/Language/math.pod6
+++ b/doc/Language/math.pod6
@@ -224,7 +224,7 @@ Raku includes a set of mathematical constants:
 These constants are also available
 through L<ASCII equivalents|/language/unicode_ascii>: C<e>, C<pi> and C<tau>.
 
-The L<Math::Constants|https://github.com/JJ/p6-math-constants/pulls> module
+The L<Math::Constants|https://github.com/JJ/p6-math-constants> module
 includes an additional series of physical and mathematical constants such as the
 previously mentioned golden ratio φ or the Planck's constant ℎ.
 


### PR DESCRIPTION
Previously this pointed into the "pulls" area, which could be confusing for git or github neophytes.

## The problem

The documentation for "Doing math with Raku" has a link to the Math::Constants repository. This actually links to github.com/JJ/p6-math-constants/pulls, which is not intuitive and could be confusing.

## Solution provided

Link to the top of the repository tree, where the readme file is a lot more useful.