### PR TITLE
In 101-basics.rakudoc, remove unneeded word

### DIFF
--- a/doc/Language/101-basics.rakudoc
+++ b/doc/Language/101-basics.rakudoc
@@ -266,7 +266,7 @@ operator C<=>. This is not only because the shorter version requires less
 typing, but also because the C<+=> operator silently initializes undefined
 values of the hash's key-value pairs to zero. In other words: by using C<+=>,
 there is no need to include a separate statement like C<%sets{$p1} = 0> before
-you can meaningfully add C<$r1> to it. We'll look at this is behavior in a bit
+you can meaningfully add C<$r1> to it. We'll look at this behavior in a bit
 more detail below.
 
 =head2 X<C<Any>|Tutorial,Any (Basics)> and X<C<+=>|Tutorial,+= (Basics)>


### PR DESCRIPTION
remove superfluous "is" in a sentence