### PR TITLE
In Capture.rakudoc: "are still Lists" → "are still like Lists"; typos

### DIFF
--- a/doc/Type/Capture.rakudoc
+++ b/doc/Type/Capture.rakudoc
@@ -146,8 +146,8 @@ Returns the number of positional elements in the C<Capture>.
     multi method keys(Capture:D: --> Seq:D)
 
 Returns a L<C<Seq>|/type/Seq> containing all positional keys followed by all
-named keys. For positional arguments the keys are the respective argument's
-ordinal position starting from zero.
+named keys. For positional arguments the keys are the respective arguments'
+ordinal positions starting from zero.
 
     my $capture = \(2, 3, 5, apples => (red => 2));
     say $capture.keys; # OUTPUT: «(0 1 2 apples)␤»


### PR DESCRIPTION
Only minor changes in [type/Capture](https://docs.raku.org/type/Capture). Saying "are still like Lists" should be a bit more accurate than "are still Lists", given the inheritance graph and this explanation:

"Captures contain a list-like part for positional arguments and a hash-like part for named arguments, thus behaving as [Positional](https://docs.raku.org/type/Positional) and [Associative](https://docs.raku.org/type/Associative), although it does not actually mix in those roles. Like any other data structure, a stand-alone capture can be created, stored, and used later."