### PR TITLE
Tidy up pages about modules

### DIFF
--- a/doc/Language/distributions/configuration-structure.rakudoc
+++ b/doc/Language/distributions/configuration-structure.rakudoc
@@ -1,6 +1,6 @@
 =begin pod :kind("Language") :subkind("Modules") :category("tutorial")
 
-=TITLE Making modules: the configuration and structure
+=TITLE Distributing modules: the configuration and structure
 
 =SUBTITLE How to structure and configure Raku modules for distribution
 
@@ -456,5 +456,23 @@ need to add a X<C<Build.rakumod>|Reference,Build.rakumod> file (a "build hook") 
 be used by the C<zef> installer as the first step in the installation process.
 See the README for C<zef> for a brief example. Also see various usage scenarios in existing
 ecosystem modules such as C<zef> itself.
+
+
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure> (this page)
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
 
 =end pod

--- a/doc/Language/distributions/introduction.rakudoc
+++ b/doc/Language/distributions/introduction.rakudoc
@@ -82,18 +82,22 @@ L<#raku on irc.libera.chat|irc://irc.libera.chat/#raku> IRC channel.
 A repository to discuss tooling issues is available at
 L<https://github.com/Raku/toolchain-bikeshed>.
 
-=head1 More information about Distributions
 
-=item1 L<An introduction|/language/distributions/introduction> (this document)
-=item1 L<The Tools|/language/distributions/tools>
-=item1 L<The Configuration and Structure|/language/distributions/configuration-structure>
-=item1 L<The Testing|/language/distributions/testing>
-=item1 L<The Code|/language/distributions/code>
-=item1 L<Uploading|/language/distributions/uploading>
+=head1 Documentation about Modules
 
-You may also be interested in:
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
 
-=item L<Using Modules: An Introduction|/language/using-modules/introduction>
-=item L<Making Modules: An Introduction|/language/making-modules/introduction>
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction> (this page)
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
 
 =end pod

--- a/doc/Language/distributions/testing.rakudoc
+++ b/doc/Language/distributions/testing.rakudoc
@@ -4,7 +4,9 @@
 
 =SUBTITLE Testing your distribution of modules
 
-This also means that a testing program such as B<Perl>'s C<prove> or the B<Raku>
+=item L<General guide to testing|/language/testing>
+
+A testing program such as B<Perl>'s C<prove> or the B<Raku>
 equivalent L<prove6|https://raku.land/zef:leont/App::Prove6> can be
 run in the root directory of the B<distribution> as, e.g.,
 
@@ -102,6 +104,18 @@ Then when the distribution is being tested by the developer, use
 
 =for code :lang<shell>
     AUTHOR_TESTING=1 prove6 -I.
+
+
+=head1 Non-Core Testing Tools
+
+Some community modules for testing module quality:
+
+=item L<Test::META|https://raku.land/zef:jonathanstowe/Test::META>      Test your META6.json file
+=item L<Test::Output|https://raku.land/zef:raku-community-modules/Test::Output>  Test the output to STDOUT and STDERR your program generates
+=item L<Test::Screen|https://raku.land/github:skids/Proc::Screen>  Use B<GNU screen> to test full screen VT applications
+=item L<Test::When|https://raku.land/zef:raku-community-modules/Test::When>  Control when your tests are run (author testing, online testing, etc.)
+
+See also L<Distributions: Tools|/language/distributions/tools> for a general list of module-related tooling.
 
 
 =head1 Documentation about Modules

--- a/doc/Language/distributions/testing.rakudoc
+++ b/doc/Language/distributions/testing.rakudoc
@@ -103,8 +103,22 @@ Then when the distribution is being tested by the developer, use
 =for code :lang<shell>
     AUTHOR_TESTING=1 prove6 -I.
 
-=head1 More information about Distributions
 
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
 =item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing> (this page)
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
 
 =end pod

--- a/doc/Language/distributions/tools.rakudoc
+++ b/doc/Language/distributions/tools.rakudoc
@@ -25,7 +25,7 @@ of a distribution of modules.
 
 =head2 Non-Core Distributions
 
-Some tests of module quality.
+Some community modules for testing module quality:
 
 =item L<Test::META|https://raku.land/zef:jonathanstowe/Test::META>      Test your META6.json file
 =item L<Test::Output|https://raku.land/zef:raku-community-modules/Test::Output>  Test the output to STDOUT and STDERR your program generates

