### PR TITLE
type/Any#duckmap: changing method to routine

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -188,8 +188,8 @@ the L<C<Seq>|/type/Seq> will be iterating over its elements, calling C<.take> on
 
 =head2 routine deepmap
 
-    method deepmap(&block --> List) is nodal
-    multi  deepmap(&op, \obj)
+    method deepmap(&block --> Iterable) is nodal
+    multi  deepmap(&op, \obj --> Iterable)
 
 C<deepmap> will apply its argument (or first argument for the sub form) to
 each element and return a new L<C<Iterable>|/type/Iterable> with the return


### PR DESCRIPTION
## The problem

duckmap was documented only as a method, not as a routine/sub

## Solution provided

added the missing bits per https://github.com/Raku/doc/issues/4560, but the result is a bit unwieldy. Other edits to this entry needed anyway, though, and I'll be making a separate issue for that.