### PR TITLE
linkfix in signatures.rakudoc

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -693,7 +693,7 @@ the function body.
     say s(2); # 10 / 2 * 2 == 10
 
 A captured type can be used as the return type constraint
-(cf. L<Constraining return types|/language/signature/Constraining_return_types>):
+(cf. L<Constraining return types|/language/signatures#Constraining_return_types>):
 
     sub cast-by-example(Any $x, ::T $example --> T) { T($x) }
     sub cast-or-create(Any $x, ::T $example --> T:D) { with $x { T($x) } else { T.new } }


### PR DESCRIPTION
Correct link to point to is https://docs.raku.org/language/signatures#Constraining_return_types