### PR TITLE
eliminate superstitious parentheses in operators.rakudoc

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -3554,17 +3554,17 @@ operands are false, returns the last one.
 This X<feed|Infix operators,feed> operator takes the result from the left and passes it to the
 next (right) routine as the last parameter.
 
-     my @array = (1, 2, 3, 4, 5);
+     my @array = 1, 2, 3, 4, 5;
      @array ==> sum() ==> say();   # OUTPUT: «15␤»
 
 This simple example, above, is the equivalent of writing:
 
-     my @array = (1, 2, 3, 4, 5);
+     my @array = 1, 2, 3, 4, 5;
      say(sum(@array));             # OUTPUT: «15␤»
 
 Or if using methods:
 
-     my @array = (1, 2, 3, 4, 5);
+     my @array = 1, 2, 3, 4, 5;
      @array.sum.say;               # OUTPUT: «15␤»
 
 The precedence is very loose so you will need to use parentheses to


### PR DESCRIPTION
## The problem

superstitious parentheses in code example in the doco of the feed operator (in operators.rakudoc)

## Solution provided

removed