### PR TITLE
In List.rakudoc, clarify wording around the subroutine version of rotor

### DIFF
--- a/doc/Type/List.rakudoc
+++ b/doc/Type/List.rakudoc
@@ -1200,7 +1200,7 @@ multi rotor(Int:D $batch, \thing, Bool() :$partial --> Seq:D)
 multi rotor(**@cycle, \thing, Bool() :$partial --> Seq:D)
 
 Technically, having a L<slurpy|/language/signatures#Slurpy_parameters> C<**@cycle>
-before the required parameter C<\thing> is not possible,
+before the positional parameter C<\thing> is not possible,
 so the actual signature of the second multi is different in Rakudo.
 In practice, however, things work as you would expect from the signatures given here:
 


### PR DESCRIPTION
https://docs.raku.org/type/List#routine_rotor

Changes:

* Rearrange lines to make clearer what was [introduced with v6.e](https://github.com/Raku/doc/commit/d0ac898f51907196adaff737f4bc46f683f3211b). 

* Update signatures: what was `\source` is now `\thing` (v6.e on MoarVM version 2025.10). 

* One substantial change: In the second signature, write `**@cycle` instead of `*@cycle`, because list arguments don't get flattened here (rather, each list counts as one Int — see example below), so that `**` is more appropriate than `*`. (Of course, technically, it's neither, as the comment `actual sig is **@cycle-and-thing but only due to Rakudo limitation` explains — because actual slurpies can only come at the end — but even so the behavior is much more like `**` than like `*`.)

Example for the last point:
```
> rotor( (7,8), 1, 2, 'a' .. 'h')  # the first list just counts as 2
((a b) (c) (d e) (f g) (h))
```