### PR TITLE
Arity Note Required Named Arguments

### DIFF
--- a/doc/Language/glossary.rakudoc
+++ b/doc/Language/glossary.rakudoc
@@ -131,7 +131,8 @@ sub the-answer() { 42 }                            # arity of 0
 =end code
 
 The arity of a L<C<Callable>|/type/Callable> is one of the main selectors in
-L<multi-dispatch|#Multi-dispatch>.
+L<multi-dispatch|#Multi-dispatch>. Note that required named arguments C<(:$foo!)>
+count as arity.
 
 =head1 X<ASCII operator|Language,ASCII operator>
 
@@ -637,10 +638,11 @@ L<C<Parameter>|/type/Parameter> prototype and the arguments it was called with.
 
 The selection process is primarily based on types and number of arguments
 (L<arity|#Arity>), where the narrowest, most specific candidate wins,
-typically without regard to the order of declaration.  The C<is default>
-trait may be used as a tiebreaker in this first phase.  There is also a
-secondary phase where some different tiebreakers may be evaluated in order
-of declaration of the methods or subs.
+typically without regard to the order of declaration. Note that required named
+arguments C<(:$foo!)> count as arity. The C<is default> trait may be used as a
+tiebreaker in this first phase.  There is also a secondary phase where some
+different tiebreakers may be evaluated in order of declaration of the
+methods or subs.
 
 =head1 X<multi-method|Reference,multi-method>
 


### PR DESCRIPTION
Add note that required named arguments C<(:$foo!)> count as arity and apply to multi-dispatch.
