### PR TITLE
Small improvements to the text in section "role" of  typesystem.rakudoc

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -618,7 +618,6 @@ For runtime mixins see L<but|/language/operators#infix_but> and L<does|/language
 =head3 Parameterized
 
 Roles can be provided with parameters in-between C<[]> behind a roles name.
-X<|Language,Type Capture (role)>L<Type captures|/language/signatures#Type_captures> are supported.
 
     role R[$d] { has $.a = $d };
     class C does R["default"] { };
@@ -629,6 +628,7 @@ X<|Language,Type Capture (role)>L<Type captures|/language/signatures#Type_captur
 
 Parameters can have type constraints, C<where> clauses are not supported for
 types but can be implemented via L<C<subset>s|#subset>.
+X<|Language,Type Capture (role)>L<Type captures|/language/signatures#Type_captures> are supported.
 
     class A {};
     class B {};
@@ -648,7 +648,7 @@ Default parameters can be provided.
 Roles can be used as type constraints wherever a type is expected. If a role is
 mixed in with C<does> or C<but>, its type-object is added to the type-object
 list of the object in question. If a role is used instead of a class (using
-auto-punning), the auto-generated class' type-object, of the same name as the
+auto-punning), the auto-generated class's type-object, of the same name as the
 role, is added to the inheritance chain.
 
 =begin code


### PR DESCRIPTION
(1) In subsection "[Parameterized](https://docs.raku.org/language/typesystem#Type_system)": Move sentence mentioning type captures to the next code example, since the example before does not involve them

(2) In subsection "[As type constraints](https://docs.raku.org/language/typesystem#Type_system)": Change «class'» to «class's» to make a long sentence easier to understand