### PR TITLE
move a slightly misplaced =head2 in create-cli.rakudoc

### DIFF
--- a/doc/Language/create-cli.rakudoc
+++ b/doc/Language/create-cli.rakudoc
@@ -190,6 +190,8 @@ Usage:
     --verbose         required verbosity
 =end code
 
+=head2 Command lines and usage messages: more examples
+
 From release 2021.03, values to single named arguments can be separated by
 spaces too. Consider a C<demo> program with the following source:
 
@@ -215,8 +217,6 @@ Usage:
     --debug-port=<port>    Listen for debugger connections on the specified port
     -v                     Display verbose output
 =end code
-
-=head2 Command lines and usage messages: more examples
 
 The following are valid ways to call C<demo>:
 


### PR DESCRIPTION
one of the new =head2 section titles that I recently added was slightly misplaced.  I moved it up a couple of paragraphs so it corresponds better to the actual structure of the text.

## The problem


## Solution provided

<!--

    The template below contains optional suggestions. Simply omit it
    if you think it does not apply to this PR.

    Please state clearly in "The problem" what you are addressing with this
    pull request, referencing the issue(s) where it is described.

    In "Solution provided", tell us what you have done to address the
    problem.

-->
