### PR TITLE
Fix link to categorize method in List documentation

### DIFF
--- a/doc/Type/List.rakudoc
+++ b/doc/Type/List.rakudoc
@@ -583,7 +583,7 @@ that as the number of elements in the output L<C<Seq>|/type/Seq>.
     multi        categorize($test, +items, *%named )
 
 These methods are directly inherited from L<C<Any>|/type/Any>; see
-L<C<Any.list>|/type/Any#routine_categorize> for more examples.
+L<C<Any.categorize>|/type/Any#routine_categorize> for more examples.
 
 This routine transforms a list of values into a hash representing the
 categorizations of those values according to C<$test>, which is called once for


### PR DESCRIPTION
## The problem

Linktext for link to Any#routine_categorize was "Any.list"

## Solution provided

Changed linktext to "Any.categorize"