### PR TITLE
Update `for` code on control.rakudoc

### DIFF
--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -583,7 +583,7 @@ list when they are needed, so to read a file line by line, you could
 use:
 
 =for code
-for $*IN.lines -> $line { .say }
+for $*IN.lines -> $ln { $ln.say }
 
 Iteration variables are always lexical, so you don't need to use C<my> to give
 them the appropriate scope. Also, they are read-only aliases. If you need them


### PR DESCRIPTION
Current code does not work because `$_` is the invocant of `.say` within the block. 
Pointy block variable must match outside/inside the block, and this pull request fixes the issue.

## The problem

`for $*IN.lines -> $line { .say }` does not work.

## Solution provided

`for $*IN.lines -> $ln { $ln.say }` works.