### PR TITLE
Add "andthen" and "orelse" to Promise.rakudoc

### DIFF
--- a/doc/Type/Promise.rakudoc
+++ b/doc/Type/Promise.rakudoc
@@ -246,8 +246,7 @@ to the C<&code>.
         say "Got $res";
         $res + 10
     });
-    await $after;
-    say $after.result;  # OUTPUT: «Got 42␤52␤»
+    say await $after;    # OUTPUT: «Got 42␤52␤»
 
     # Broken promise skips the code
     my $broken = Promise.broken(X::AdHoc.new(payload => "Error"));
@@ -270,14 +269,12 @@ to the C<&code>.
         my $err = $orig.cause;  # Get exception from original promise
         "Using cached data because of {$err.message}"
     });
-    await $recovered;
-    say $recovered.result;  # OUTPUT: «Using cached data because of DB Error␤»
+    say await $recovered;  # OUTPUT: «Using cached data because of DB Error␤»
 
     # Kept promise skips the code
     my $kept = Promise.kept(42);
     my $unchanged = $kept.orelse(-> $orig { "recovered" });
-    await $unchanged;
-    say $unchanged.result;  # OUTPUT: «42␤»
+    say await $unchanged;  # OUTPUT: «42␤»
 
 =head2 method keep
 


### PR DESCRIPTION
This pull requests adds documentation for `Promise.andthen` and `Promise.orelse` methods, since they're really useful.