### PR TITLE
In regexes.rakudoc, add example (駱) to show that "word characters" also comprise syllabic characters

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -523,6 +523,7 @@ Examples of word characters:
     03B4 δ GREEK SMALL LETTER DELTA
     03F3 ϳ GREEK LETTER YOT
     0409 Љ CYRILLIC CAPITAL LETTER LJE
+    99F1 駱 CJK UNIFIED IDEOGRAPH-99F1
     =end code
 
 =head3 X<C<\c> and C<\C>|Regexes,\c;Regexes,\C>


### PR DESCRIPTION
The wording focusses mostly on "letters" so adding this example should clarify that e.g. CJK characters are also matched. The specific chosen character stands for "camel" in traditional Chinese, and probably [also in Japanese](https://www.japandict.com/%E9%A7%B1%E9%A7%9D#entry-1574540).