### PR TITLE
Fix in io.rakudoc: .e method is on IO::Path objects, not IO::Handle

### DIFF
--- a/doc/Language/io.rakudoc
+++ b/doc/Language/io.rakudoc
@@ -144,7 +144,7 @@ an exception.
 
 =head1 Checking files and directories
 
-Use the C<e> method on an L<C<IO::Handle>|/type/IO::Handle> object to test whether the file or
+Use the C<e> method on an L<C<IO::Path>|/type/IO::Path> object to test whether the file or
 directory exists.
 
 =for code


### PR DESCRIPTION
Very straightforward fix.

For instance:

```
"/".IO.WHAT  # (Path)
"/".IO.e     # True
$*IN.WHAT  # (Handle)
$*IN.e     # No such method 'e' for invocant of type 'IO::Handle'. Did you mean 't'?
```

The roasts also don't require anything different, as far as I can see.