### PR TITLE
In regexes.rakudoc, correct description of `<punct>`

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -581,7 +581,7 @@ L<C<\c> and C<\C>|#\c_and_\C>.
     <digit>  | \d        | Decimal digits
     <xdigit> |           | Hexadecimal digit [0-9A-Fa-f]
     <alnum>  | \w        | <alpha> plus <digit>
-    <punct>  |           | Punctuation and Symbols (ASCII and Non-ASCII)
+    <punct>  |           | Punctuation and Symbols (ASCII and non-ASCII)
     <graph>  |           | <alnum> plus <punct>
     <space>  | \s        | Whitespace
     <cntrl>  |           | Control characters


### PR DESCRIPTION
https://docs.raku.org/language/regexes#Predefined_character_classes

The current description ("only Punct beyond ASCII") is wrong, because standard ASCII punctuation characters match, too.

From this [roast](https://github.com/Raku/roast/blob/b822369da22c305b84968acdb04328eeb3bd8947/S05-mass/charsets.t#L27), it's obvious that at least the matching of ASCII and latin punctation is indeed required, but like the present description says, non-ASCII-non-latin punctuation chars also match (REPL: `my $chars = [~] chr(0)..chr(0xFFFF); $chars.comb(/<punct>/).put;`), which also seems to be intended.