### PR TITLE
Update CONTRIBUTING.md - added missing header for Building the documentation section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,8 @@ If you would like to contribute documentation or other bug fixes, please use
 [GitHub's pull requests (PRs)](https://github.com/Raku/doc/pulls). For a complete
 recipe for a new PR contributor, check [this PR guide](https://github.com/tbrowder/tidbits/blob/master/Contributing-PRs.md).
 
+## Building the documentation
+
 ### Dependency installation
 
 #### Raku


### PR DESCRIPTION
Updated doc/CONTRIBUTING.md to add missing section header

## The problem

The CONTRIBUTING.md table of contents shows "Building the documentation" section immediately following the Pull request section, but there is no section header in the body (hence toc does not have a valid link).

## Solution provided

Added ## Building the documentation in the appropriate location.
