### PR TITLE
Document parameters :$heap and $message of Telemetry::snap

### DIFF
--- a/doc/Type/Telemetry.rakudoc
+++ b/doc/Type/Telemetry.rakudoc
@@ -99,22 +99,23 @@ become the value of the C<message> attribute of the new C<Telemetry> object.
 
 Also from release 2019.07, one can pass a named argument C<:heap>
 to instruct the compiler to write a heap snapshot to a file.
+From release 2021.12, C<snap> returns that filename.
 The argument C<:heap> can be of type C<Bool>, C<Str>, or C<IO::Path>. Their implications are as follows:
 
 =item C<IO::Path>, e.g. C«snap( heap => 'outputfile'.IO )»: The snapshot will be written to exactly this path.
-The returned filename is an absolute path.
+The returned filename is always an absolute path.
 
 =item C<Str>, e.g. C«snap(:heap<outputfile>)»: The snapshot will be written to this path I<if> no such file already exists.
 If such a file already exists, the snapshot will instead be written to C<outputfile-$($*PID)-$($i).mvmheap>
-(where C<$i> starts at 1 and increases each time). The returned filename is a relative path.
+(where C<$i> starts at 1 and increases each time).
+The returned filename is a relative or an absolute path depending on what form C<:heap> has.
 
 =item Boolean C<True>, e.g. C<snap(:heap)>: The snapshot will be written to the file C<heapsnapshot-$($*PID)-$($i).mvmheap>.
-The returned filename is a relative path.
+The returned filename is always a relative path.
 
-Additionally, in each of these cases, two ordinary C<Telemetry> object are pushed to the internal array:
-One is object created just before writing the snapshot and has C<$message> as its C<message> attribute.
+Additionally, in each of these cases, two ordinary C<Telemetry> objects are pushed to the internal array:
+One of them is created just before writing the snapshot and has C<$message> as its C<message> attribute.
 The other is created just after writing the snapshot and has the filename as ith C<message> attribute.
-From release 2021.12, C<snap> returns that filename.
 
 Finally, there's also this option for C<:heap>:
 


### PR DESCRIPTION
As requested in issue #2905, this documents the parameters :$heap and $message that got introduced with release 2019.07 through the commits [afc9f84](https://github.com/rakudo/rakudo/commit/afc9f849), [90e18b6](https://github.com/rakudo/rakudo/commit/90e18b65), and [0c80e06](https://github.com/rakudo/rakudo/commit/0c80e067) .

It also adds the information that it was with release 2017.11 (commit [5244048](https://github.com/rakudo/rakudo/commit/52440486188faf0ad1310f87ff5c2acdd4169498)) that the option to pass a custom array `@s` got introduced.