### PR TITLE
Z metaoperator & infix:<Z>: clarify their relationship

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -3126,7 +3126,7 @@ list:
     say 100, 200 Z+ 42, 23;             # OUTPUT: «(142 223)␤»
     say 1..3 Z~ <a b c> Z~ 'x' xx 3;    # OUTPUT: «(1ax 2bx 3cx)␤»
 
-C<infix:<Z>> is a shortcut for C<Z,>, which is the L<C<Z> metaoperator|/language/operators#Zip_metaoperator> 
+C<infix:<Z>> is a shortcut for C<Z,>, which is the L<C<Z> metaoperator|/language/operators#Zip_metaoperator>
 applied to the L<C<,> list-construction operator|/language/operators#infix_,>.
 
 As any other infix operator, it can be used under its full name:


### PR DESCRIPTION
## The problem

The relationship between `infix:<Z>` and the `Z` metaoperator was not explained very well, with only implicit mention of the fact that `infix:<Z>` is a shortcut for `Z,`

## Solution provided

Added more links between the two sections, and spelled out the fact that `infix:<Z>` is a shortcut for `Z,`