--- a/doc/Language/distributions/tools.rakudoc
+++ b/doc/Language/distributions/tools.rakudoc
@@ -83,5 +83,21 @@ Here some modules to help you work with NativeCall (for calling non-Raku librari
 
 
 
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools> (this page)
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
 
 =end pod

--- a/doc/Language/distributions/uploading.rakudoc
+++ b/doc/Language/distributions/uploading.rakudoc
@@ -79,5 +79,23 @@ There have been three ways to distribute a module, but the CPAN and P6C ways
 have been deprecated; please use the zef/fez method instead.  However, no
 matter the method, all modules will be indexed on the L<raku.land|https://raku.land> website.
 
+
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading> (this page)
+
+
 =end pod
 

--- a/doc/Language/making-modules/code.rakudoc
+++ b/doc/Language/making-modules/code.rakudoc
@@ -133,4 +133,21 @@ say 'Carry on, carry on...';  # OUTPUT: «Carry on, carry on...␤»
 =end code
 
 
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code> (this page)
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
+
 =end pod

--- a/doc/Language/making-modules/code.rakudoc
+++ b/doc/Language/making-modules/code.rakudoc
@@ -2,7 +2,7 @@
 
 =TITLE Making modules: the code
 
-=SUBTITLE How to use modules in your code
+=SUBTITLE How to organize your module with regard to its usage
 
 =head1 Modules on disk
 

--- a/doc/Language/making-modules/introduction.rakudoc
+++ b/doc/Language/making-modules/introduction.rakudoc
@@ -70,4 +70,21 @@ Packages|/language/module-packages> and the examples below) but here we mostly
 mean "module" as a set of source files in a namespace.
 
 
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction> (this page)
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
+
 =end pod

--- a/doc/Language/module-packages.rakudoc
+++ b/doc/Language/module-packages.rakudoc
@@ -4,10 +4,21 @@
 
 =SUBTITLE Creating module packages for code reuse
 
-See:
+=head1 Documentation about Modules
 
-=item L<Modules: An Introduction|/language/using-modules/introduction>
-=item L<Making Modules: The Code|/language/making-modules/code>
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure> (this page)
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
 
 
 =end pod

--- a/doc/Language/module-packages.rakudoc
+++ b/doc/Language/module-packages.rakudoc
@@ -15,7 +15,7 @@
 
 Want to distribute your modules?
 =item1 L<Distributions: An introduction|/language/distributions/introduction>
-=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure> (this page)
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
 =item2 L<Distributions: The Tools|/language/distributions/tools>
 =item2 L<Distributions: Testing|/language/distributions/testing>
 =item2 L<Distributions: Uploading|/language/distributions/uploading>

--- a/doc/Language/modules.rakudoc
+++ b/doc/Language/modules.rakudoc
@@ -2,7 +2,7 @@
 
 =TITLE Modules
 
-=SUBTITLE How to create, use, and distribute Raku modules
+=SUBTITLE How to use, create, and distribute Raku modules
 
 =head1 Creating and using modules
 
@@ -19,44 +19,52 @@ package declared with the C<module> keyword (see L<Module
 Packages|/language/module-packages> and the examples below) but here we mostly
 mean "module" as a set of source files in a namespace.
 
-=head2 Looking for and installing modules.
+=head1 Using Modules
+
+=head2 Introduction
+
+See L<Using Modules: An Introduction|/language/using-modules/introduction>
+
+=head2 Looking for and installing modules
 
 See L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
 
-=head2 Basic structure
+=head2 Loading and using modules
 
-See L<Modules: An Introduction|/language/using-modules/introduction>
+See L<Using Modules|/language/using-modules/code>
 
-=head1 X<Loading and basic importing|Language,compunit>
+=head1 Making Modules
 
-See L<Modules: An Introduction|/language/using-modules/introduction>
+=head2 Terminology and basic structure
 
-=head2 Finding installed modules
+See L<Making Modules|/language/making-modules/introduction>
 
-See L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=head2 How to organize your module with regard to its usage
 
-=head1 Testing modules and a distribution
-
-See L<Distributions: Testing|/language/distributions/testing>.
+See L<Making Modules|/language/making-modules/code>
 
 =head1 Distributing modules
 
-See L<Distributions: Uploading|/language/distributions/uploading>.
+See L<Distributions: An Introduction|/language/distributions/introduction>.
 
 =head2 Preparing the module
 
