### PR TITLE
Add documentation for method new in Range

### DIFF
--- a/doc/Type/Range.rakudoc
+++ b/doc/Type/Range.rakudoc
@@ -116,6 +116,12 @@ with the exception. It will print C<Value> by default.
 
 =head1 Methods
 
+=head2 method new
+
+     multi method new(Range: \min, \max, :$excludes-min, :$excludes-max)
+
+Creates a new Range with the given minimum and maximum, and with the min and
+max excluded based on the values passed in the corresponding named arguments.
 
 =head2 method ACCEPTS
 


### PR DESCRIPTION
Method `new` wasn't present on Range's type page. now it is :)