### PR TITLE
Update control.rakudoc to fix take-rw link target

### DIFF
--- a/doc/Language/control.rakudoc
+++ b/doc/Language/control.rakudoc
@@ -781,7 +781,7 @@ methods that are called from within C<gather>:
     say weird(<a b c>, :direction<backward> );          # OUTPUT: «(c b a)␤»
 
 If values need to be mutable on the caller side, use
-L<take-rw|/type/Mu#routine_take-rw>.
+L<take-rw|/type/Mu#sub_take-rw>.
 
 Note that the L<C<Seq>|/type/Seq> created by C<gather/take> may be coerced to another type.
 An example with assignment to a hash:


### PR DESCRIPTION
Changing take-rw link from  incorrect anchor Mu#routine_take-rw to correct anchor Mu#sub_take-rw.

## The problem

Control flow page contained take-rw link to non-existent anchor Mu#routine_take-rw

## Solution provided

Changed the link to use Mu#sub_take-rw
