### PR TITLE
rm duplicate paragraph in Language/signatures

### DIFF
--- a/doc/Language/signatures.rakudoc
+++ b/doc/Language/signatures.rakudoc
@@ -142,10 +142,6 @@ Another exception is the L<double semicolon C<;;>|/language/Signatures#The_;;_se
 which can take the place of one comma in a L<multi|/language/functions#Multi-dispatch> signature
 to declare that the subsequent parameters should not contribute to its precedence in multiple dispatch.
 
-A further exception is the L<double semicolon C<;;>|/language/Signatures#The_;;_separator>,
-which can be used in L<multi|/language/functions#Multi-dispatch> signatures to declare that all subsequent parameters should not
-contribute to its precedence under multiple dispatch.
-
 X<|Language,type constraint>
 X<|Language,Constraint>
 =head1 Type constraints


### PR DESCRIPTION
## The problem

The new paragraph explaining the double semicolon in multi-dispatch signatures was duplicated almost exactly. 

## Solution provided

removed the slightly weaker of the two versions.