### PR TITLE
`routine elems`, `routine end` (prev had only method form)

### DIFF
--- a/doc/Type/Any.rakudoc
+++ b/doc/Type/Any.rakudoc
@@ -326,29 +326,36 @@ returns that L<C<List>|/type/List>.
     say $range;         # OUTPUT: «1..5␤»
     say $range.eager;   # OUTPUT: «(1 2 3 4 5)␤»
 
-=head2 method elems
+=head2 routine elems
 
     multi method elems(Any:U: --> 1)
     multi method elems(Any:D:)
+    multi        elems($a)
+    multi        elems(array:D \a)
 
-Interprets the invocant as a list, and returns the number of elements in the
-list.
+Interprets the invocant or argument as a list, and returns the number of
+elements in the list.
 
-    say 42.elems;                   # OUTPUT: «1␤»
+    say elems 42;                   # OUTPUT: «1␤»
     say <a b c>.elems;              # OUTPUT: «3␤»
     say Whatever.elems ;            # OUTPUT: «1␤»
 
 It will also return 1 for classes.
 
-=head2 method end
+=head2 routine end
 
     multi method end(Any:U: --> 0)
     multi method end(Any:D:)
+    multi        end($a)
+    multi        end(array:D \a)
+    multi        end($, *%)
 
-Interprets the invocant as a list, and returns the last index of that list.
+Interprets the invocant or argument as a list, and returns the last index of
+that list.
 
     say 6.end;                      # OUTPUT: «0␤»
     say <a b c>.end;                # OUTPUT: «2␤»
+    say end ^9;                     # OUTPUT: «8␤»
 
 =head2 method pairup
 


### PR DESCRIPTION
## The problem

`elems` and `end` documented only as methods on Any

## Solution provided

per [4560](https://github.com/Raku/doc/issues/4560), documenting them as routines