### PR TITLE
Remove mention of pseudo-methods from metamethods

### DIFF
--- a/doc/Language/mop.rakudoc
+++ b/doc/Language/mop.rakudoc
@@ -63,12 +63,13 @@ conventionally for things like L<phasers|/syntax/Phasers>. This will avoid
 conflicts with any metamethods that may appear in future versions of the
 language.
 
+Defining a method with the same name as a metamethod will B<not> hide that
+metamethod's functionality because they have special handling in the grammar.
+
 =head2 X<WHAT|Syntax,WHAT>
 
-The type object of the type. This is a pseudo-method that can be overloaded
-without producing error or warning, but will be ignored.
-
-For example C<42.WHAT> returns the L<C<Int>|/type/Int> type object.
+The type object of a value.  For example C<42.WHAT> returns the L<C<Int>|/type/Int>
+type object.
 
 =head2 X<WHICH|Syntax,WHICH>
 
@@ -105,10 +106,9 @@ The attached L<Pod|/language/pod> value.
 
 =head2 X<DEFINITE|Syntax,DEFINITE>
 
-The object has a valid concrete representation. This is a pseudo-method that
-can be overloaded without producing error or warning, but will be ignored.
-
-Returns C<True> for instances and C<False> for type objects.
+The object has a valid concrete representation.  Returns C<True> for instances
+(even if they have the "defined" method overloaded, such as in L<C<Failure>|/type/Failure>
+objects) and C<False> for type objects.
 
 =head2 X<VAR|Syntax,VAR>
 


### PR DESCRIPTION
- remove texts mentioning pseudo-methods.
- generalize the fact that defining a method with a metamethod name will **not** shadow the metamethod