### PR TITLE
regularize Mu's routine/sub/method headings

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -352,22 +352,6 @@ is considered to be a key again). It returns a L<C<Seq>|/type/Seq> of L<C<Pair>|
     say (a => 1, 'b', 'c').pairup.raku;     # OUTPUT: «(:a(1), :b("c")).Seq␤»
 
 X<|Syntax,$ (item contextualizer)>
-=head2 sub item
-
-    multi item(\x)
-    multi item(|c)
-    multi item(Mu $a)
-
-Forces given object to be evaluated in item context and returns the value of it.
-
-    say item([1,2,3]).raku;              # OUTPUT: «$[1, 2, 3]␤»
-    say item( %( apple => 10 ) ).raku;   # OUTPUT: «${:apple(10)}␤»
-    say item("abc").raku;                # OUTPUT: «"abc"␤»
-
-You can also use C<$> as item contextualizer.
-
-    say $[1,2,3].raku;                   # OUTPUT: «$[1, 2, 3]␤»
-    say $("abc").raku;                   # OUTPUT: «"abc"␤»
 
 =head2 method Array
 

--- a/doc/Type/Mu.rakudoc
+++ b/doc/Type/Mu.rakudoc
@@ -176,15 +176,25 @@ that can be used via L«C<EVAL>|/routine/EVAL» to reconstruct the value of the 
 
     say (1..3).Set.raku;  # OUTPUT: «Set.new(1,2,3)␤»
 
-=head2 method item
+=head2 routine item
 
     method item(Mu \item:) is raw
+    multi  item(\x)
+    multi  item(|c)
+    multi  item(Mu $a)
 
-Forces the invocant to be evaluated in item context and returns the value of it.
+Forces the invocant to be evaluated in item context and returns the
+value of it.
 
     say [1,2,3].item.raku;          # OUTPUT: «$[1, 2, 3]␤»
     say %( apple => 10 ).item.raku; # OUTPUT: «${:apple(10)}␤»
-    say "abc".item.raku;            # OUTPUT: «"abc"␤»
+    say item([1,2,3]).raku;         # OUTPUT: «$[1, 2, 3]␤»
+    say item("abc").raku;           # OUTPUT: «"abc"␤»
+
+You can also use C<$> as item contextualizer.
+
+    say $[1,2,3].raku;              # OUTPUT: «$[1, 2, 3]␤»
+    say $("abc").raku;              # OUTPUT: «"abc"␤»
 
 =head2 method self
 


### PR DESCRIPTION
## The problem

inconsistent use of designations "routine", "sub", & "method" in documenting routines of class Mu, as discussed in issue https://github.com/Raku/doc/issues/4560 

## Solution provided

regularized the most obvious inconsistencies, and also merged sub item (from class Any) with Mu's method item