### PR TITLE
Remove $.a attribute from Foo class

### DIFF
--- a/doc/Language/operators.rakudoc
+++ b/doc/Language/operators.rakudoc
@@ -846,9 +846,8 @@ It can be also applied, within classes, to access metamethods on self:
 
 =for code
 class Foo {
-    has $.a = 3;
     method bar {
-        return $.^name
+        return self.^name
     }
 };
 say Foo.new.bar; # OUTPUT: «Foo␤»


### PR DESCRIPTION
Removed the declaration of the attribute $.a in class Foo because it is superfluous in this example.

Also, since the text mentions "self", use the `self.^name` syntax, rather than the bit more obscure `$.^name` syntax.