### PR TITLE
Issue 4709, reverts part of PR 4743

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -2414,9 +2414,9 @@ say infix:<=:=>(False); # OUTPUT: «True␤»
 X<|Infix operators,smartmatch operator>
 =head2 infix C«~~»
 
-The smartmatch operator calls the L<C<.ACCEPTS()>|/routine/ACCEPTS> method on
-its right-hand side, with its left-hand side as the argument. The semantics
-are left to the type of the right-hand side operand.
+The smartmatch operator aliases the left-hand side to C<$_>, then evaluates
+the right-hand side and calls C<.ACCEPTS($_)> on it. The semantics are left
+to the type of the right-hand side operand.
 
 Here is a partial list of some of the built-in smartmatching functionality. For
 full details, see L<ACCEPTS|/routine/ACCEPTS> documentation


### PR DESCRIPTION
It turns out that we may have been too hasty in removing the assertion that ~~ topicalizes

See @raiph's [comment on PR 4743](https://github.com/Raku/doc/pull/4743#issuecomment-3700919268) (and [my comment on issue 4709](https://github.com/Raku/doc/issues/4709#issuecomment-3701031053) which pulls in some of the specifics from the SO article referred to in @raiph's comment)
