### PR TITLE
reorg "Regex interpolation" section per 3705

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -25,9 +25,9 @@ i.e. a sublanguage or L<I<slang>|/language/slangs>. This page describes this lan
 regexes can be used to search for text patterns in strings in a process called
 I<pattern matching>.
 
-Raku regexes can be modified by a variety of L<adverbs|/language/regexes#Adverbs>,
-and can L<interpolate|/language/regexes#Regex_interpolation> variables or code
-blocks in several different ways.
+Raku regexes can L<interpolate|/language/regexes#Regex_interpolation>
+variables or code blocks in several different ways, and can be modified
+by a variety of L<adverbs|/language/regexes#Adverbs>.
 
 =head1 X<Lexical conventions|Syntax,/ /;Syntax,rx;Syntax,m>
 


### PR DESCRIPTION
## The problem

Issue [3705](https://github.com/Raku/doc/issues/3705) pointed out several clarifications that are needed to the "Regex interpolation" section of /language/regexes

## Solution provided

- Added @-variable forms to $-variable forms in the main table
- Added Boolean condition checks to the main table
- Added subsection headings to parallelize discussion of all five entries
- Moved mention of hashes in regexes being reserved to immediately after the table
- Added links to this section (and to adverbs section) in the introductory part of the article
- Changed the ordering of some of the sections in the last half of the article