### PR TITLE
In Enumeration.rakudoc, add output of `.WHAT` to example

### DIFF
--- a/doc/Type/Enumeration.rakudoc
+++ b/doc/Type/Enumeration.rakudoc
@@ -16,7 +16,7 @@ types:
 
     enum norse-gods <Þor Oðin Loki>;
     my $one-of-them = norse-gods.pick;
-    say $one-of-them.WHAT; # OUTPUT: «(norse-gods)␤»
+    say $one-of-them.^name; # OUTPUT: «(norse-gods)␤»
     say $one-of-them ~~ Enumeration; # OUTPUT: «True␤»
 
 but nothing prevents you from using it in your own programs if you want to


### PR DESCRIPTION
Currently the first code example of the [document](https://docs.raku.org/type/Enumeration) is

```
enum norse-gods <Þor Oðin Loki>;
my $one-of-them = norse-gods.pick;
say $one-of-them ~~ Enumeration; # OUTPUT: «True␤»
```

I've added the line `say $one-of-them.WHAT` to highlight the fact that `$one-of-them` is more than just a string. This then makes it easier to understand why it smartmatches `Enumeration`.