### PR TITLE
Refer to the correct class name in the the example that follows

### DIFF
--- a/doc/Language/grammars.rakudoc
+++ b/doc/Language/grammars.rakudoc
@@ -103,7 +103,7 @@ These methods can share a name and
 functionality in common, and thus can use L<proto|/syntax/proto>.
 
 For instance, if you have a lot of alternations, it may become difficult to
-produce readable code or subclass your grammar. In the C<Actions> class below,
+produce readable code or subclass your grammar. In the C<Calculations> class below,
 the ternary in C<method TOP> is less than ideal and it becomes even worse the
 more operations we add:
 


### PR DESCRIPTION
The example defines a class `Calculations` not `Actions` as previously referred to in the text.
