### PR TITLE
In signatures.rakudoc: Complete overhaul regarding double semicolon (;;) for controlling signature precedence

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -1134,8 +1134,8 @@ example.
 In L<multiple dispatch|/language/Functions#Multi-dispatch>, when more than one multi signature matches
 the given input parameters, the narrowest signature wins.
 
-When a double semicolon <;;> is present in a signature,
-only parameters to the left of the `;;` are considered in this narrowness analysis.
+When a double semicolon C<;;> is present in a signature,
+only parameters to the left of the C<;;> are considered in this narrowness analysis.
 It can take the place of a comma, or be at the very beginning:
 
     multi foo (;; Numeric $a) { say "numeric" };
@@ -1172,9 +1172,9 @@ There is more than one way to control the narrowness
 (and thereby, precedence) of signatures. Other options include
 making parameters optional via C<?> or required via C<!>.
 
-The double semicolon `;;` can also be used in signatures of L<parameterized Roles|/language/Typesystem#Parameterized>.
+The double semicolon C<;;> can also be used in signatures of L<parameterized Roles|/language/Typesystem#Parameterized>.
 Parameterized roles have a so-called "long name" generated from their signature, which can be used for introspection.
-Only parameters to the left of `;;` contribute to it.
+Only parameters to the left of C<;;> contribute to it.
 
 =head1 Parameter traits and modifiers
 


### PR DESCRIPTION
https://docs.raku.org/language/signatures

Current name of the section is `Long_names`; this commit changes it to `The_;;_separator`. It does't seem to be linked to by any other docs, so this shouldn't cause much trouble.

Related to [this PR](https://github.com/Raku/doc/pull/4647) from today by @arkiuat on Parameters. 
Relevant roasts are collected in my [comment](https://github.com/Raku/doc/pull/4647#issuecomment-3381778293) there.