### PR TITLE
In regexes.rakudoc, add explanations for <same> and <at(n)>, and fix/clarify some more

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -1595,7 +1595,7 @@ say HasOur.parse('Þor is mighty'); # OUTPUT: «｢Þor is mighty｣␤»
 say $HasOur::our;                  # OUTPUT: «Þor␤»
 =end code
 
-Once the parsing has been done successfully, we use the FQN name of the C<$our>
+Once the parsing has been done successfully, we use the L<FQN name|/syntax/FQN> of the C<$our>
 variable to access its value, that can be none other than C<Þor>.
 
 =head2 X<Named captures|Regexes,Named captures>


### PR DESCRIPTION
Both are only [mentioned](https://docs.raku.org/language/regexes#Predefined_Regexes) without any details so far. Their behavior is documented at the bottom of roast [S05-mass/stdrules.t](S05-mass/stdrules.t).

As for `at(n)`, I'm not entirely sure if presentation that I've chosen is the best, since `at` also installs a named capture and is nowhere explicitly called an anchor (although it works at least very similar to one).