### PR TITLE
Explain that ^ and : declare variables

### DIFF
--- a/doc/Language/variables.pod6
+++ b/doc/Language/variables.pod6
@@ -391,8 +391,7 @@ the block in the code
 has two formal parameters, namely C<$a> and C<$b>. Note that even though C<$^b>
 appears before C<$^a> in the code, C<$^a> is still the first formal parameter
 to that block. This is because the placeholder variables are sorted in Unicode
-order. If you have self-declared a parameter using C<$^a> once, you may refer
-to it using only C<$a> thereafter.
+order.
 
 Although it is possible to use nearly any valid identifier as a placeholder
 variable, it is recommended to use short names or ones that can be trivially
@@ -425,6 +424,29 @@ therefore not ordered using Unicode order, of course). For instance:
     # OUTPUT: «-1␤»
 
 See L<^|/syntax/$CIRCUMFLEX_ACCENT> for more details about placeholder variables.
+
+=head3 A note on C<^> and C<:>
+
+Unlike other twigils, C<^> and C<:> I<declare> variables, which can then be 
+referred to without that twigil.  Thus, the previous example could be written as:
+
+    say { $:add ?? $^a + $^b !! $a - $b }( 4, 5 ) :!add      # OUTPUT: «-1␤»
+
+That is, once you have used C<$^a> to declare C<$a>, you can refer to that variable 
+in the same scope with I<either> C<$^a> or C<$a>.  The same is true for C<:>: after 
+declaring C<$:add>, you are free to refer to that declared variable with C<$add> if 
+you prefer.
+
+In some instances, this is just a convenience – but it can be much more significant 
+when dealing with nested blocks.  For example:
+
+    { say $^a; with "inner" { say $^a } }("outer");       # OUTPUT: «outer␤inner␤»
+    { say $^a; with "inner" { say $a } }("outer");        # OUTPUT: «outer␤outer␤»
+
+The first line declares I<two> formal positional parameters, while the second declares 
+only one (but refers to it twice).  This can be especially significant with constructs 
+such as C<with>, C<for>, and C<if> that are often used without much consideration of 
+the fact that they create blocks.
 
 =head2 The C<=> twigil
 X<|$=>


### PR DESCRIPTION
Based on [recent discussion on the mailing list](https://www.mail-archive.com/perl6-users@perl.org/msg10076.html), this PR explains that the `^` and `:` twiglis declare variables that can subsequently be used without the sigil.  It also provides some examples of how this can alter program behavior with nested blocks.
