### PR TITLE
In quoting.rakudoc, add note how newline after Heredoc can be removed via `chomp`

### DIFF
--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -562,6 +562,14 @@ some multi line
 =end code
 
 I<Heredocs> include the newline from before the terminator.
+A common idiom to remove it is to put a L<C<chomp>|/type/Str#routine_chomp> at the beginning, for example:
+
+=begin code
+my $s = chomp q:to/END/;
+The result will have
+no final newline.
+END
+=end code
 
 To allow interpolation of variables use the C<qq> form, but you will then have
 to escape metacharacters C<\{> as well as C<$> if it is not the sigil for a


### PR DESCRIPTION
.. the idiom is used e.g. [here](https://docs.raku.org/language/regexes#Start_of_string_and_end_of_string).