### PR TITLE
Mention Lock::Async in language/concurrency

### DIFF
--- a/doc/Language/concurrency.rakudoc
+++ b/doc/Language/concurrency.rakudoc
@@ -828,6 +828,20 @@ C<protect> returns whatever the code block returns.
 Because C<protect> will block any threads that are waiting to execute
 the critical section the code should be as quick as possible.
 
+=head2 Lock::Async
+
+L<C<Lock::Async>|/type/Lock::Async> is a mutual exclusion mechanism much like
+Lock, but it exposes its functionality through C<Promise>s, allowing the use of
+C<await> when waiting for a lock to become available, instead of blocking an
+entire thread.
+
+Another difference is that it is not re-entrant, meaning that the lock is not
+considered available to code that is C<protect>ed by the lock.
+
+C<Lock::Async> is more high-level than C<Lock>, but it is still considered a
+low-level primitive. Higher-level primitives should be preferred over mutating
+shared data inside critical sections.
+
 =head1 Safety concerns
 
 Some shared data concurrency issues are less obvious than others.


### PR DESCRIPTION
mention and link Lock::Async in the language/concurrency page. It is preferable to Lock, though other high-level concurrency bits are better.