### PR TITLE
Remove redundant note on hashes in regexes

### DIFF
--- a/doc/Language/regexes.rakudoc
+++ b/doc/Language/regexes.rakudoc
@@ -2103,8 +2103,6 @@ C<@(code)>. In this example, both regexes are equivalent:
     say S:g/@(%h.keys)/%h{$/}/ given 'abc';    # OUTPUT: «12c␤»
     say S:g/@a/%h{$/}/ given 'abc';            # OUTPUT: «12c␤»
 
-The use of hashes in regexes is reserved.
-
 =head2 Regex Boolean condition check
 
 X«|Regexes,<?{}>;Regexes,<!{}>»


### PR DESCRIPTION
## The problem

Identical sentence occurs twice in article (it was supposed to move in the last PR, but got duplicated instead). 

## Solution provided

Removed duplicate.
