### PR TITLE
Clarify when BUILD applies default values to attributes

### DIFF
--- a/doc/Language/objects.rakudoc
+++ b/doc/Language/objects.rakudoc
@@ -869,8 +869,9 @@ C<new> method).
 are initialized from named arguments of the same name.
 
 =begin item
-All attributes that have not been touched in any of the previous steps have
-their default values applied:
+All attributes that have not been touched in the previous two steps have
+their default values applied (overriding any parent attributes
+with the same name):
 
 C<has $.attribute = 'default value';>
 =end item
@@ -919,7 +920,7 @@ say RectangleWithCachedArea.new( x2 => 5, x1 => 1, y2 => 1, y1 => 0).area;
 
 =begin item
 Since passing arguments to a routine binds the arguments to the parameters,
-one can simplify BUILD methods by using the attribute as a parameter.
+one can simplify C<BUILD> methods by using the attribute as a parameter.
 
 A class using ordinary binding in the C<BUILD> method:
 =begin code
@@ -945,7 +946,7 @@ submethod BUILD(:$!x, :$!y) {
 =end item
 
 =begin item
-In order to use default values together with a `BUILD()` method one can't use
+In order to use default values together with a C<BUILD> method one can't use
 parameter binding of attributes, as that will always touch the attribute and
 thus prevent the automatic assignment of default values (step three in the
 above list). Instead one would need to conditionally assign the value:
@@ -963,7 +964,7 @@ say A.new().raku;
 # OUTPUT: «A.new(attr => "default")␤»
 =end code
 
-It's simpler to set a default value of the `BUILD` parameter instead though:
+It's simpler to set a default value of the C<BUILD> parameter instead though:
 
 =begin code
 class A {


### PR DESCRIPTION
https://docs.raku.org/language/objects#Object_construction

The current phrasing ("All attributes that have not been touched in any of the previous steps") is ambiguous, since "any" might be understood as including all runs of the parent classes' bless method. Thus, change wording to "not been touched in the previous two steps". The added remark "(overriding any parent attributes of the same name)" makes this even more explicit.

I'm a bit on the fence about the wording "override" though, since the parent class itself retains its attribute intact; the child class's attribute merely "eclipses" it:

```
class Shape  {
  has $.scale = 10;
  submethod BUILD(:$param) {
    $!scale = $param;
  }
}

class Line is Shape {
  has $.scale;
}
my $l = Line.new( param => 0.5);
say $l;
say $l.scale;
say $l.Shape::scale;

# OUTPUT:
Line.new(scale => Any, scale => 0.5)
(Any)
0.5

```


