### PR TITLE
In operators.rakudoc, change wording for andthen and notandthen

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -3450,7 +3450,7 @@ behavior:
 
 =head2 infix X<C«notandthen»|Infix operators,notandthen>
 
-The C<notandthen> operator returns L«C<Empty>|/type/Slip#constant_Empty» if the 
+The C<notandthen> operator returns L«C<Empty>|/type/Slip#constant_Empty» if the
 first argument is L<defined|/routine/defined>, otherwise the last argument. The last argument
 is returned as-is, without being checked for definedness at all. Short-circuits.
 The result of the left side is bound to C<$_> for the right side, or passed as


### PR DESCRIPTION
The current wording ("upon encountering the first undefined argument") reads as though the operator would walk through a series arguments, waiting to encounter one that is undefined. With the new wording it should be correct (cf. [roast](https://github.com/Raku/roast/blob/master/S03-operators/andthen.t)) and also clearer.