### PR TITLE
Add .WHERE, .DEFINITE and .REPR to list of reserved methods

### DIFF
--- a/doc/Language/typesystem.rakudoc
+++ b/doc/Language/typesystem.rakudoc
@@ -284,7 +284,7 @@ X<|Language,WHICH (reserved method)>X<|Language,WHO (reserved method)>
 
 Some built-in introspection methods are actually special syntax provided by the
 compiler, namely C<WHAT>, C<WHO>, C<HOW>, C<VAR>,
-and (since Rakudo version 2026.01) C<WHERE>, C<DEFINITE>, and C<REPR>.
+and (since Rakudo v2026.01) C<WHERE>, C<DEFINITE>, and C<REPR>.
 Declaring methods with those names will silently fail. A dynamic call will work,
 which allows to call methods from foreign objects.
 


### PR DESCRIPTION
These are three items from the Checklist for 2026.01 (#4758), which were introduced with commits [a0a198d](https://github.com/rakudo/rakudo/commit/a0a198dd#diff-ec36479462b7787dc44cbcddb0a5507243cb49adf1280be1eefeaa8a6fabf6e5), [62927745](https://github.com/rakudo/rakudo/commit/62927745) and [971b2fa4](https://github.com/rakudo/rakudo/commit/971b2fa4) respectively. They apply from Rakudo 2026.01 (as is stated in the new text).

**Question:** Do all three VMs for Rakudo have a moving or compacting garbage collector? I found evidence of this only for MoarVM ([here](https://github.com/MoarVM/MoarVM/blob/6a80a5d43ce2db89f61d7ba2baeed0022c518eea/src/6model/6model.h#L186)), but am not sure about the particular JVM and JS VM.

Context: The two other files that say something about `WHERE` explain that its return value may change due to garbage collection:
* doc/Language/mop.rakudoc ([website](https://docs.raku.org/language/mop#WHERE))
* doc/Type/Mu.rakudoc ([website](https://docs.raku.org/type/Mu.html#method_WHERE))

These files don't need changing because of these commits, _but_ we could take the occasion to make sure that both places tell the complete and correct story.