### PR TITLE
per 4318 mv `constant` into declarators table

### DIFF
--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -1172,7 +1172,7 @@ X<|Language,match variable>
 =head3 The C<$/> variable
 
 C<$/> is the match variable.  A fresh one is created in every B<routine>.
-It is set to the result of the last L<Regex|/language/regexes>
+It is set to the result of the last L<regex|/language/regexes>
 match and so usually contains objects of type L<C<Match>|/type/Match>.
 
     'abc 12' ~~ /\w+/;  # sets $/ to a Match object
@@ -1213,7 +1213,7 @@ This (non-)feature has been deprecated as of version 6.d.
 
 =head4 X«Positional attributes|Variables,$0;Variables,$1»
 
-C<$/> can have positional attributes if the L<Regex|/language/regexes> had
+C<$/> can have positional attributes if the L<regex|/language/regexes> had
 capture-groups in it, which are just formed with parentheses.
 
     'abbbbbcdddddeffg' ~~ / a (b+) c (d+ef+) g /;
@@ -1238,7 +1238,7 @@ This I<magic> behavior of C<@()> has been deprecated as of 6.d
 
 =head4 X«Named attributes|Variables,$<named>»
 
-C<$/> can have named attributes if the L<Regex|/language/regexes> had named
+C<$/> can have named attributes if the L<regex|/language/regexes> had named
 capture-groups in it, or if the Regex called out to another Regex.
 
 =for code


### PR DESCRIPTION
`constant` is listed along with the quasi declarators `let` and `temp` but belongs in the main table with the other declarators

There are a couple of other remaining points under discussion in issue [4318](https://github.com/Raku/doc/issues/4318), but consensus was reached on this part a long time ago.

Moved `constant` accordingly while also clarifying its description.