### PR TITLE
Delete mistaken `().are` line

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -750,7 +750,6 @@ smartmatches fails, returns a L<C<Failure>|/type/Failure>.
     say (42,666e0).are(Real);     # OUTPUT: «True␤»
     say (42,i).are(Numeric);      # OUTPUT: «True␤»
     say ("a",42,3.14).are(Cool);  # OUTPUT: «True␤»
-    say ().are;                   # OUTPUT: «True␤»
 
     Int.are(Str);      # OUTPUT: «Expected 'Str' but got 'Int'␤»
     (1,2,3).are(Str);  # OUTPUT: «Expected 'Str' but got 'Int' in element 0␤»


### PR DESCRIPTION
It seems both out-of-place and incorrect:
a bunch of paragraphs earlier the output for this was `Nil` (the only output this call has ever had)