### PR TITLE
In list.rakudoc, add explanations and references about indexing

### DIFF
--- a/doc/Language/list.rakudoc
+++ b/doc/Language/list.rakudoc
@@ -74,10 +74,22 @@ first element of a list is at index number zero:
 say (1, 2)[0];  # says 1
 say (1, 2)[1];  # says 2
 say (1, 2)[2];  # says Nil
+
+Counting backwards from the end is done with the L<C<Whatever>|/type/Whatever> star
+(details on the page on L<Subscripts|/language/subscripts#From_the_end>):
 =for code :skip-test<syntax error>
-say (1, 2)[-1]; # Error
+say (1, 2)[*-1]; # says 2
+say (1, 2)[-1];  # Error
+
+To access elements of nested (multidimensional) lists,
+separate the indices for different dimensions with semicolons:
 =for code
 say ((<a b>,<c d>),(<e f>,<g h>))[1;0;1]; # says "f"
+
+Pulling out multiple elements at once is possible
+by passing lists or ranges of indices;
+this is described in sections L<Slice indexing context|#Slice_indexing_context>
+and L<Range as slice|#Range_as_slice>.
 
 =head1 The @ sigil
 


### PR DESCRIPTION
This in particular adds the correct example for indexing lists from the end, `(1, 2)[*-1];`.