### PR TITLE
Fix some "an h" broken articulation.

### DIFF
--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -326,7 +326,7 @@ Use L<.contains|/type/Str#method_contains> or L<.indices|/type/Str#method_indice
 
 =head2 String: How can I get the hexadecimal representation of a string
 
-To get an hexadecimal list of each byte of a string (i.e. hex encoder),
+To get a hexadecimal list of each byte of a string (i.e. hex encoder),
 first convert the string to a L<Blob|/type/Blob> with L<.encode|/routine/encode>.
 
 =begin code

--- a/doc/Type/IO/Handle.pod6
+++ b/doc/Type/IO/Handle.pod6
@@ -7,7 +7,7 @@
    class IO::Handle { }
 
 
-Instances of C<IO::Handle> encapsulate an I<handle> to manipulate input/output
+Instances of C<IO::Handle> encapsulate a I<handle> to manipulate input/output
 resources. Usually there is no need to create directly an C<IO::Handle>
 instance, since it will be done by other roles and methods. For instance, an
 L<IO::Path|/type/IO::Path> object provides an L<open|/routine/open> method that returns an


### PR DESCRIPTION
The h is not silent so it is "a h\w+".

See https://en.wikipedia.org/wiki/English_articles .

## The problem

"an" instead of "a" articles.

## Solution provided

Change "an" to "a". Untested so far.
