### PR TITLE
In regexes.rakudoc, fix unneeded word

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2938,7 +2938,7 @@ for the third (C<\d+>).
 C<:ratchet> is enabled by default in C<token>s and C<rule>s; see
 L<grammars|/language/grammars> for more details.
 
-Raku also offers three regex metacharacters to control backtracking at for an
+Raku also offers three regex metacharacters to control backtracking for an
 individual atom.
 
 =head3 X<Disable backtracking: C<:>|Regexes,:;Regexes,disable backtracking>


### PR DESCRIPTION
basically just a typo