### PR TITLE
More Information on Attribute Traits

### DIFF
--- a/doc/Language/objects.rakudoc
+++ b/doc/Language/objects.rakudoc
@@ -273,7 +273,7 @@ default constructor, the attribute C<@!travelers> is not initialized.
 
 =head2 Traits
 
-Several Traits are provided to modify the behavior of attributes.
+Several traits are provided to modify the behavior of attributes.
 Attribute traits are introduced by the C<is> keyword after the attribute name.
 The following traits (and some others) are documented L<here|/type/Attribute#Traits>.
 
@@ -300,15 +300,15 @@ Here's how to construct and use this new version of Journey:
 # Create a new instance of the class.
 my $vacation = Journey.new(
     origin      => 'Sweden',
-    status      => 'Requested',
+    status      => 'Requested'
 );
 
 # Use a setter accessor on a read/write attribute, then a getter to read it,
-then assign Nil to reset the default.
+# then assign Nil to reset the default.
 $vacation.destination = 'San Francisco';
-say $vacation.destination;    #OUTPUT San Francisco
-$vacation.destination = Nil;  #resets to default
-say $vacation.destination;    #OUTPUT Orlando
+say $vacation.destination;    # OUTPUT: «San Francisco␤»
+$vacation.destination = Nil;
+say $vacation.destination;    # OUTPUT: «Orlando␤»
 
 # Try to change a built private attribute later.
 try { $vacation.status = 'Booked'; }  #ERROR


### PR DESCRIPTION
Some of the more recent attribute traits (`is built`) are not covered in the Objects tutorial. This introduces a new short section to summarize all the available attribute traits (as documented in `class Attribute`

See this SO question:

https://stackoverflow.com/questions/79836453/instantiating-required-attributes-without-build-submethod/79836679#79836679
