### PR TITLE
update util/missing-types due to module name change for TypeGraph

### DIFF
--- a/util/missing-types.raku
+++ b/util/missing-types.raku
@@ -1,9 +1,13 @@
 #!/usr/bin/env raku
 
-use lib 'lib';
-use Perl6::TypeGraph;
+# This script parses the type-graph.txt file and checks
+# the existence of the corresponding pod6 file for most entries
+# skips: Metamodel and PROCESS types
 
-my $t = Perl6::TypeGraph.new-from-file('type-graph.txt');
+use lib 'lib';
+use Doc::TypeGraph;
+
+my $t = Doc::TypeGraph.new-from-file('type-graph.txt');
 
 for $t.sorted  -> $type {
     next if $type.name.index('Metamodel').defined || $type.name eq 'PROCESS';


### PR DESCRIPTION
Updated the script to reflect module name change from Perl6::TypeGraph to Doc::TypeGraph

   There are still a few problems with this script.
   1. `int` Type is documented in `doc/Native/int.pod6`.
       -  We could just write a different case for it, unless other types are planned for `doc/Native/` path.
   2. Types from External modules like `Telemetry` etc.. also cannot be dealt with.
   3. The only module entry `Test` also needs handling (either skip it, or write a case to deal with module entries).
   4. There are a lot of missing docs for types with `X::` prefix, should they be skipped?

We can deal 2 and 3 if all module entries in type-graph.txt are initially loaded.