### PR TITLE
In intro.rakudoc, fix grammar & clarify that «» quotes have special semantics

### DIFF
--- a/doc/Language/intro.rakudoc
+++ b/doc/Language/intro.rakudoc
@@ -72,9 +72,10 @@ my @a = 1, 2, 3;
 say @a;             # OUTPUT: «[2 3 4]␤»
 
 Note on the last line, there is a comment, starting with C<# OUTPUT:>, that shows what the example outputs.
-The output is wrapped in C<«»> quotes (also a valid quoting construct in Raku!), and may include a C<␤>, which
-is the Unicode character "Symbol for Newline" - to indicates where in the actual output a literal newline would
-appear.
+The output is wrapped in C<«»> quotes and may include a C<␤>, which
+is the Unicode character "Symbol for Newline", to indicate where in the actual output a literal newline would
+appear. (C<«»> quotes are also a valid L<quoting construct|/language/quoting> in Raku,
+but with special semantics.)
 
 =end item
 


### PR DESCRIPTION
From the previous wording, a new reader would likely suspect that `«»` quotes in Raku code to behave similarly to the `«»` in `"OUTPUT: «»` comments, i.e. do nothing.