### PR TITLE
Update modules.rakudoc

### DIFF
--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -312,7 +312,7 @@ no matter whether the using program adds any tag or not.
     =end code
 
 5. Multiple tags may be used in the C<export> trait, but they must
-   all be separated by either commas, or whitespace, but not both.
+   all be separated by whitespace, with or without commas.
 
    =begin code
    sub foo() is export(:foo :s2 :net) {}


### PR DESCRIPTION
## The problem

"but not both" doesn't match what the example actually shows

## Solution provided

changed "either commas, or whitespace, but not both" to "whitespace, with or without commas"
