### PR TITLE
In regexes.rakudoc, add substution example `$str ~~ s[replace] = 'with';`

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -1807,7 +1807,7 @@ text out there.
 =head2 Common adverbs
 
 The full list of adverbs that you can apply to regular expressions can be found
-elsewhere in this document (L<section Adverbs|#Adverbs>), but the most
+elsewhere in this document (section L<Adverbs|#Adverbs>), but the most
 common are probably C<:g> and C<:i>.
 
 =item Global adverb C<:g>
@@ -1838,7 +1838,7 @@ case-insensitive.
     .say;                          # OUTPUT: «vegetable␤»
 
 For more information on what these adverbs are actually
-doing, refer to the L<Adverbs section|#Adverbs> of this document.
+doing, refer to the L<Adverbs|#Adverbs> section of this document.
 
 These are just a few of the transformations you can apply with the substitution
 operator. Some of the simpler uses in the real world include removing personal


### PR DESCRIPTION
Currently there's no substitution example showing that with balancing delimiters (like brackets) one can also operate on named string variables.

The behavior is intended, see e.g. this roast:
https://github.com/Raku/roast/blob/b822369da22c305b84968acdb04328eeb3bd8947/S05-substitution/subst.t#L273