### PR TITLE
in 2025.08, lizmat fixed the newly documented misbehavior of julian-date

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -120,6 +120,10 @@ E: liz@wenzperl.nl
 N: ennio
 E: scriplit@yahoo.com
 
+N: Eric Forste
+U: arkiuat
+E: arkiuat@mm.st
+
 N: Felix Herrmann
 E: felix@herrmann-koenigsberg.de
 

--- a/doc/Type/DateTime.rakudoc
+++ b/doc/Type/DateTime.rakudoc
@@ -280,8 +280,9 @@ is used in astronomy to define times of celestial objects transiting the
 Earth's Prime Meridian. For any instant, it is the sum of the number of whole days and
 the fraction of a day from that epoch to that instant.
 
-Note the C<julian-date> method does B<not> use any timezone information,
-and silently ignores it in the C<DateTime> object.
+Before Rakudo release 2020.08, the C<julian-date> method does B<not>
+use any timezone information, and silently ignores it in the
+C<DateTime> object.
 
 Available as of the 2021.04 Rakudo compiler release.
 
@@ -299,8 +300,9 @@ reference the same epoch (November 17, 1858).
 The MJD is obtained by subtracting the constant C<2_400_000.5> from the I<Julian Date> and is used to simplify
 transformations between civil and astronomical time systems.
 
-Note the C<modified-julian-date> method does B<not> use any timezone
-information, and silently ignores it in the C<DateTime> object.
+Before Rakudo release 2020.08, the C<julian-date> method does B<not>
+use any timezone information, and silently ignores it in the
+C<DateTime> object.
 
 Available as of the 2021.04 Rakudo compiler release.
 


### PR DESCRIPTION
## The problem

The recently documented behavior of the julian-date and modified-julian-date methods was corrected by lizmat as of release 2025.08. 

## Solution provided

Updated wording to reflect this. (also added to CREDITS)
