### PR TITLE
Language/REPL: make Trap section more prominent per issue 3908

### DIFF
--- a/doc/Language/REPL.rakudoc
+++ b/doc/Language/REPL.rakudoc
@@ -10,6 +10,12 @@ The C<REPL> is an interactive Raku prompt. Each line of code you enter in the C<
 is executed, and if no output was generated, the value returned
 by the expression is output.
 
+=head1 Trap
+
+B<Note>: Running code in the C<REPL> is not equivalent to saving the code in a file and
+running that. Each line introduces a new scope which can confuse code that has multiple
+lines. See C<sub repl()> below for a way to target a REPL inside a larger script.
+
 =head1 Previous Values
 
 As you enter commands into the REPL, each line has a numeric ID associated with it, starting
@@ -32,12 +38,6 @@ To exit type 'exit' or '^D'
 40
 [3] >
 =end code
-
-=head1 Trap
-
-B<Note>: Running code in the C<REPL> is not equivalent to saving the code in a file and
-running that. Each line introduces a new scope which can confuse code that has multiple
-lines. See C<sub repl()> below for a way to target a REPL inside a larger script.
 
 =head1 non-interactive mode
 


### PR DESCRIPTION
## The problem

Issue [3908](https://github.com/Raku/doc/issues/3908) shows that guidance is needed about pasting example code into the REPL, because it won't always work. There's an existing Trap section that explains this, but it has gotten a little buried in the article.

## Solution provided

Moved Trap section up to immediately follow the Overview section.
