### PR TITLE
Revise description of named arrays in create-cli.rakudoc

### DIFF
--- a/doc/Language/create-cli.rakudoc
+++ b/doc/Language/create-cli.rakudoc
@@ -294,9 +294,9 @@ Usage:
 
 =head2 Named arrays
 
-The MAIN subroutine can also use a kind of named parameter not available
-to ordinary subs: the named array.  This enables, for instance, providing
-two different short arrays as arguments on a command line.
+The MAIN subroutine can also use a different kind of named parameter: the named array.
+This enables, for instance, providing two different short arrays as arguments on a
+command line.
 
 Declare a named-array parameter with C<:@> in sub MAIN's signature:
 


### PR DESCRIPTION
## The problem

In my first version, I incorrectly stated that other subs (than MAIN) can't use named arrays, but this isn't right. They just work somewhat differently, particularly on the calling/argument side, but look much the same on the parameter side.

## Solution provided

Revised the passage so as not to be misleading.