### PR TITLE
changing method to routine for deepmap, in type/Any

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -199,15 +199,15 @@ L<deepmap|/routine/deepmap> will descend recursively into the sublist.
 
     say [[1,2,3],[[4,5],6,7]].deepmap(* + 1);
     # OUTPUT: «[[2 3 4] [[5 6] 7 8]]␤»
-    say deepmap * + 1, [[1,2,3],[[4,5],6,7]]
+    say deepmap * + 1, [[1,2,3],[[4,5],6,7]];
     # OUTPUT: «[[2 3 4] [[5 6] 7 8]]␤»
 
 In the case of L<C<Associative>|/type/Associative>s, it will be applied to its values:
 
 =for code
-{ what => "is", this => "thing", a => <real list> }.deepmap( *.flip ).say
+{ what => "is", this => "thing", a => <real list> }.deepmap( *.flip ).say;
 # OUTPUT: «{a => (laer tsil), this => gniht, what => si}␤»
-say deepmap *.flip, {what=>'is', this=>'thing', a=><real list>}
+say deepmap *.flip, {what=>'is', this=>'thing', a=><real list>};
 # OUTPUT: «{a => (laer tsil), this => gniht, what => si}␤»
 
 =head2 method duckmap


### PR DESCRIPTION
Adding documentation for the sub form of deepmap (in type/Any) as per docs issue https://github.com/Raku/doc/issues/4560

## The problem

deepmap was documented only as a method, with no hint about its sub form

## Solution provided

changed entry from `method` to `routine` and added documentation for the sub form