### PR TITLE
In regexes.rakudoc, add cross-reference to /type/Str

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -3066,4 +3066,7 @@ The L<Regexes: Best practices and gotchas|/language/regexes-best-practices>
 provides useful information on how to avoid common pitfalls when writing regexes
 and grammars.
 
+See also the type reference for L<C<Str>|/type/Str> for an overview of
+ways other than regexes to investigate and manipulate strings.
+
 =end pod


### PR DESCRIPTION
Among the [reference](https://docs.raku.org/reference) pages, there is (currently) none that's dedicated to working with given strings by means other than regexes. The type reference on Str probably comes closest to this. Thus I think it's good if the regexes page explicitly refers to it.