### PR TITLE
slightly demystified `temp` & `let`

### DIFF
--- a/doc/Language/variables.rakudoc
+++ b/doc/Language/variables.rakudoc
@@ -510,7 +510,7 @@ augment slang Regex {  # derive from $~Regex and then modify $~Regex
 See L<I<slangs>|/language/slangs> for more.
 
 X<|Syntax,supersede>
-=head1 Variable declarators, scope, and shadowing
+=head1 Variable declarators and scope
 
 Most of the time it's enough to create a new variable using the C<my>
 keyword:
@@ -533,8 +533,7 @@ beyond what L<Twigils|#Twigils> can do.
     augment       Adds definitions to an existing name
     supersede     Replaces definitions of an existing name
 
-There are also two keywords that act on predefined variables, allowing
-temporary shadowing of their current values:
+There are also two keywords that act on predefined variables:
 
 =for table
     Keyword   Effect
@@ -977,9 +976,8 @@ augment class IO::Path {
 
 =head2 The C<temp> keyword
 
-Shadows the current value with a new value within the current block, and
-restores the old value of the variable at the end of its scope. Unlike C<my>,
-C<temp> does not create a new variable.
+Like C<my>, C<temp> restores the old value of a variable at the end of its
+scope. However, C<temp> does not create a new variable.
 
     my $in = 0; # temp will "entangle" the global variable with the call stack
                 # that keeps the calls at the bottom in order.
@@ -1014,10 +1012,8 @@ C<temp> does not create a new variable.
 
 =head2 The C<let> keyword
 
-This is more of a conditional reassignment than just shadowing, because the old
-value is not restored if the block exits successfully, that is, if it returns a
-defined value or list. If, on the other hand, the block exits without returning
-anything, the old value is restored just as with C<temp>.
+Restores the previous value if the block exits unsuccessfully. A
+successful exit means the block returned a defined value or a list.
 
     my $answer = 42;
 


### PR DESCRIPTION
## The problem

Current doc says that `temp` & `let` are like declarators, which was confusing, since they don't create variables.

This PR is intended to close docs issue [4318](https://github.com/Raku/doc/issues/4318)

## Solution provided

Relabeled `temp` & `let` neutrally as "keywords"

Also relocated the entry for `constant` to better reflect its current position in the summary table (which was a recent change motivated by the same issue, 4318).