### PR TITLE
Upgrade (c) to (r)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Official Documentation of Raku™
+# Official Documentation of Raku®
 
 [![artistic](https://img.shields.io/badge/license-Artistic%202.0-blue.svg?style=flat)](https://opensource.org/licenses/Artistic-2.0)
 [![test](https://github.com/Raku/doc/actions/workflows/test.yml/badge.svg)](https://github.com/Raku/doc/actions/workflows/test.yml)


### PR DESCRIPTION
Raku now enjoys an (r) (Registered) trade mark

## The problem

The heading on the README.md still has the ™ mark


## Solution provided

Changed that to an ®
