### PR TITLE
In signatures.rakudoc, some rewording re. slurpies & single argument rule

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -106,12 +106,12 @@ It can have any name; conventionally, it's an underscore:
 
 Signatures can also contain a slurpy positional parameter
 (which must be the last of all positional parameters);
-it slurps up any extra positional arguments into one big array.
+it slurps up any extra positional arguments into one big L<C<Array>|/type/Array>.
 The slurpy positional parameter can be one of L<three kinds|/language/signatures#Types_of_slurpy_array_parameters>:
 
-    my $sig = :($p, :$n, **@_); # keep arguments the way they are
-    my $sig = :($p, :$n,  *@_); # flatten any iterable arguments
-    my $sig = :($p, :$n,  +@_); # flatten the argument if it is _one_ iterable, else act like **@_
+    my $sig = :($p, :$n, **@_); # keep arguments as they are: @_ contains one entry per argument
+    my $sig = :($p, :$n,  *@_); # flatten any lists
+    my $sig = :($p, :$n,  +@_); # set @_ = argument if it's a single list, else act like **@_
 
 =head1 Parameter separators
 
@@ -788,7 +788,7 @@ make routines that use them I<variadic>, and by extension are called variadic
 arguments. Here we will focus on slurpy parameters, or simply I<slurpies>.
 
 An array or hash parameter can be
-marked as I<slurpy> by leading single (C<*>) or double asterisk (C<**>) or a
+marked as I<slurpy> by a leading single (C<*>) or double asterisk (C<**>) or a
 leading plus (C<+>). A slurpy parameter can bind to an arbitrary number of
 arguments (zero or more), and it will result in a type that is compatible
 with the sigil.
@@ -846,7 +846,7 @@ assign the value from each argument to those L<C<Scalar>|/type/Scalar>s.  If the
 argument also had an intermediary L<C<Scalar>|/type/Scalar> it is bypassed during this process,
 and is not available inside the called function.
 
-Sigiled parameters will always impose a context on the collected arguments.
+Sigiled parameters will always impose a L<context|/language/contexts> on the collected arguments.
 Sigilless parameters can also be used slurpily, preceded by a + sign, to
 work with whatever initial type they started with:
 
@@ -863,7 +863,7 @@ as described in
 L<the section on slurpy array parameters|/language/signatures#Types_of_slurpy_array_parameters>.
 
 L<Methods|/type/Method> automatically get a C<*%_> slurpy named parameter added if they
-don't have another slurpy named parameter declared.
+don't have one declared.
 
 =head1 Types of slurpy array parameters
 
@@ -873,11 +873,9 @@ There are three variations to slurpy array parameters.
 
 =item The double-asterisk form C<**@> does not flatten arguments.
 
-=item The plus form C<+@> flattens according to the single argument rule.
+=item The plus form C<+@> flattens according to the L<single argument rule|/language/list#Single_Argument_Rule>.
 
-Each will be described in detail in the next few sections. As the difference
-between each is a bit nuanced, examples are provided for each to demonstrate how
-each slurpy convention varies from the others.
+We now describe each of them in detail.
 
 =head2 X<Flattening slurpy: C<*@>|Syntax,*@>
 
@@ -932,8 +930,8 @@ in the slurpy array.
 X<|Syntax,+ (Single argument rule slurpy)>
 =head2 Single argument rule slurpy: C<+@>
 
-A slurpy parameter created using a plus engages the I<"single argument rule">,
-which decides how to handle the slurpy argument based upon context. Basically,
+A slurpy parameter created using a plus engages the L<single argument rule|/language/list#Single_Argument_Rule>,
+which decides how to handle the slurpy argument based on context. Basically,
 if only a single argument is passed and that argument is
 L<C<Iterable>|/type/Iterable>, that argument is used to fill the slurpy parameter
 array. In any other case, C<+@> works like C<**@>.


### PR DESCRIPTION
Some rewording on things related to slurpies and the single argument rule.

The most material change is the comment (in the introduction) about `+@`: My previous formulation, that it "flattens if it is _one_ argument", was incorrect in that it read as if the behavior on a single list would be like that of `*@`, which it isn't.

```
> sub fa(*@_) { .say for @_} ; fa( ((1,2,3),) )
1
2
3
> sub fp(+@_) { .say for @_ } ; fp( ((1,2,3,) )
(1 2 3)
```

Also I've opted to speak of "lists" rather than "Iterables" in a few places since Scalars can still do the Iterable role.