### PR TITLE
Fix return type of `match` method

### DIFF
--- a/doc/Type/Str.rakudoc
+++ b/doc/Type/Str.rakudoc
@@ -331,7 +331,7 @@ characters, and ignores additional marks such as combining accents.
     method match($pat, :continue(:$c), :pos(:$p), :global(:$g), :overlap(:$ov), :exhaustive(:$ex), :st(:$nd), :rd(:$th), :$nth, :$x --> Match)
 
 Performs a match of the string against C<$pat> and returns a
-L<C<Match>|/type/Match> object if there is a successful match; it returns C<(Any)>
+L<C<Match>|/type/Match> object if there is a successful match; it returns C<Nil>
 otherwise. Matches are stored in the L<default match variable
 C<$/>|/language/variables#index-entry-match_variable>. If C<$pat> is not a
 L<C<Regex>|/type/Regex> object, match will coerce the argument to a Str and then


### PR DESCRIPTION
It has been wrong ever since it was written down at https://github.com/Raku/doc/commit/a0cb9311e5e1d9c5a6b2cf66ee2d52d9a831b6ac
