### PR TITLE
In quoting.rakudoc, correct postfix for subs to `()`, and add postfix `{}` for hashes

### DIFF
--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -193,8 +193,8 @@ interpolated whenever the occur (unless escaped); that's why, in the example
 above, C<"$color"> became C<blue>.
 
 Variables with other sigils, however, only trigger interpolation when you follow
-the variable with the appropriate postfix (C<[]> for Arrays, C«<>», for Hashes,
-C<&> for Subs). This allows you to write expressions like
+the variable with the appropriate postfix (C<[]> for Arrays, C«<>» or C«{}» for Hashes,
+C<()> for Subs). This allows you to write expressions like
 C<"documentation@raku.org"> without interpolating the C<@raku> variable.
 
 To interpolate an Array (or other L<C<Positional>|/type/Positional> variable),


### PR DESCRIPTION
Hash interpolation with {} works too and is intended ([roast](https://github.com/Raku/roast/blob/b822369da22c305b84968acdb04328eeb3bd8947/S02-literals/hash-interpolation.t#L26)).

It even works with a scalar inside the {}, i.e. things like `"address{$person}"`. Not sure if that's explicitly intended too, though.
