### PR TITLE
In Str.rakudoc, fix invocant marker & formatting

### DIFF
--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -45,15 +45,14 @@ Examples:
 
 =head2 method contains
 
-    multi method contains(Str:D $:: Str:D $needle --> Bool)
-    multi method contains(Str:D $:: Str:D $needle, Int:D $pos --> Bool)
-    multi method contains(Str:D $:: Str:D $needle, :m(:$ignoremark)! --> Bool)
-    multi method contains(Str:D $:: Str:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool)
-    multi method contains(Str:D $:: Str:D $needle, Int:D $pos, :m(:$ignoremark)! --> Bool)
-    multi method contains(Str:D $:: Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool)
-    multi method contains(Str:D $:: Regex:D $needle --> Bool)
-    multi method contains(Str:D $:: Regex:D $needle, Int:D $pos --> Bool)
-
+    multi method contains(Str:D: Str:D $needle --> Bool)
+    multi method contains(Str:D: Str:D $needle, Int:D $pos --> Bool)
+    multi method contains(Str:D: Str:D $needle, :m(:$ignoremark)! --> Bool)
+    multi method contains(Str:D: Str:D $needle, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool)
+    multi method contains(Str:D: Str:D $needle, Int:D $pos, :m(:$ignoremark)! --> Bool)
+    multi method contains(Str:D: Str:D $needle, Int:D $pos, :i(:$ignorecase)!, :m(:$ignoremark) --> Bool)
+    multi method contains(Str:D: Regex:D $needle --> Bool)
+    multi method contains(Str:D: Regex:D $needle, Int:D $pos --> Bool)
 
 Given a C<Str> invocant (known as the I<haystack>) and a first argument
 (known as the C<$needle>), it searches for the C<$needle> in the I<haystack>
@@ -78,7 +77,7 @@ Similarly, C<$pos> can be of type C<Cool>, which will be coerced to C<Int>.
 (Technically, these cases will take a detour over L<C<Cool.contains>|/type/Cool#method_contains>,
 which does the coercions and then calls C<Str.contains>.)
 
-    say "Hello, 12345".contains(5, "10.0");     # OUTPUT: «True␤»
+    say "Hello, 12345".contains(5, "10.0");    # OUTPUT: «True␤»
 
 Since Rakudo release 2020.02, the C<$needle> can also be
 a L<C<Regex>|/type/Regex> in which case the C<contains> method


### PR DESCRIPTION
This PR should fix issues with example compilation introduced by my [commit yesterday](https://github.com/Raku/doc/commit/93aba54f436b2b996533a508c1b80489038ad70f).