### PR TITLE
In Hash.rakudoc, remove extra colon

### DIFF
--- a/doc/Type/Hash.rakudoc
+++ b/doc/Type/Hash.rakudoc
@@ -287,7 +287,7 @@ categories the routine produces. The second item in that array indicates
 further levels of classification, in our case the classification into
 C<prime>/C<non-prime> inside of each category.
 
-B<NOTE:>: every L«C<Iterable>|/type/Iterable»s category
+B<NOTE:> every L«C<Iterable>|/type/Iterable»s category
 must have the same number of elements, or the method will throw an exception.
 This restriction exists to avoid conflicts when the same key is a
 leaf of one value's classification but a node of another value's classification.


### PR DESCRIPTION
simple typo