### PR TITLE
Fixed typo: Se -> We

### DIFF
--- a/doc/Type/IO/Handle.rakudoc
+++ b/doc/Type/IO/Handle.rakudoc
@@ -982,7 +982,7 @@ say $store.lines(); # OUTPUT: «[one␤ two␤ three␤]»
 =end code
 
 In this example we are creating a simple C<WRITE> redirection which stores
-anything written to the filehandle to an array. Se need to save the standard
+anything written to the filehandle to an array. We need to save the standard
 output first, which we do in C<$output>, and then everything that is C<print>ed
 or said (through C<say>) gets stored in the defined C<IO::Store> class. Two
 things should be taken into account in this class. By default, C<IO::Handle>s


### PR DESCRIPTION
## The problem
Simple typo in the doc.

## Solution provided

Changed 'Se' to 'We'.
