### PR TITLE
Added section on "Avoiding Slangs"

### DIFF
--- a/doc/Language/slangs.rakudoc
+++ b/doc/Language/slangs.rakudoc
@@ -155,11 +155,13 @@ your custom class declarator. You still use C<has> to declare attributes, but th
 will be instantiated as instances of your custom attribute class instead of the
 default C<Attribute> class.
 
-Here's an example based on L<ValueClass|https://github.com/FCO/ValueClass>:
+Here's an example showing just the custom attribute class part (based on
+L<ValueClass|https://github.com/FCO/ValueClass>):
 
-=begin code
-# lib/ValueClass.rakumod
+=begin code :skip-test<needs module>
 # Custom attribute class example
+# Note: This is just the attribute class part. You would also need to define
+# a HOW class for the class declarator (like MetamodelX::ValueClassHOW).
 
 class ValueClass::Attribute is Attribute {
     method compose(|) {
@@ -168,7 +170,7 @@ class ValueClass::Attribute is Attribute {
         die "Attributes { $.name } can't be rw on a value-class" if $.rw;
         nextsame
     }
-    
+
     method container_initializer(|c) {
         # Custom initialization logic
         # This can change default values or types
@@ -181,9 +183,11 @@ class ValueClass::Attribute is Attribute {
     }
 }
 
+# Export the attribute class via EXPORTHOW::DECLARE
+# (The class declarator would also be exported here)
 my package EXPORTHOW {
     package DECLARE {
-        constant value-class = MetamodelX::ValueClassHOW;
+        # constant value-class = MetamodelX::ValueClassHOW;  # Not shown here
         constant value-class-attr = ValueClass::Attribute;
     }
 }


### PR DESCRIPTION
## The problem

Sometimes when you want to modify the language, there's an easier option than creating a slang.  These should be listed in one place.  

## Solution provided

I've added a new section to address this.  