### PR TITLE
default base type for subset declaration

### DIFF
--- a/doc/Language/typesystem.pod6
+++ b/doc/Language/typesystem.pod6
@@ -911,6 +911,11 @@ Subsets can be used in signatures, e.g. by typing the output:
     a(1, "foo");  # passes
     a("foo", 1);  # fails
 
+If you skip the base type, it defaults to C<Any>. So the following two are equivalent:
+
+    subset A-or-B where * ~~ A | B
+    subset A-or-B of Any where * ~~ A | B
+
 Subsets can be anonymous, allowing inline placements where a subset is required
 but a name is neither needed nor desirable.
 


### PR DESCRIPTION
Clarify that the default base type in the declaration of subset is `Any`[1].

  [1]: https://github.com/rakudo/rakudo/blob/c0a6823b0c0ef3382c281202adcc6ce079afc141/src/Perl6/Actions.nqp#L5218