### PR TITLE
remove prohibition on code preceding `unit`

### DIFF
--- a/doc/Language/syntax.rakudoc
+++ b/doc/Language/syntax.rakudoc
@@ -1006,9 +1006,9 @@ rules.
     grammar G { }
 
 Several packages may be declared in a single file. However, you can declare
-a C<unit> package at the start of the file (preceded only by comments or C<use>
-statements), and the rest of the file will be taken as being the body of the
-package. In this case, the curly braces are not required.
+a C<unit> package at the start of the file, and the rest of the file will be
+taken as being the body of the package. In this case, the curly braces are not
+required.
 
 =begin code :solo
 unit module M;


### PR DESCRIPTION
## The problem

The prohibition on code other than comments and `use` statements before a `unit` declaration has never been consistently enforced, and is now planned for removal (to the extent that it ever has been enforced). 

## Solution provided

Remove the only (I think?) reference to the prohibition. Closes #2148