### PR TITLE
In exceptions.rakudoc, remove a `CATCH` keyword. Plus some stylistic improvements.

### DIFF
--- a/doc/Language/exceptions.rakudoc
+++ b/doc/Language/exceptions.rakudoc
@@ -388,7 +388,7 @@ sub bad-sub {
     say "Returned $return";
     CATCH {
         default {
-            say "Error ", .^name, ': ',.Str;
+            say "Error ", .^name, ': ', .Str;
             $return = '0';
             .resume;
         }


### PR DESCRIPTION
Since the outer `CATCH` statement serves no function here, I think the example will be more transparent without that keyword (i.e. with only `{}` instead of `CATCH {}`).

I guess one could try to cook something up with two nested `CATCH`es that illustrates how the outer `CATCH` block does give back control to the encompassing (main) block. However, as the example is now, neither of the `CATCH` blocks even gets entered in the first place, because no Failure is thrown in the main block. So removing the `CATCH` word before the outer block is an improvement.