### PR TITLE
Fix examples' output

### DIFF
--- a/doc/Type/List.pod6
+++ b/doc/Type/List.pod6
@@ -1261,9 +1261,7 @@ C<zip> has an infix synonym, the C<Z> operator.
 C<zip> can provide input to a for loop :
 
     for <a b c> Z <d e f> Z <g h i> -> [$x,$y,$z] {say ($x,$y,$z).join(",")}
-    # OUTPUT: «a,d,g␤
-    # b,e,h␤
-    # c,f,i␤»
+    # OUTPUT: «a,d,g␤b,e,h␤c,f,i␤»
 
 , or more succinctly:
 
@@ -1284,9 +1282,7 @@ example, the following multiplies corresponding elements together to return a
 single list of products.
 
     .say for zip <1 2 3>, [1, 2, 3], (1, 2, 3), :with(&infix:<*>);
-    # OUTPUT: «1␤
-    # 8␤
-    # 27␤»
+    # OUTPUT: «1␤8␤27␤»
 
 The C<Z> form can also be used to perform reduction by implicitly
 setting the C<with> parameter with a metaoperator :
@@ -1308,8 +1304,7 @@ to have an unequal number of elements.
     # OUTPUT: «((a d g) (b e h) (c f i))␤»
 
     say .join(",") for roundrobin([1, 2], [2, 3], [3, 4]);
-    # OUTPUT: «1,2,3␤
-    # 2,3,4␤»
+    # OUTPUT: «1,2,3␤2,3,4␤»
 
 C<roundrobin> does not terminate once one or more of the input lists become
 exhausted, but proceeds until all elements from all lists have been processed.
@@ -1318,10 +1313,7 @@ exhausted, but proceeds until all elements from all lists have been processed.
     # OUTPUT: «((a d g) (b e h) (c f i) (m j) (n) (o) (p))␤»
 
     say .join(",") for roundrobin([1, 2], [2, 3, 57, 77], [3, 4, 102]);
-    # OUTPUT: «1,2,3␤
-    # 2,3,4␤
-    # 57,102␤
-    # 77␤»
+    # OUTPUT: «1,2,3␤2,3,4␤57,102␤77␤»
 
 Therefore no data values are lost due in the 'zipping' operation. A record of
 which input list provided which element cannot be gleaned from the resulting


### PR DESCRIPTION
if there is a ␤, don't break the line :)
