### PR TITLE
Some work on py-nutshell.rakudoc

### DIFF
--- a/doc/Language/py-nutshell.rakudoc
+++ b/doc/Language/py-nutshell.rakudoc
@@ -125,7 +125,7 @@ initialized or declared and initialized at once.
     $foo = 12;     # initialize
     my $bar = 19;  # both at once
 
-Also, as you may have noticed, variables in Raku usually start with sigils –
+Also, as you may have noticed, variables in Raku usually start with sigils—
 symbols indicating the type of their container. Variables starting with a C<$>
 hold scalars. Variables starting with an C<@> hold arrays, and variables
 starting with a C<%> hold a hash (dict). Sigilless variables, declared with a


### PR DESCRIPTION
This will partly address issue #2354.

Note to self:

Add a rudimentary section on Raku's type system below the section on variables.
In this new section, include among other things the distinction between definite and indefinite objects.

In the section "Control flow", include (a little bit) of material on `given` and `//` – mostly to show what would be Raku equivalents of the common Python idiom `if x is not None`. Perhaps split the control flow section into the two subsections "Conditionals" (if, given, when...) and "Iteration" (for, while/until, loop...).