### PR TITLE
 control.rakudoc: bad link to #Closures section

### DIFF
--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -42,7 +42,7 @@ executed.
 Unless it stands alone as a statement, a block simply creates a closure. The
 statements inside are not executed immediately. Closures are another topic
 and how they are used is explained
-L<elsewhere|/language/functions#Blocks_and_lambdas>. For now it is just
+L<elsewhere|/language/functions#Closures>. For now it is just
 important to understand when blocks run and when they do not:
 
 =for code


### PR DESCRIPTION
## The problem

a link plainly intended to direct to the #Closures section instead pointed to the #Blocks_and_lambdas section

## Solution provided

Corrected the link
