### PR TITLE
Revise variable interpolation explanation in quoting.rakudoc

### DIFF
--- a/doc/Language/quoting.rakudoc
+++ b/doc/Language/quoting.rakudoc
@@ -572,9 +572,7 @@ no final newline.
 END
 =end code
 
-To allow interpolation of variables use the C<qq> form, but you will then have
-to escape metacharacters C<\{> as well as C<$> if it is not the sigil for a
-defined variable. For example:
+To allow interpolation of variables use the L<C<qq>|/language/quoting#Interpolation:_qq> form. For example:
 
   my $f = 'db.7.3.8';
   my $s = qq:to/END/;


### PR DESCRIPTION
## The problem

Discussion of variable interpolation in heredocs confusing and unhelpful.

## Solution provided

Removed confusing extra verbiage from the explanation for variable interpolation in heredocs, and added a link to doc that more clearly explains what the removed verbiage was trying but failing to explain. Credit to @raiph++
