### PR TITLE
DRAFT: Issue 4560, class Any

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -30,45 +30,52 @@ Returns C<True> if C<$other === self> (i.e. it checks object identity).
 
 Many built-in types override this for more specific comparisons.
 
-=head2 method any
+=head2 routine any
 
-    method any(--> Junction:D)
+    method any(        --> Junction:D)
+    sub    any(+values --> Junction:D)
 
-Interprets the invocant as a list and creates an
+Interprets the invocant or arguments as a list and creates an
 L<any|/routine/any>-L<C<Junction>|/type/Junction> from it.
 
     say so 2 == <1 2 3>.any;        # OUTPUT: «True␤»
-    say so 5 == <1 2 3>.any;        # OUTPUT: «False␤»
+    say so 5 == any(<1 2 3>);       # OUTPUT: «False␤»
 
-=head2 method all
+=head2 routine all
 
-    method all(--> Junction:D)
+    method all(        --> Junction:D)
+    multi  all(+values --> Junction:D)
+    multi  all(@values --> Junction:D)
 
-Interprets the invocant as a list and creates an
+Interprets the invocant or arguments as a list and creates an
 L<all|/routine/all>-L<C<Junction>|/type/Junction> from it.
 
-    say so 1 < <2 3 4>.all;         # OUTPUT: «True␤»
     say so 3 < <2 3 4>.all;         # OUTPUT: «False␤»
+    say so 1 < all(<2 3 4>);        # OUTPUT: «True␤»
 
-=head2 method one
+=head2 routine one
 
-    method one(--> Junction:D)
+    method one(        --> Junction:D)
+    multi  one(+values --> Junction:D)
+    multi  one(@values --> Junction:D)
 
-Interprets the invocant as a list and creates a
+Interprets the invocant or arguments as a list and creates a
 L<one|/routine/one>-L<C<Junction>|/type/Junction> from it.
 
     say so 1 == (1, 2, 3).one;      # OUTPUT: «True␤»
-    say so 1 == (1, 2, 1).one;      # OUTPUT: «False␤»
+    say so 1 == one(1, 2, 1);       # OUTPUT: «False␤»
 
-=head2 method none
+=head2 routine none
 
-    method none(--> Junction:D)
+    method none(        --> Junction:D)
+    multi  none(+values --> Junction:D)
+    multi  none(@values --> Junction:D)
 
-Interprets the invocant as a list and creates a
+Interprets the invocant or arguments as a list and creates a
 L<none|/routine/none>-L<C<Junction>|/type/Junction> from it.
 
     say so 1 == (1, 2, 3).none;     # OUTPUT: «False␤»
-    say so 4 == (1, 2, 3).none;     # OUTPUT: «True␤»
+    say so 4 == none(1, 2, 3);      # OUTPUT: «True␤»
 
 =head2 method list
 


### PR DESCRIPTION
## The problem

inconsistent use of designations "routine", "sub", & "method" in documenting routines of class Any, as discussed in issue https://github.com/Raku/doc/issues/4560

## Solution provided

adding subs to method listings missing them; adding methods to sub listings missing them, etc