### PR TITLE
Update irc.libera.chat webclient url

### DIFF
--- a/assets/documentable.json
+++ b/assets/documentable.json
@@ -1,7 +1,7 @@
 {
   "title-page": "Raku Documentation",
   "pod-root-path": "https://github.com/Raku/doc/blob/master/doc",
-  "irc-link": "https://kiwiirc.com/client/irc.libera.chat/#raku",
+  "irc-link": "https://web.libera.chat/?channel=#raku",
   "kinds": [
     {
       "kind": "language",

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -108,7 +108,7 @@ function setup_debug_mode(){
                 console.info("checking for dead links");
 
                 function report_broken_link(url) {
-                    $('html').find('#search').after('<div style="text-align: center;">Broken link: ' + url + ' found. Please report at <a href="https://kiwiirc.com/client/irc.libera.chat/#raku">irc.libera.chat#raku</a></div>');
+                    $('html').find('#search').after('<div style="text-align: center;">Broken link: ' + url + ' found. Please report at <a href="https://web.libera.chat/?channel=#raku">irc.libera.chat#raku</a></div>');
                 }
 
                 var seen_link = [];

--- a/doc/Language/community.pod6
+++ b/doc/Language/community.pod6
@@ -258,7 +258,7 @@ B<PufferBot> (L<details|https://github.com/Kaiepi/p6-RakudoBot>)
 
 An IRC bot for testing builds of Rakudo on OpenBSD. It can be
 addressed by its full name ('PufferBot'). Talks only in
-L<#raku-dev|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>.
+L<#raku-dev|https://web.libera.chat/?channel=#raku-dev>.
 =end item
 
 =begin item
@@ -266,7 +266,7 @@ B<BeastieBot> (L<details|https://github.com/Kaiepi/p6-RakudoBot>)
 
 An IRC bot for testing builds of Rakudo on FreeBSD. It can be
 addressed by its full name ('BeastieBot'). Talks only in
-L<#raku-dev|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>.
+L<#raku-dev|https://web.libera.chat/?channel=#raku-dev>.
 =end item
 
 

--- a/doc/Language/faq.pod6
+++ b/doc/Language/faq.pod6
@@ -113,7 +113,7 @@ Anything published before December, 2015 likely describes a pre-release
 version of Raku.
 
 You can always
-L<get help from a live human in our help chat|https://kiwiirc.com/client/irc.libera.chat/#raku>
+L<get help from a live human in our help chat|https://web.libera.chat/?channel=#raku>
 or L<search the chat logs|https://colabti.org/irclogger/irclogger_log_search/raku>
 to find previous conversations and discussions.
 

--- a/doc/Type/IO/CatHandle.pod6
+++ b/doc/Type/IO/CatHandle.pod6
@@ -769,7 +769,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method nl-out
 
@@ -779,7 +779,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method out-buffer
 
@@ -789,7 +789,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method print
 
@@ -799,7 +799,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method printf
 
@@ -809,7 +809,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method print-nl
 
@@ -819,7 +819,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method put
 
@@ -829,7 +829,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method say
 
@@ -839,7 +839,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method write
 
@@ -849,7 +849,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method WRITE
 
@@ -859,7 +859,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method READ
 
@@ -869,7 +869,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =head2 method EOF
 
@@ -879,7 +879,7 @@ Defined as:
 
 The L<IO::CatHandle|/type/IO::CatHandle> type overrides this method to throw a C<X::NYI>
 exception. If you have a good idea for how this method should behave,
-L<tell Rakudo developers about it|https://kiwiirc.com/client/irc.libera.chat/#raku-dev>!
+L<tell Rakudo developers about it|https://web.libera.chat/?channel=#raku-dev>!
 
 =end pod
 

--- a/documentable.json
+++ b/documentable.json
@@ -1,7 +1,7 @@
 {
   "title-page": "Raku official documentation",
   "pod-root-path": "https://github.com/Raku/doc/edit/master/doc/",
-  "irc-link": "https://kiwiirc.com/client/irc.libera.chat/#raku",
+  "irc-link": "https://web.libera.chat/?channel=#raku",
   "kinds": [
     {
       "kind": "language",

--- a/writing-docs/SQUASHATHONS.md
+++ b/writing-docs/SQUASHATHONS.md
@@ -6,7 +6,7 @@ to this repository. It will help the organization of the hackathon if
 you follow these rules when participating in it.
 
 1. Always work against an [issue](https://github.com/Raku/doc/issues). If you find some typo or any other kind of error for which an issue does not exist, please create one.
-2. Always work on assigned issues. Assignments get echoed in the [`raku` IRC channel](https://kiwiirc.com/client/irc.libera.chat/#raku), so everyone knows someone is working on that.
+2. Always work on assigned issues. Assignments get echoed in the [`raku` IRC channel](https://web.libera.chat/?channel=#raku), so everyone knows someone is working on that.
 3. You can only assign issues to contributors, so if someone who is
    not a contributor asks to be assigned something, please assign it
    to yourself (provided you are a contributor) and do an `@` mention with the nick of the actual


### PR DESCRIPTION
Updated to https://web.libera.chat/

## The problem

Libera chat has it's own webclient.

## Solution provided

Updated the urls.

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
