### PR TITLE
Fix factual error in `Str::substr` doc.

### DIFF
--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -942,9 +942,8 @@ Returns a substring of the original string, between the indices specified by
 C<$from-to>'s endpoints (coerced to L<C<Int>|/type/Int>) or from index C<$from> and of
 length C<$chars>.
 
-Both C<$from> and C<$chars> can be specified as L<C<Callable>|/type/Callable>, which will be
-invoked with the L<length|/routine/chars> of the original string and the
-returned value will be used as the value for the argument. If C<$from> or
+Both C<$from> and C<$chars> can be specified as L<C<Callable>|/type/Callable> and the
+returned value will be used as the value for the argument. C<$from> is invoked with the L<length|/routine/chars> of the original string, while C<$chars> is invoked with remaining character count after C<$from>. If C<$from> or
 C<$chars> are not L<C<Callable>|/type/Callable>, they'll be coerced to L<C<Int>|/type/Int>.
 
 If C<$chars> is omitted or is larger than the available characters,


### PR DESCRIPTION
## The problem

Running
`substr("Long string", 8, &say);`
prints `3`, which contradicts the documentation stating "[Callables] will be invoked with the length of the original string".

## Solution provided

This commit fixes documentation, reflecting that `chars` is invoked with remaining character count after `from`.