### PR TITLE
2nd attempt to close issue 3881

### DIFF
--- a/doc/Type/Instant.rakudoc
+++ b/doc/Type/Instant.rakudoc
@@ -18,10 +18,11 @@ C<Instant> to a L<C<Duration>|/type/Duration> returns another Instant. Subtracti
 will yield a L<C<Duration>|/type/Duration>. Adding two C<Instant>s is explicitly disallowed. All
 other operations with Instants are undefined.
 
-I<NOTE:> POSIX time, a commonly used time standard, does not address leap seconds,
-while C<Instant> objects do, so there's some extra machinery in the conversion
-methods to handle this. See methods C<from-posix>, C<to-posix>, and the discussion
-of leap seconds below.
+I<NOTE:> L<POSIX time|https://en.wikipedia.org/wiki/Unix_time>, a commonly used
+L<time standard|https://en.wikipedia.org/wiki/Time_standard>,
+does not address leap seconds, while C<Instant> objects do, so there's some
+extra machinery in the conversion methods to handle this. See methods C<from-posix>,
+C<to-posix>, and the discussion of leap seconds below.
 
 =head1 Methods
 
@@ -88,11 +89,12 @@ C<DateTime.now.posix> does not change for two whole seconds.
     demo(3); # OUTPUT: «[2017-01-01T00:00:01Z 1483228801]␤»
 
 Atomic clocks also disregard the Earth's rotation, so between 1958 when they
-were first calibrated and the POSIX epoch of 1970, UTC had fallen 10 seconds
-behind atomic-clock time. The numerical value of C<Instant> happens to track
-atomic-clock time, and as of 2026 there have been 27 leap seconds recorded.
-This adds up to a total of 37 seconds, which is why, as of 2026, the following
-holds:
+were first calibrated and the POSIX epoch of 1970,
+L<UTC|https://en.wikipedia.org/wiki/Coordinated_Universal_Time> had fallen 10 seconds
+behind L<atomic-clock time|https://en.wikipedia.org/wiki/International_Atomic_Time>.
+The numerical value of C<Instant> happens to track atomic-clock time, and as of
+2026 there have been 27 leap seconds recorded. This adds up to a total of 37
+seconds, which is why, as of 2026, the following holds:
 
     with now { say .Int - DateTime.new($_).posix } # OUTPUT: «37␤»
 


### PR DESCRIPTION
I've attempted to implement the changes that @librasteve suggested in [problem-solving issue 497](https://github.com/Raku/problem-solving/issues/497) with the modifications that I suggested and he okayed in [#3881 ](https://github.com/Raku/doc/issues/3881).

I've also updated the dates in the examples where they can be updated, and added a brief explanation at the very end as to why the "future leap seconds" examples have to be so very old (for now).

Finally I've tried to reign in some of my immoderate language a bit. I hope that this proves acceptable and that we can close the docs issue that spawned it.