-See L<Making Modules: The Configuration and Structure|/language/distributions/configuration-structure>
+See L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+
+=head2 Tools that help with module authoring
+
+See L<Distributions: The Tools|/language/distributions/tools>
+
+=head2 Testing modules and a distribution
+
+See L<Distributions: Testing|/language/distributions/testing>.
 
 =head2 Uploading the module
 
 See L<Distributions: Uploading|/language/distributions/uploading>.
 
-=head1 Modules and tools related to module authoring
+=head2 Discussing module development
 
-See L<Distributions: The Tools|/language/distributions/tools>
-
-=head2 Contact information
-
-See L<Distributions: An Introduction|/language/distributions/introduction>
+See L<Distributions: An Introduction|/language/distributions/introduction#Contact_information>
 
 =end pod

--- a/doc/Language/using-modules/code.rakudoc
+++ b/doc/Language/using-modules/code.rakudoc
@@ -13,7 +13,8 @@ the importing statement.
 
 =head2 X<C<need>|Syntax,need>
 
-C<need> loads a C<compunit> at compile time.
+C<need> loads a C<compunit> at compile time
+(see L<here|/language/compilation> for technical details).
 
 =for code :skip-test<needs dummy module>
 need MyModule;
@@ -50,7 +51,8 @@ say $class.raku;
 
 =head2 X<C<use>|Syntax,use>
 
-C<use> loads and then imports from a compunit at compile time. It will look for
+C<use> loads and then L<imports|/language/using-modules/introduction#Working_with_modules>
+from a compunit at compile time. It will look for
 files that end in C<.rakumod>. See L<here|/language/using-modules/finding-installing#Finding_installed_modules>
 for where the runtime will look for modules.
 
@@ -419,21 +421,6 @@ use MakeQuestionable Cool;
 say ( 0?, 1?, {}?, %( a => "b" )? ).join(' '); # OUTPUT: «False True False True␤»
 =end code
 
-=head2 Introspection
-
-To list exported symbols of a module first query the export tags supported by
-the module.
-
-    use URI::Escape;
-    say URI::Escape::EXPORT::.keys;
-    # OUTPUT: «(DEFAULT ALL)␤»
-
-Then use the tag you like and pick the symbol by its name.
-
-    say URI::Escape::EXPORT::DEFAULT::.keys;
-    # OUTPUT: «(&uri-escape &uri-unescape &uri_escape &uri_unescape)␤»
-    my &escape-uri = URI::Escape::EXPORT::DEFAULT::<&uri_escape>;
-
 Be careful I<not> to put C<sub EXPORT> after L«C<unit> declarator|/syntax/unit».
 If you do so, it'll become just a sub inside your package, rather than the
 special export sub:
@@ -449,6 +436,22 @@ do it:
 =for code :solo
 sub EXPORT { Map.new: Foo => &say } # RIGHT!!! Sub is outside the module
 unit module Bar;
+
+
+=head2 Introspection
+
+To list exported symbols of a module first query the export tags supported by
+the module.
+
+    use URI::Escape;
+    say URI::Escape::EXPORT::.keys;
+    # OUTPUT: «(DEFAULT ALL)␤»
+
+Then use the tag you like and pick the symbol by its name.
+
+    say URI::Escape::EXPORT::DEFAULT::.keys;
+    # OUTPUT: «(&uri-escape &uri-unescape &uri_escape &uri_unescape)␤»
+    my &escape-uri = URI::Escape::EXPORT::DEFAULT::<&uri_escape>;
 
 
 =head1 Documentation about Modules

--- a/doc/Language/using-modules/code.rakudoc
+++ b/doc/Language/using-modules/code.rakudoc
@@ -450,4 +450,22 @@ do it:
 sub EXPORT { Map.new: Foo => &say } # RIGHT!!! Sub is outside the module
 unit module Bar;
 
+
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
+=item2 L<Using Modules: The Code|/language/using-modules/code> (this page)
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
+
 =end pod

--- a/doc/Language/using-modules/finding-installing.rakudoc
+++ b/doc/Language/using-modules/finding-installing.rakudoc
@@ -66,4 +66,22 @@ To avoid performance penalties at module load time, you may need to ensure
 that directories added to this path are not too large; see
 L<here|/language/traps#Filesystem_repositories> for more information.
 
+
+=head1 Documentation about Modules
+
+=item1 L<Using Modules: An Introduction|/language/using-modules/introduction>
+=item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing> (this page)
+=item2 L<Using Modules: The Code|/language/using-modules/code>
+
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
+=item2 L<Making Modules: The Code|/language/making-modules/code>
+
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
+
 =end pod

