### PR TITLE
In Attribute.rakudoc, create section for trait is readonly

### DIFF
--- a/doc/Type/Attribute.rakudoc
+++ b/doc/Type/Attribute.rakudoc
@@ -169,7 +169,7 @@ Marks as C<readonly> an attribute of a class that has the C<is rw> trait.
     # OUTPUT: «Cannot modify an immutable Str (copper)␤...»
     =end code
 
-The attributes of classes without the C<is rw> trait are already readonly by default,
+The attributes of classes without the C<is rw> trait are already readonly by default.
 Thus, in classes without the C<is rw> trait, the attribute trait C<is readonly> is redundant.
 
 =head2 X<trait is built|Traits,is built>


### PR DESCRIPTION
Introduce section for the `is readonly` trait for [Attributes](https://docs.raku.org/type/Attribute#Traits), which isn't documented so far. 

The new example is tested with Rakudo (Rakudo Star v2025.04, MoarVM version 2025.04).

This trait is specced in roast `S12-class/rw.t`, lines 31 to 34:
```
  19 │     my class Bar is rw {
  20 │         has $.readwrite_attr;
  21 │         has $.but_not_this is readonly;
  22 │     }
  23 │ 
  24 │     my Bar $bar .= new(but_not_this => 42);
  25 │ 
  26 │     lives-ok { $bar.readwrite_attr++ },
  27 │         "'is rw' on the class declaration applies to all attributes (1)";
  28 │     is $bar.readwrite_attr, 1,
  29 │         "'is rw' on the class declaration applies to all attributes (2)";
  30 │ 
  31 │     dies-ok { $bar.but_not_this = 42 },
  32 │         "'is readonly' on a specific attribute can overrule the is rw on the class (1)";
  33 │     is $bar.but_not_this, 42,
  34 │         "'is readonly' on a specific attribute can overrule the is rw on the class (2)";
```