--- a/doc/Language/using-modules/introduction.rakudoc
+++ b/doc/Language/using-modules/introduction.rakudoc
@@ -62,21 +62,21 @@ say friendly-greeting;  # OUTPUT: «Greetings, friend!␤»
 =end code
 
 
-=head1 More information about Modules
+=head1 Documentation about Modules
 
 =item1 L<Using Modules: An Introduction|/language/using-modules/introduction> (this page)
 =item2 L<Using Modules: Finding and Installing|/language/using-modules/finding-installing>
 =item2 L<Using Modules: The Code|/language/using-modules/code>
-=item2 L<Using Modules: The Tools|/language/using-modules/tools>
 
-=item1 L<Making Modules: The Terminology|/language/making-modules/terminology>
-=item2 L<Making Modules: The Tools|/language/making-modules/tools>
+=item1 L<Making Modules: Introduction|/language/making-modules/introduction>
 =item2 L<Making Modules: The Code|/language/making-modules/code>
-=item2 L<Making Modules: The Configuration and Structure|/language/making-modules/configuration-structure>
-=item2 L<Making Modules: Uploading|/language/making-modules/uploading>
 
-=item1 Want to distribute your modules?
-See L<Distributions: An introduction|/language/distributions/introduction> and
-following pages.
+Want to distribute your modules?
+=item1 L<Distributions: An introduction|/language/distributions/introduction>
+=item2 L<Distributions: The Configuration and Structure|/language/distributions/configuration-structure>
+=item2 L<Distributions: The Tools|/language/distributions/tools>
+=item2 L<Distributions: Testing|/language/distributions/testing>
+=item2 L<Distributions: Uploading|/language/distributions/uploading>
+
 
 =end pod


### PR DESCRIPTION
* A number of links have become dead, probably through the great organization overhaul ([PR 4570](https://github.com/Raku/doc/pull/4570) in response to #3714). This should fix most if not all of them.

* While looking at any individual page, it's hard to tell where it fits in the overall context, or where to find what one is looking for if it isn't there. That's why I've copied the overview section from the bottom of [using-modules/introduction](https://docs.raku.org/language/using-modules/introduction#More_information_about_Modules) (with fixed links, of course) to every other page. That's the big block starting with `=head1 Documentation about Modules` added to the bottom of most files.

Furthermore, I have
* added some cross-references where it seems useful
* replicated the section about non-core testing tools from [distributions/tools](https://docs.raku.org/language/distributions/tools#Non-Core_Distributions) to distributions/testing
* modified some page titles or subtitles to better fit the content

There's still a lot to do, but I'd like to get this "structure cleanup" merged first. It's good to go from my side.

------

Some Todos for later:
* Put `use` first, above the more technical `need`, in [using-modules/code](https://docs.raku.org/language/using-modules/code), and add a section on `import`. In the section about `require`, briefly state how to a conditionally load a module into the right scope, along the lines of [this SO question](https://stackoverflow.com/q/79898394) and e.g. raiph's reply.
* Also in [using-modules/code](https://docs.raku.org/language/using-modules/code), at the bottom, keep only the parts about _selective importing_ and _introspection_, while moving the contents about exporting to language/making-modules/code
* Decide what to do with pages like [language/module-packages](https://docs.raku.org/language/module-packages) and [language/modules-extra](https://docs.raku.org/language/modules-extra), which consist merely of one or more links to other module pages. My preference would be to remove them altogether, in favor of making [language/modules](https://docs.raku.org/language/modules) the single, polished table of contents for everything modules. (To keep old incoming links functional, use HTTP redirects wherever possible. Only for obsolete URLs with multiple successor documents should there be—at the website level, not the Rakudoc level, or at least well-distinguished from the actual documentation—pages with links to the several successor pages; these linklist pages should not, however, be referenced from within the Rakudocs and in particular not be listed on docs.raku.org/introduction—as is currently the case for the given two examples.)

Also, the alphabetic ordering of the index of [Tutorials](https://docs.raku.org/introduction) is suboptimal for the modules pages, since it makes the advanced topics _Distributions_ and _Making Modules_ come first and the beginner topics _Using Modules_ at the end, with the beginner introduction page sitting very inconspicuously in the middle (using-modules/introduction, listed there as "Modules"). Also, I'd say that all the pages about modules (whatever their internal arrangement) are definitely worth their own subsection in or beside this Tutorials index.